### PR TITLE
Memory component and Cortex planning/execution upgrades

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        run: |
-          apt-get update
-          apt-get install -y python3-pip python3-pytest
-
       - name: Build workspace
         run: |
           . /opt/ros/${{ matrix.ros_distro }}/setup.sh
@@ -33,7 +28,7 @@ jobs:
           git clone https://github.com/automatika-robotics/sugarcoat /ws/src/sugarcoat
           cd /ws
           # All Python deps installed via pip, covers sugarcoat and embodied-agents
-          pip install --ignore-installed opencv-python-headless \
+          pip install --ignore-installed pytest opencv-python-headless \
                       'attrs>=23.2.0' jinja2 httpx msgpack msgpack-numpy \
                       setproctitle pyyaml toml platformdirs tqdm websockets \
                       emem

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,8 @@ jobs:
           git clone https://github.com/automatika-robotics/sugarcoat /ws/src/sugarcoat
           cd /ws
           pip install numpy 'attrs>=23.2.0' jinja2 httpx \
-                      msgpack msgpack-numpy setproctitle platformdirs tqdm websockets
+                      msgpack msgpack-numpy setproctitle platformdirs tqdm websockets \
+                      emem
           colcon build --symlink-install
         shell: bash
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,33 +23,20 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update
-          # python3-opencv: sugarcoat imports cv2 at module load
-          apt-get install -y python3-pip python3-pytest python3-opencv
-
-      - name: Install ROS package dependencies
-        run: |
-          . /opt/ros/${{ matrix.ros_distro }}/setup.sh
-          apt-get install -y python3-rosdep
-          rosdep update || true
-          rosdep install --from-paths . -y --ignore-src || true
+          apt-get install -y python3-pip python3-pytest
 
       - name: Build workspace
         run: |
           . /opt/ros/${{ matrix.ros_distro }}/setup.sh
           mkdir -p /ws/src
           ln -s $GITHUB_WORKSPACE /ws/src/embodied_agents
-          # Clone and build ros_sugar dependency
           git clone https://github.com/automatika-robotics/sugarcoat /ws/src/sugarcoat
           cd /ws
-          # humble ships cv2 compiled against NumPy 1.x (apt numpy 1.21).
-          # Pin numpy <2 on humble so pip resolves to the highest 1.x
-          if [ "${{ matrix.ros_distro }}" = "humble" ]; then
-            NUMPY_PIN='numpy<2'
-          else
-            NUMPY_PIN='numpy'
-          fi
-          pip install "$NUMPY_PIN" 'attrs>=23.2.0' jinja2 httpx msgpack msgpack-numpy \
-                      setproctitle platformdirs tqdm websockets emem
+          # All Python deps installed via pip, covers sugarcoat and embodied-agents
+          pip install --ignore-installed opencv-python-headless \
+                      'attrs>=23.2.0' jinja2 httpx msgpack msgpack-numpy \
+                      setproctitle pyyaml toml platformdirs tqdm websockets \
+                      emem
           colcon build --symlink-install
         shell: bash
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install pip
+        run: |
+          apt-get update
+          apt-get install -y python3-pip
+
       - name: Build workspace
         run: |
           . /opt/ros/${{ matrix.ros_distro }}/setup.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,9 +40,15 @@ jobs:
           # Clone and build ros_sugar dependency
           git clone https://github.com/automatika-robotics/sugarcoat /ws/src/sugarcoat
           cd /ws
-          pip install numpy 'attrs>=23.2.0' jinja2 httpx \
-                      msgpack msgpack-numpy setproctitle platformdirs tqdm websockets \
-                      emem
+          # humble ships cv2 compiled against NumPy 1.x (apt numpy 1.21).
+          # Pin numpy <2 on humble so pip resolves to the highest 1.x
+          if [ "${{ matrix.ros_distro }}" = "humble" ]; then
+            NUMPY_PIN='numpy<2'
+          else
+            NUMPY_PIN='numpy'
+          fi
+          pip install "$NUMPY_PIN" 'attrs>=23.2.0' jinja2 httpx msgpack msgpack-numpy \
+                      setproctitle platformdirs tqdm websockets emem
           colcon build --symlink-install
         shell: bash
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update
-          apt-get install -y python3-pip python3-pytest
+          # python3-opencv: sugarcoat imports cv2 at module load
+          apt-get install -y python3-pip python3-pytest python3-opencv
 
       - name: Install ROS package dependencies
         run: |

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -4,7 +4,7 @@ from importlib.metadata import version, PackageNotFoundError
 from packaging import version as pkg_version
 
 # Define the minimum required version of sugarcoat
-MIN_SUGARCOAT_VERSION = "0.6.1"
+MIN_SUGARCOAT_VERSION = "0.7.0"
 
 
 def _print_sugarcoat_error(current_version=None):

--- a/agents/clients/ollama.py
+++ b/agents/clients/ollama.py
@@ -159,7 +159,7 @@ class OllamaClient(ModelClient):
             else inference_input
         )
 
-        # self.logger.debug(f"Sending to ollama server: {input}")
+        self.logger.debug(f"Sending to ollama server: {input}")
 
         # call inference method
         try:

--- a/agents/clients/ollama.py
+++ b/agents/clients/ollama.py
@@ -74,6 +74,25 @@ class OllamaClient(ModelClient):
             )
             raise
 
+    def _is_embedding_model(self) -> bool:
+        """Detect whether the served model is an embedding model.
+
+        First checks Ollama's ``show()`` capabilities list, then falls back
+        to the legacy internal name used by ChromaClient.
+        """
+        if self.model_name == "internal_ollama_embeddings":
+            return True
+        try:
+            info = self.client.show(self.model_init_params["checkpoint"])
+            capabilities = getattr(info, "capabilities", None) or []
+            return "embedding" in capabilities
+        except Exception as e:
+            self.logger.debug(
+                f"Could not probe capabilities for "
+                f"{self.model_init_params['checkpoint']}: {e}"
+            )
+            return False
+
     def _initialize(self) -> None:
         """
         Initialize the model on platform using the paramters provided in the model specification class
@@ -87,12 +106,14 @@ class OllamaClient(ModelClient):
                 raise Exception(
                     f"Could not pull model {self.model_init_params['checkpoint']}"
                 )
-            # load model in memory with empty request
-            if (
-                self.model_name == "internal_ollama_embeddings"
-            ):  # Internal embeddings model name
+            # Cache capability check so _deinitialize can use it too
+            self._is_embedding = self._is_embedding_model()
+            # load model in memory with an appropriate empty request
+            if self._is_embedding:
                 self.client.embed(
-                    model=self.model_init_params["checkpoint"], keep_alive=10
+                    model=self.model_init_params["checkpoint"],
+                    input="",
+                    keep_alive=10,
                 )
             else:
                 self.client.generate(
@@ -138,7 +159,7 @@ class OllamaClient(ModelClient):
             else inference_input
         )
 
-        self.logger.debug(f"Sending to ollama server: {input}")
+        # self.logger.debug(f"Sending to ollama server: {input}")
 
         # call inference method
         try:
@@ -201,8 +222,15 @@ class OllamaClient(ModelClient):
 
         self.logger.error(f"Deinitializing {self.model_name} model on ollama")
         try:
-            self.client.generate(
-                model=self.model_init_params["checkpoint"], keep_alive=0
-            )
+            if getattr(self, "_is_embedding", False):
+                self.client.embed(
+                    model=self.model_init_params["checkpoint"],
+                    input="",
+                    keep_alive=0,
+                )
+            else:
+                self.client.generate(
+                    model=self.model_init_params["checkpoint"], keep_alive=0
+                )
         except Exception as e:
             self.logger.error(str(e))

--- a/agents/clients/roboml.py
+++ b/agents/clients/roboml.py
@@ -459,7 +459,7 @@ class RoboMLRESPClient(ModelClient):
         """Call inference on the model using data and inference parameters from the component"""
         try:
             if inference_input.get("stream"):
-                self.logger.warn(
+                self.logger.warning(
                     "RoboML RESPClient currently does not handle streaming. Set stream to False in component config to get rid of this warning."
                 )
                 inference_input.pop("stream")

--- a/agents/components/__init__.py
+++ b/agents/components/__init__.py
@@ -44,6 +44,7 @@ from .cortex import Cortex
 from .imagestovideo import VideoMessageMaker
 from .llm import LLM
 from .map_encoding import MapEncoding
+from .memory import Memory
 from .mllm import MLLM, VLM
 from .model_component import ModelComponent
 from .semantic_router import SemanticRouter
@@ -57,6 +58,7 @@ __all__ = [
     "Cortex",
     "ModelComponent",
     "MapEncoding",
+    "Memory",
     "MLLM",
     "VLM",
     "LLM",

--- a/agents/components/__init__.py
+++ b/agents/components/__init__.py
@@ -22,8 +22,11 @@ A Component is the main execution unit in _EmbodiedAgents_ and in essence each c
 * - **[TextToSpeech](agents.components.texttospeech.md)**
   - Synthesizes audio from text using TTS models (e.g., TransformersTTS). Output audio can be played using the robot's speakers or published to a topic. Implements `say(text)` and `stop_playback` functions to play/stop audio based on events from other components or the environment.
 
-* - **[MapEncoding](agents.components.map_encoding.md)**
-  - Provides a spatio-temporal working memory by converting semantic outputs (e.g., from MLLMs or Vision) into a structured map representation. Uses robot localization data and output topics from other components to store information in a vector DB.
+* - **[MapEncoding](agents.components.map_encoding.md)** *(deprecated — use Memory)*
+  - Provides a spatio-temporal working memory by converting semantic outputs (e.g., from MLLMs or Vision) into a structured map representation. Uses robot localization data and output topics from other components to store information in a vector DB. **Deprecated:** use the [Memory](agents.components.memory.md) component instead.
+
+* - **[Memory](agents.components.memory.md)**
+  - Provides a graph-based spatio-temporal memory primitive powered by eMEM. Encodes perception streams (e.g., VLM descriptions, detections) and interoception streams (internal body state) into a memory indexed by meaning, location, and time. Exposes structured retrieval tools (semantic, spatial, temporal, entity, episode) as component actions and supports episode-based consolidation with entity tracking.
 
 * - **[SemanticRouter](agents.components.semantic_router.md)**
   - Routes information between topics based on semantic content and predefined routing rules. Uses a vector DB for semantic matching or an LLM for decision-making. This allows for creating complex graphs of components where a single input source can trigger different information processing pathways.

--- a/agents/components/component_base.py
+++ b/agents/components/component_base.py
@@ -1,8 +1,6 @@
 import json
 from abc import abstractmethod
 from copy import deepcopy
-import time
-from contextlib import contextmanager
 from typing import Optional, Sequence, Union, List, Dict, Type
 
 from ..ros import (
@@ -14,7 +12,6 @@ from ..ros import (
     BaseTopic,
     Event,
     Action,
-    LifecycleStateMsg,
 )
 from ..config import BaseComponentConfig
 from ..utils import flatten

--- a/agents/components/component_base.py
+++ b/agents/components/component_base.py
@@ -340,31 +340,3 @@ class Component(BaseComponent):
         self._update_inactive_input_topic(old_topic, new_topic)
 
         return None
-
-    # TODO: Move the context manager to sugarcoat base component
-    @contextmanager
-    def safe_restart(self):
-        """Stop the component, yield for operations, then restart and wait for ACTIVE state."""
-        self._maintain_default_services = True
-        self.stop()
-        self.trigger_cleanup()
-
-        try:
-            yield
-        finally:
-            self.start()
-
-            timeout_counter = 0
-            while self.lifecycle_state != LifecycleStateMsg.PRIMARY_STATE_ACTIVE and (
-                timeout_counter < self.config.wait_for_restart_time
-            ):
-                self.get_logger().warn(
-                    f"Component {self.node_name} is not in ACTIVE state. Waiting for it to become active again.",
-                    once=True,
-                )
-                time.sleep(1 / self.config.loop_rate)
-                timeout_counter += 1 / self.config.loop_rate
-
-            if self.lifecycle_state != LifecycleStateMsg.PRIMARY_STATE_ACTIVE:
-                self.health_status.set_fail_component()
-                raise RuntimeError("Error restarting the component")

--- a/agents/components/cortex.py
+++ b/agents/components/cortex.py
@@ -332,61 +332,106 @@ class Cortex(ModelComponent, Monitor):
         status during planning, and use memory retrieval tools.
         """
         # Find a managed Memory component
-        memory_comp_name: Optional[str] = None
-        for name, comp in self._managed_components.items():
+        memory_comp = None
+        for comp in self._managed_components.values():
             if type(comp).__name__ == "Memory":
-                memory_comp_name = name
+                memory_comp = comp
                 break
 
-        if not memory_comp_name:
+        if memory_comp is None:
             return
 
-        prefix = f"{memory_comp_name}."
+        prefix = f"{memory_comp.node_name}."
         start_ep_tool = f"{prefix}start_episode"
         end_ep_tool = f"{prefix}end_episode"
         body_status_tool = f"{prefix}body_status"
+        store_note_tool = f"{prefix}store_specific_memory"
 
         # Only augment if the expected tools are actually registered
         required = {start_ep_tool, end_ep_tool}
         if not required.issubset(self._execution_tools):
             return
 
-        # Retrieval tools registered on the memory component (planning phase)
-        retrieval_tools = sorted(
+        # Perception retrieval tools (planning phase), excluding body_status
+        perception_retrieval_tools = sorted(
             name
             for name in self._planning_tools
             if name.startswith(prefix) and name != body_status_tool
         )
-        retrieval_str = ", ".join(retrieval_tools) if retrieval_tools else "(none)"
+        perception_str = (
+            ", ".join(perception_retrieval_tools)
+            if perception_retrieval_tools
+            else "(none)"
+        )
+
+        # Pre-compute memory component inspection so layer names are in
+        # the prompt directly — the planner doesn't need to spend a round
+        # trip calling inspect_component on memory
+        try:
+            memory_inspection = memory_comp.inspect_component()
+        except Exception as e:
+            self.get_logger().warning(
+                f"Failed to inspect memory component for prompt augmentation: {e}"
+            )
+            memory_inspection = ""
 
         addendum = (
             "\n\n=== Memory Guidance ===\n"
-            f"A spatio-temporal memory component '{memory_comp_name}' is "
-            "available.\n\n"
-            "TASK CLASSIFICATION — first decide which type of task you have:\n"
-            "  (A) QUERY TASK: the user is asking a question about the past "
-            "(e.g. 'what happened in the last episode?', 'where did you see "
-            "the cup?', 'what did you do today?'). No real-world action is "
-            "needed.\n"
-            "  (B) ACTION TASK: the user wants the robot to do something "
-            "(e.g. 'take a picture and describe it', 'toggle the LED', "
+            f"A spatio-temporal memory component '{memory_comp.node_name}' is "
+            "available. It has TWO distinct retrieval surfaces you must "
+            "distinguish between:\n"
+            f"  - Perception memory: past external observations (what the "
+            f"robot saw, detected, or was told). Retrieved via: {perception_str}.\n"
+            f"  - Interoception / body state: the robot's own internal "
+            f"readings (battery, temperature, joint health, fault flags). "
+            f"Retrieved via '{body_status_tool}' ONLY — internal state is "
+            f"NOT returned by perception retrieval tools.\n\n"
+            + (
+                f"Memory component inspection (use these layer names as "
+                f"'layer' / 'layers' filters on retrieval tools):\n"
+                f"{memory_inspection}\n\n"
+                if memory_inspection
+                else ""
+            )
+            + "TASK CLASSIFICATION — decide which type of task you have:\n"
+            "  (A) PERCEPTION QUERY: user is asking about past external "
+            "observations (e.g. 'what happened in the last episode?', "
+            "'where did you see the cup?', 'what did you do today?').\n"
+            "  (B) BODY QUERY: user is asking about the robot's internal "
+            "state (e.g. 'are you low on battery?', 'is anything wrong?', "
+            "'what is your current temperature?').\n"
+            "  (C) ACTION TASK: user wants the robot to do something in "
+            "the world (e.g. 'take a picture and describe it', "
             "'navigate to the kitchen').\n\n"
-            "FOR QUERY TASKS:\n"
-            f"  - Call the appropriate retrieval tool(s) during planning: "
-            f"{retrieval_str}.\n"
-            "  - After the retrieval results come back, respond with a "
-            "text answer summarizing what you found. DO NOT return any "
-            "execution tool calls. DO NOT start or end an episode — "
-            "query tasks do not generate new observations.\n\n"
+            "FOR PERCEPTION QUERY TASKS:\n"
+            f"  - Call one or more perception retrieval tools during "
+            f"planning: {perception_str}.\n"
+            "  - Respond with a text answer summarizing what you found.\n"
+            "  - DO NOT return any execution tool calls. DO NOT start or "
+            "end an episode — query tasks do not generate new observations.\n\n"
+            "FOR BODY QUERY TASKS:\n"
+            f"  - Call '{body_status_tool}' during planning (optionally "
+            f"filtered by an internal-state layer name listed above).\n"
+            "  - Respond with a text answer summarizing the readings.\n"
+            "  - DO NOT return execution tool calls. DO NOT start or end "
+            "an episode.\n\n"
             "FOR ACTION TASKS:\n"
             f"  1. Call '{body_status_tool}' during planning to read the "
-            "robot's current internal state (battery, location, etc.).\n"
-            "  2. Optionally use retrieval tools during planning to ground "
-            f"the task in past memory (e.g. use '{memory_comp_name}.locate' "
-            "to find a known object's position).\n"
+            "robot's current internal state. If readings indicate a "
+            "problem (very low battery, fault, overheating), abort the task "
+            "with a clear text explanation instead of proceeding.\n"
+            "  2. Optionally call perception retrieval tools during "
+            f"planning to ground the task in past memory (e.g. use "
+            f"'{memory_comp.node_name}.locate' to find a known object's "
+            "position).\n"
             f"  3. Begin your execution plan with '{start_ep_tool}' using a "
             "short, descriptive episode name derived from the task.\n"
-            f"  4. End your execution plan with '{end_ep_tool}' to "
+            "  4. Execute the task steps.\n"
+            f"  5. If during the task you derive a fact worth remembering "
+            f"(e.g. a VLM description you want to persist, an operator "
+            f"instruction, a decision), include '{store_note_tool}' in the "
+            f"plan to record it.\n"
+            f"  6. End your execution plan with '{end_ep_tool}' to "
             "consolidate observations from this task into long-term memory.\n"
             f"  Episodes are mandatory for ACTION tasks — always wrap the "
             f"plan between '{start_ep_tool}' and '{end_ep_tool}'."
@@ -396,7 +441,7 @@ class Cortex(ModelComponent, Monitor):
         self.config._system_prompt = self._effective_planning_prompt
         self.messages = [{"role": "system", "content": self._effective_planning_prompt}]
         self.get_logger().info(
-            f"Planning prompt augmented for Memory component '{memory_comp_name}'."
+            f"Planning prompt augmented for Memory component '{memory_comp.node_name}'."
         )
 
     def custom_on_deactivate(self):

--- a/agents/components/cortex.py
+++ b/agents/components/cortex.py
@@ -172,9 +172,9 @@ class Cortex(ModelComponent, Monitor):
         self._service_request_tools: Dict[str, Tuple[str, str, Any]] = {}
 
         # Behavioral actions: dispatched via internal event system
+        self._behavioral_actions = actions
         self._pure_internal_events = []
         self._additional_internal_actions = {}
-        self._setup_internal_action_events(actions)
 
         # Planning output buffer for failed plans
         self._planning_output: Optional[str] = None
@@ -267,6 +267,7 @@ class Cortex(ModelComponent, Monitor):
             activation_attempt_time=activation_attempt_time,
         )
         self.config = _config
+        self._setup_internal_action_events(self._behavioral_actions)
 
     def _setup_internal_action_events(self, actions: Optional[List[Action]]) -> None:
         """Create internal event topics and tool descriptions for each action."""

--- a/agents/components/cortex.py
+++ b/agents/components/cortex.py
@@ -150,12 +150,16 @@ class Cortex(ModelComponent, Monitor):
         self.model_client = model_client
         self.db_client = db_client if db_client else None
 
+        # Effective planning prompt; augmented in custom_on_activate
+        # based on discovered managed components (e.g. to handle Memory)
+        self._effective_planning_prompt = self._PLANNING_PROMPT
+
         # Initialize messages buffer
         self.messages: List[Dict] = [
-            {"role": "system", "content": self._PLANNING_PROMPT}
+            {"role": "system", "content": self._effective_planning_prompt}
         ]
 
-        # Tool registries — separated into planning and execution phases.
+        # Tool registries separated into planning and execution phases.
         # Planning tools (e.g. inspect_component) gather information.
         # Execution tools (actions, system tools) are what the plan consists of.
         self._planning_tools: Set = set()
@@ -306,6 +310,7 @@ class Cortex(ModelComponent, Monitor):
         if self._components_to_monitor:
             Monitor.activate(self)
             self._register_system_tools()
+            self._augment_planning_prompt_for_memory()
 
         # Display all the tools registered
         planning_names = [
@@ -316,6 +321,83 @@ class Cortex(ModelComponent, Monitor):
         ]
         self.get_logger().debug(f"Cortex planning tools: {planning_names}")
         self.get_logger().debug(f"Cortex execution tools: {execution_names}")
+
+    def _augment_planning_prompt_for_memory(self) -> None:
+        """Append memory-aware guidance to the planning prompt when a
+        Memory component is present in the managed recipe.
+
+        Detects the Memory component by class name, verifies it exposes
+        the expected episode/body-status tools, and builds an addendum
+        instructing the planner to wrap tasks in episodes, check body
+        status during planning, and use memory retrieval tools.
+        """
+        # Find a managed Memory component
+        memory_comp_name: Optional[str] = None
+        for name, comp in self._managed_components.items():
+            if type(comp).__name__ == "Memory":
+                memory_comp_name = name
+                break
+
+        if not memory_comp_name:
+            return
+
+        prefix = f"{memory_comp_name}."
+        start_ep_tool = f"{prefix}start_episode"
+        end_ep_tool = f"{prefix}end_episode"
+        body_status_tool = f"{prefix}body_status"
+
+        # Only augment if the expected tools are actually registered
+        required = {start_ep_tool, end_ep_tool}
+        if not required.issubset(self._execution_tools):
+            return
+
+        # Retrieval tools registered on the memory component (planning phase)
+        retrieval_tools = sorted(
+            name
+            for name in self._planning_tools
+            if name.startswith(prefix) and name != body_status_tool
+        )
+        retrieval_str = ", ".join(retrieval_tools) if retrieval_tools else "(none)"
+
+        addendum = (
+            "\n\n=== Memory Guidance ===\n"
+            f"A spatio-temporal memory component '{memory_comp_name}' is "
+            "available.\n\n"
+            "TASK CLASSIFICATION — first decide which type of task you have:\n"
+            "  (A) QUERY TASK: the user is asking a question about the past "
+            "(e.g. 'what happened in the last episode?', 'where did you see "
+            "the cup?', 'what did you do today?'). No real-world action is "
+            "needed.\n"
+            "  (B) ACTION TASK: the user wants the robot to do something "
+            "(e.g. 'take a picture and describe it', 'toggle the LED', "
+            "'navigate to the kitchen').\n\n"
+            "FOR QUERY TASKS:\n"
+            f"  - Call the appropriate retrieval tool(s) during planning: "
+            f"{retrieval_str}.\n"
+            "  - After the retrieval results come back, respond with a "
+            "text answer summarizing what you found. DO NOT return any "
+            "execution tool calls. DO NOT start or end an episode — "
+            "query tasks do not generate new observations.\n\n"
+            "FOR ACTION TASKS:\n"
+            f"  1. Call '{body_status_tool}' during planning to read the "
+            "robot's current internal state (battery, location, etc.).\n"
+            "  2. Optionally use retrieval tools during planning to ground "
+            f"the task in past memory (e.g. use '{memory_comp_name}.locate' "
+            "to find a known object's position).\n"
+            f"  3. Begin your execution plan with '{start_ep_tool}' using a "
+            "short, descriptive episode name derived from the task.\n"
+            f"  4. End your execution plan with '{end_ep_tool}' to "
+            "consolidate observations from this task into long-term memory.\n"
+            f"  Episodes are mandatory for ACTION tasks — always wrap the "
+            f"plan between '{start_ep_tool}' and '{end_ep_tool}'."
+        )
+
+        self._effective_planning_prompt = self._PLANNING_PROMPT + addendum
+        self.config._system_prompt = self._effective_planning_prompt
+        self.messages = [{"role": "system", "content": self._effective_planning_prompt}]
+        self.get_logger().info(
+            f"Planning prompt augmented for Memory component '{memory_comp_name}'."
+        )
 
     def custom_on_deactivate(self):
         if self.db_client:
@@ -486,7 +568,7 @@ class Cortex(ModelComponent, Monitor):
                 user_content = f"Context:\n{rag_context}\n\nTask: {task}"
 
         return [
-            {"role": "system", "content": self._PLANNING_PROMPT},
+            {"role": "system", "content": self._effective_planning_prompt},
             {"role": "user", "content": user_content},
         ]
 
@@ -519,9 +601,6 @@ class Cortex(ModelComponent, Monitor):
                 f"[Planning step {step + 1}] calling {fn_name}({fn_args})"
             )
             tool_result = self._execute_planning_tool(fn_name, fn_args)
-            self.get_logger().debug(
-                f"[Planning step {step + 1}] {fn_name} -> {tool_result[:300]}"
-            )
             messages.append({
                 "role": "tool",
                 "tool_call_id": f"plan_{step}_{i}",
@@ -777,7 +856,6 @@ class Cortex(ModelComponent, Monitor):
             inference_input["tools"] = self._execution_tool_descriptions
 
         result = self._call_inference(inference_input)
-        self.get_logger().debug(f"Got confirm step result = {result}")
         if not result:
             self.get_logger().warning(
                 "Confirmation inference failed; defaulting to EXECUTE."

--- a/agents/components/cortex.py
+++ b/agents/components/cortex.py
@@ -1416,11 +1416,24 @@ class Cortex(ModelComponent, Monitor):
         return executed_results, False
 
     def _finalize_goal(
-        self, goal_handle, feedback_msg, result_msg, executed_results, plan_len, aborted
+        self,
+        goal_handle,
+        feedback_msg,
+        result_msg,
+        executed_results,
+        plan_len,
+        aborted,
+        voluntarily_stopped: bool = False,
     ) -> None:
-        """Set the final goal status based on execution results."""
-        summary = "; ".join(f"{r['action']}: {r['result']}" for r in executed_results)
+        """Set the final goal status based on execution results.
+
+        Success criterion: the planning loop ended voluntarily (the LLM
+        returned no more tool calls), meaning the LLM considered the task
+        complete. Earlier per-step errors are tolerated as long as the
+        loop recovered — the LLM had the chance to continue if needed.
+        """
         has_failures = any(r.get("failed") for r in executed_results)
+        had_recovery = has_failures and voluntarily_stopped
 
         # If the goal is already in a terminal state e.g on client cancellation,
         # don't attempt another state transition.
@@ -1432,33 +1445,38 @@ class Cortex(ModelComponent, Monitor):
             with self._main_goal_lock:
                 self._cancel_all_active_clients()
                 goal_handle.abort()
-        elif has_failures:
-            self._send_feedback(
-                goal_handle,
-                feedback_msg,
-                plan_len,
-                f"Plan finished with errors. {summary}",
-                completed=True,
-            )
-            self.get_logger().warning(f"Task finished with errors: {summary}")
-            with self._main_goal_lock:
-                self._cancel_all_active_clients()
-                goal_handle.abort()
-        else:
+        elif voluntarily_stopped:
             result_msg.success = True
+            if had_recovery:
+                feedback = "Plan finished despite errors along the way."
+                self.get_logger().info(feedback)
+            else:
+                feedback = f"All {plan_len} steps completed."
+                self.get_logger().info(
+                    f"Task completed: {len(executed_results)} steps executed."
+                )
             self._send_feedback(
-                goal_handle,
-                feedback_msg,
-                plan_len,
-                f"All {plan_len} steps completed. {summary}",
-                completed=True,
-            )
-            self.get_logger().info(
-                f"Task completed: {len(executed_results)} steps executed."
+                goal_handle, feedback_msg, plan_len, feedback, completed=True
             )
             with self._main_goal_lock:
                 self._cancel_all_active_clients()
                 goal_handle.succeed()
+        else:
+            # Loop exhausted without the LLM voluntarily stopping
+            self._send_feedback(
+                goal_handle,
+                feedback_msg,
+                plan_len,
+                f"Plan did not finish: reached max_execution_steps "
+                f"({self.config.max_execution_steps}).",
+                completed=True,
+            )
+            self.get_logger().warning(
+                "Task exhausted max_execution_steps without voluntary completion."
+            )
+            with self._main_goal_lock:
+                self._cancel_all_active_clients()
+                goal_handle.abort()
 
     def main_action_callback(self, goal_handle):
         """Action server callback. Iterative plan-execute loop.
@@ -1485,6 +1503,7 @@ class Cortex(ModelComponent, Monitor):
         all_executed_results: List[Dict] = []
         total_steps = 0
         planning_messages = None
+        voluntarily_stopped = False
 
         for _ in range(self.config.max_execution_steps):
             # Plan (or continue planning with prior results)
@@ -1493,7 +1512,8 @@ class Cortex(ModelComponent, Monitor):
             if plan is None:
                 # No more actions needed
                 if all_executed_results:
-                    # We already executed some steps — task is complete
+                    # We already executed some steps — LLM signalled done
+                    voluntarily_stopped = True
                     break
                 # First iteration, no plan at all
                 text_output = self._planning_output or ""
@@ -1544,7 +1564,7 @@ class Cortex(ModelComponent, Monitor):
                     result_msg,
                     all_executed_results,
                     total_steps,
-                    True,
+                    aborted=True,
                 )
                 return result_msg
 
@@ -1554,14 +1574,15 @@ class Cortex(ModelComponent, Monitor):
                 planning_messages, plan, executed_results
             )
 
-        # All iterations done — finalize
+        # Loop exited — either voluntarily (LLM stopped) or exhausted
         self._finalize_goal(
             goal_handle,
             feedback_msg,
             result_msg,
             all_executed_results,
             total_steps,
-            False,
+            aborted=False,
+            voluntarily_stopped=voluntarily_stopped,
         )
         return result_msg
 

--- a/agents/components/cortex.py
+++ b/agents/components/cortex.py
@@ -87,10 +87,17 @@ class Cortex(ModelComponent, Monitor):
         "You are a task planning agent on a robot. "
         "Given a task, first use inspect_component to research the available "
         "components and discover their capabilities, topics, and actions. "
-        "Once you have enough information, create a plan by calling the "
-        "appropriate actions in sequence. "
-        "Return ALL actions needed as tool calls in a single response. "
-        "Each tool call is one step. Order them in execution sequence. "
+        "Once you have enough information, break down the task into subtasks"
+        " and create a plan by calling the appropriate actions in sequence.\n"
+        "IMPORTANT: Always return ALL actions needed as tool calls in a "
+        "single response. Each tool call is one step. Order them in execution "
+        "sequence. Fill in arguments you already know (e.g. topic names from "
+        "inspection). For arguments that depend on the output of a previous "
+        'step, use a placeholder like "<output from step 1>" — this is '
+        "expected and correct. The arguments will be automatically resolved "
+        "at execution time using actual results from prior steps. "
+        "Never return fewer tool calls than needed — always include every "
+        "step in the plan even if some arguments are not yet known. "
         "If the task requires no actions, respond with text only."
     )
 
@@ -103,7 +110,13 @@ class Cortex(ModelComponent, Monitor):
         "  ABORT - abort the entire plan\n"
         "  CONTINUE - wait for ongoing async actions to complete before proceeding\n"
         "Use CONTINUE when there are active async actions that should finish "
-        "before moving on. Optionally follow with a brief reason after a colon."
+        "before moving on. Optionally follow with a brief reason after a colon.\n\n"
+        "When you respond EXECUTE, you may also return a tool call for the next "
+        "action with updated arguments based on the results of previous steps. "
+        "For example, if a previous step produced text output, use that text as "
+        "the argument for the next step instead of the placeholder from the plan."
+        " But this is not just limited to text outputs, you can also use structured"
+        " outputs from previous steps to fill input parameters of next steps."
     )
 
     @validate_func_args
@@ -502,9 +515,12 @@ class Cortex(ModelComponent, Monitor):
         for i, tc in enumerate(planning_calls):
             fn_name = tc["function"]["name"]
             fn_args = self._parse_tool_args(tc["function"].get("arguments", {}))
+            self.get_logger().debug(
+                f"[Planning step {step + 1}] calling {fn_name}({fn_args})"
+            )
             tool_result = self._execute_planning_tool(fn_name, fn_args)
             self.get_logger().debug(
-                f"[Planning step {step + 1}] {fn_name} -> {tool_result[:200]}"
+                f"[Planning step {step + 1}] {fn_name} -> {tool_result[:300]}"
             )
             messages.append({
                 "role": "tool",
@@ -524,7 +540,9 @@ class Cortex(ModelComponent, Monitor):
         self.get_logger().info(f"Got plan: {plan}")
         return plan
 
-    def _plan_task(self, task: str) -> Optional[List[Dict]]:
+    def _plan_task(
+        self, task: str, messages: Optional[List[Dict]] = None
+    ) -> Tuple[Optional[List[Dict]], List[Dict]]:
         """Multi-step planning loop that researches components before producing a plan.
 
         The LLM is given both planning tools and execution tools.
@@ -535,11 +553,25 @@ class Cortex(ModelComponent, Monitor):
         - Respond with text only — no actions needed, loop ends.
 
         :param task: The high-level task description
-        :returns: List of tool_call dicts (the plan), or None if no actions needed
+        :param messages: Optional pre-existing planning messages to continue
+            from (e.g. after feeding back execution results). If None, a
+            fresh conversation is started.
+        :returns: Tuple of (plan, planning_messages). plan is a list of
+            tool_call dicts or None if no actions needed. planning_messages
+            is the conversation history, preserved so execution results can
+            be fed back for continued planning.
         """
         all_tools = self._planning_tool_descriptions + self._execution_tool_descriptions
-        messages = self._build_planning_messages(task)
+        if messages is None:
+            messages = self._build_planning_messages(task)
         output = ""
+
+        self.get_logger().debug(
+            f"[Planning] starting task={task!r} with "
+            f"{len(self._planning_tool_descriptions)} planning tools, "
+            f"{len(self._execution_tool_descriptions)} execution tools, "
+            f"max_steps={self.config.max_planning_steps}"
+        )
 
         for step in range(self.config.max_planning_steps):
             inference_input = {
@@ -549,12 +581,16 @@ class Cortex(ModelComponent, Monitor):
             if all_tools:
                 inference_input["tools"] = all_tools
 
+            self.get_logger().debug(
+                f"[Planning step {step + 1}/{self.config.max_planning_steps}] "
+                "invoking planner LLM"
+            )
             result = self._call_inference(inference_input)
             if not result:
                 self.get_logger().error(
                     f"Inference failed during planning step {step + 1}."
                 )
-                return None
+                return None, messages
 
             output = result.get("output") or ""
             if self.config.strip_think_tokens:
@@ -562,8 +598,12 @@ class Cortex(ModelComponent, Monitor):
 
             tool_calls = result.get("tool_calls")
             if not tool_calls:
+                self.get_logger().debug(
+                    f"[Planning step {step + 1}] planner returned no tool calls; "
+                    "ending loop"
+                )
                 self._planning_output = output
-                return None
+                return None, messages
 
             # Separate planning tool calls from execution tool calls
             planning_calls = [
@@ -576,23 +616,77 @@ class Cortex(ModelComponent, Monitor):
                 for tc in tool_calls
                 if tc["function"]["name"] not in self._planning_tools
             ]
+
+            self.get_logger().debug(
+                f"[Planning step {step + 1}] planner requested "
+                f"{len(planning_calls)} planning call(s) "
+                f"{[tc['function']['name'] for tc in planning_calls]} and "
+                f"{len(execution_calls)} execution call(s) "
+                f"{[tc['function']['name'] for tc in execution_calls]}"
+            )
+
             if planning_calls:
                 self._process_planning_calls(planning_calls, messages, output, step)
 
             if execution_calls:
-                return self._finalize_plan(execution_calls)
+                self.get_logger().debug(
+                    f"[Planning] producing plan with {len(execution_calls)} "
+                    f"step(s) after {step + 1} planning iteration(s)"
+                )
+                return self._finalize_plan(execution_calls), messages
 
         self.get_logger().warning(
             f"Planning reached max steps ({self.config.max_planning_steps}) "
             "without producing an execution plan."
         )
         self._planning_output = output
-        return None
+        return None, messages
+
+    def _append_execution_results_to_planning(
+        self,
+        messages: List[Dict],
+        plan: List[Dict],
+        executed_results: List[Dict],
+    ) -> None:
+        """Append executed plan steps and their results to the planning
+        conversation so the LLM can continue planning with context.
+
+        Each executed step is added as an assistant tool_call followed by
+        a tool response message with the result.
+        """
+        tool_calls_msg = []
+        for i, step in enumerate(plan):
+            tool_calls_msg.append({
+                "id": f"exec_{i}",
+                "type": "function",
+                "function": step["function"],
+            })
+
+        messages.append({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": tool_calls_msg,
+        })
+
+        for i, result in enumerate(executed_results):
+            messages.append({
+                "role": "tool",
+                "tool_call_id": f"exec_{i}",
+                "content": result["result"],
+            })
 
     def _execute_planning_tool(self, tool_name: str, args: Dict) -> str:
-        """Execute a planning-phase tool (e.g. inspect_component)."""
+        """Execute a planning-phase tool.
+
+        Handles the built-in ``inspect_component`` tool plus any component
+        action that was registered into the planning toolset (actions
+        decorated with ``phase=ActionPhase.PLANNING`` or ``BOTH``).
+        """
         if tool_name == "inspect_component":
             return self._inspect_component(args.get("component", ""))
+        if tool_name in self._planning_tools and "." in tool_name:
+            parsed_args = self._parse_tool_args(args)
+            return self._call_component_action(tool_name, parsed_args)
         return f"Error: Unknown planning tool '{tool_name}'."
 
     # =========================================================================
@@ -648,13 +742,20 @@ class Cortex(ModelComponent, Monitor):
         plan: List[Dict],
         executed_results: List[Dict],
         step_index: int,
-    ) -> str:
+    ) -> Tuple[str, Optional[Dict]]:
         """Ask the LLM whether the next planned step should be executed.
+
+        The confirmation call includes execution tools so the LLM can
+        return a tool call with resolved arguments (e.g. using output
+        from a previous step as input to the next).
 
         :param plan: Full list of planned tool_calls
         :param executed_results: Results of already-executed steps
         :param step_index: Index of the next step to confirm
-        :returns: "EXECUTE", "SKIP", "ABORT", or "CONTINUE"
+        :returns: Tuple of (decision, resolved_step) where decision is
+            one of "EXECUTE", "SKIP", "ABORT", "CONTINUE" and
+            resolved_step is a tool_call dict with updated arguments
+            (or None to use the pre-planned arguments)
         """
         user_message = self._build_confirmation_message(
             plan, executed_results, step_index
@@ -670,23 +771,37 @@ class Cortex(ModelComponent, Monitor):
             "stream": False,
         }
 
+        # Include execution tools so the LLM can return a tool call
+        # with arguments resolved from prior step results
+        if self._execution_tool_descriptions:
+            inference_input["tools"] = self._execution_tool_descriptions
+
         result = self._call_inference(inference_input)
         self.get_logger().debug(f"Got confirm step result = {result}")
         if not result:
             self.get_logger().warning(
                 "Confirmation inference failed; defaulting to EXECUTE."
             )
-            return "EXECUTE"
+            return "EXECUTE", None
 
         output = (result.get("output") or "").strip()
         if self.config.strip_think_tokens:
             output = strip_think_tokens(output).strip()
 
+        # Check for a tool call with resolved arguments
+        resolved_step = None
+        if tool_calls := result.get("tool_calls"):
+            resolved_step = tool_calls[0]
+            self.get_logger().debug(
+                f"Confirmation returned resolved tool call: {resolved_step}"
+            )
+
         upper = output.upper()
-        for token in ("ABORT", "SKIP", "CONTINUE", "EXECUTE"):
+        for token in ("ABORT", "SKIP", "CONTINUE"):
             if upper.startswith(token):
-                return token
-        return "EXECUTE"
+                return token, None
+        # EXECUTE, either explicitly stated or implied by a tool call
+        return "EXECUTE", resolved_step
 
     def _execute_action_step(self, step: Dict) -> str:
         """Execute a single planned step via the appropriate dispatch mechanism."""
@@ -806,86 +921,94 @@ class Cortex(ModelComponent, Monitor):
     })
 
     def _register_component_actions(self):
-        """Discover @component_action/@component_fallback methods on all
-        managed components and register them as callable LLM tools.
+        """Discover LLM tools on managed components.
 
-        Uses ``get_methods_with_decorator`` from sugarcoat to find decorated
-        methods. Tool names are namespaced as ``{component_name}.{method_name}``.
-        These are execution-phase tools. Lifecycle management methods
-        (start, stop, restart, etc.) are excluded.
+        For each managed component, registers:
+          1. Its ``@component_action`` / ``@component_fallback`` methods
+             (routed to the planning or execution toolset based on the
+             ``_action_phase`` tag from ``agents.ros.component_action``).
+          2. Its additional ROS services as tools.
+          3. Its additional ROS action servers as tools.
+
+        Lifecycle management methods (start, stop, restart, ...) are
+        excluded. Tool names are namespaced as ``{component_name}.{method_name}``.
         """
         for comp_name, comp in self._managed_components.items():
-            # Collect all action/fallback method names
-            action_methods = get_methods_with_decorator(comp, "component_action")
-            fallback_methods = get_methods_with_decorator(comp, "component_fallback")
+            self._register_component_methods_as_tools(comp_name, comp)
+            self._register_component_entrypoints_as_tools(comp_name, comp)
 
-            for attr_name in action_methods + fallback_methods:
-                if attr_name in self._LIFECYCLE_METHODS:
-                    continue
+    def _register_component_methods_as_tools(self, comp_name: str, comp: Any) -> None:
+        """Register decorated action/fallback methods on one component.
 
-                try:
-                    tool_name = f"{comp_name}.{attr_name}"
-                    # Check if already registered
-                    if tool_name in self._execution_tools:
-                        continue
+        For each method:
+          1. Parse the raw ``_action_description`` into OpenAI tool format
+             (falling back to a docstring stub if not valid JSON).
+          2. Read the ``_action_phase`` tag (default ``execution``) and
+             add the tool to the planning set, execution set, or both.
+        """
+        action_methods = get_methods_with_decorator(comp, "component_action")
+        fallback_methods = get_methods_with_decorator(comp, "component_fallback")
 
-                    # Get the description from the decorator attribute
-                    class_attr = getattr(type(comp), attr_name, None)
-                    desc_raw = (
-                        getattr(class_attr, "_action_description", None)
-                        if class_attr
-                        else None
-                    )
+        for attr_name in action_methods + fallback_methods:
+            if attr_name in self._LIFECYCLE_METHODS:
+                continue
 
-                    # Not the decorator we were looking for
-                    if not desc_raw:
-                        continue
+            class_attr = getattr(type(comp), attr_name, None)
+            desc_raw = (
+                getattr(class_attr, "_action_description", None) if class_attr else None
+            )
+            if not desc_raw:
+                continue
 
-                    # Build tool description from OpenAI-format JSON or docstring
-                    try:
-                        parsed = json.loads(desc_raw)
-                        tool_desc = {
-                            "type": "function",
-                            "function": {
-                                **parsed["function"],
-                                "name": tool_name,
-                            },
-                        }
-                    except (json.JSONDecodeError, TypeError, KeyError):
-                        tool_desc = {
-                            "type": "function",
-                            "function": {
-                                "name": tool_name,
-                                "description": desc_raw[:200],
-                                "parameters": {
-                                    "type": "object",
-                                    "properties": {},
-                                    "required": [],
-                                },
-                            },
-                        }
+            tool_name = f"{comp_name}.{attr_name}"
+            try:
+                parsed = json.loads(desc_raw)
+                tool_desc = {
+                    "type": "function",
+                    "function": {**parsed["function"], "name": tool_name},
+                }
+            except (json.JSONDecodeError, TypeError, KeyError):
+                tool_desc = {
+                    "type": "function",
+                    "function": {
+                        "name": tool_name,
+                        "description": desc_raw[:200],
+                        "parameters": {
+                            "type": "object",
+                            "properties": {},
+                            "required": [],
+                        },
+                    },
+                }
 
-                    self._execution_tools.add(tool_name)
-                    self._execution_tool_descriptions.append(tool_desc)
-                except Exception:
-                    continue
-            # Register component additional entry points (Actions & Services)
-            entrypoints: Dict[str, Dict] = comp.get_ros_entrypoints()
-            # Register additional services as tools
-            srv_entrypoints = entrypoints.get("services", {})
-            for srv_name, srv_type in srv_entrypoints.items():
-                self.__register_service_client_as_tool(
-                    component_name=comp_name, srv_name=srv_name, srv_type=srv_type
-                )
+            phase = getattr(class_attr, "_action_phase", "execution")
+            if phase in ("planning", "both") and tool_name not in self._planning_tools:
+                self._planning_tools.add(tool_name)
+                self._planning_tool_descriptions.append(tool_desc)
+            if (
+                phase in ("execution", "both")
+                and tool_name not in self._execution_tools
+            ):
+                self._execution_tools.add(tool_name)
+                self._execution_tool_descriptions.append(tool_desc)
 
-            # Register additional Action Servers as tools
-            actions_entrypoints = entrypoints.get("actions", {})
-            for action_name, action_type in actions_entrypoints.items():
-                self.__register_action_client_as_tool(
-                    component_name=comp_name,
-                    action_name=action_name,
-                    action_type=action_type,
-                )
+    def _register_component_entrypoints_as_tools(
+        self, comp_name: str, comp: Any
+    ) -> None:
+        """Register a component's additional ROS services and action servers."""
+        entrypoints: Dict[str, Dict] = comp.get_ros_entrypoints()
+
+        for srv_name, srv_type in entrypoints.get("services", {}).items():
+            self.__register_service_client_as_tool(
+                component_name=comp_name, srv_name=srv_name, srv_type=srv_type
+            )
+
+        for action_name, action_type in entrypoints.get("actions", {}).items():
+            self.__register_action_client_as_tool(
+                component_name=comp_name,
+                action_name=action_name,
+                action_type=action_type,
+            )
 
     def _send_action_goal_from_dict(
         self,
@@ -988,18 +1111,56 @@ class Cortex(ModelComponent, Monitor):
             return f"Error calling {tool_name}: {e}"
 
     def _call_component_action(self, tool_name: str, args: Dict) -> str:
-        """Call a component action method directly, as a service."""
+        """Call a component action method via its ExecuteMethod service.
+
+        Returns the method's output as a string, suitable to feed back to
+        an LLM as a tool result:
+
+        - On failure (``response.success == False``) returns
+          ``"Error: ..."`` built from ``response.error_msg``.
+        - On success with no return value (method returned ``None`` or
+          ``True``) returns a short confirmation string.
+        - On success with a return value, decodes ``response.response_json``.
+          Plain strings are returned as-is (preserving multi-line
+          formatting from retrieval tools); structured values are
+          re-serialized to JSON.
+        """
         self.get_logger().info(
             f"Calling component action {tool_name} with args: {args}"
         )
         try:
-            comp_name, method_name = tool_name.split(".")
+            comp_name, method_name = tool_name.split(".", 1)
+        except ValueError as e:
+            return f"Error: Could not parse tool name for {tool_name}: {e}"
+
+        try:
             response = self.execute_component_method(comp_name, method_name, args)
-            if response.success:
-                return f"{tool_name} executed successfully"
-            return f"Error: {tool_name} failed with error: {response.error_msg}"
         except Exception as e:
-            return f"Error: Could not parse tool name for {tool_name}. Failed with error: {e}"
+            return f"Error calling {tool_name}: {e}"
+
+        if not response.success:
+            return f"Error: {tool_name} failed with error: {response.error_msg}"
+
+        # Success. Unpack the return value from response_json if present.
+        raw = getattr(response, "response_json", "") or ""
+        if not raw:
+            return f"{tool_name} executed successfully"
+        try:
+            result = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            # Server produced invalid JSON. Return the raw payload rather
+            # than losing it.
+            return raw
+
+        # True/None are both "method ran, nothing to report"
+        if result is True or result is None:
+            return f"{tool_name} executed successfully"
+        # Plain strings pass through unmolested so newlines and formatting are
+        # preserved for the LLM
+        if isinstance(result, str):
+            return result
+        # Structured data — re-serialize for the LLM
+        return json.dumps(result)
 
     def _inspect_component(self, component_name: str) -> str:
         """Return a text description of a component's structure.
@@ -1139,15 +1300,15 @@ class Cortex(ModelComponent, Monitor):
 
     def _wait_for_active_clients(
         self, goal_handle, feedback_msg, plan, executed_results, step_index, label: str
-    ) -> str:
+    ) -> Tuple[str, Optional[Dict]]:
         """Poll active async actions until the LLM stops returning CONTINUE.
 
-        :returns: Final decision (EXECUTE, SKIP, or ABORT)
+        :returns: Tuple of (decision, resolved_step)
         """
-        decision = self._confirm_step(plan, executed_results, step_index)
+        decision, resolved_step = self._confirm_step(plan, executed_results, step_index)
         while decision == "CONTINUE":
             if goal_handle.is_cancel_requested:
-                return "ABORT"
+                return "ABORT", None
             self._send_feedback(
                 goal_handle,
                 feedback_msg,
@@ -1155,12 +1316,20 @@ class Cortex(ModelComponent, Monitor):
                 f"{label}: waiting for async actions to complete...",
             )
             time.sleep(self.config.monitoring_interval)
-            decision = self._confirm_step(plan, executed_results, step_index)
+            decision, resolved_step = self._confirm_step(
+                plan, executed_results, step_index
+            )
             self.get_logger().info(f"[{label}] re-check -> {decision}")
-        return decision
+        return decision, resolved_step
 
     def _execute_plan(self, plan, goal_handle, feedback_msg) -> Tuple[List[Dict], bool]:
         """Execute plan steps with per-step confirmation.
+
+        The confirmation call includes execution tools so the LLM can
+        return a tool call with arguments resolved from prior step results.
+        For example, if step 1 (vlm.describe) returns a description, the
+        LLM can fill step 2 (tts.say) with that text instead of the
+        placeholder from the original plan.
 
         :returns: (executed_results, aborted)
         """
@@ -1176,11 +1345,11 @@ class Cortex(ModelComponent, Monitor):
                 return executed_results, True
 
             fn_name = step["function"]["name"]
-            fn_args = step["function"].get("arguments", {})
             label = f"Step {i + 1}/{total} ({fn_name})"
 
-            # Confirm (may wait for async actions via CONTINUE)
-            decision = self._wait_for_active_clients(
+            # Confirm (may wait for async actions via CONTINUE).
+            # The LLM may also return a tool call with resolved arguments.
+            decision, resolved_step = self._wait_for_active_clients(
                 goal_handle, feedback_msg, plan, executed_results, i, label
             )
             self.get_logger().info(f"[{label}] -> {decision}")
@@ -1202,13 +1371,18 @@ class Cortex(ModelComponent, Monitor):
                 )
                 continue
 
+            # Use resolved arguments from the confirmation call if available,
+            # otherwise fall back to the pre-planned arguments
+            effective_step = resolved_step if resolved_step else step
+            fn_args = effective_step["function"].get("arguments", {})
+
             # EXECUTE
             args_str = f" with {fn_args}" if fn_args else ""
             self._send_feedback(
                 goal_handle, feedback_msg, i + 1, f"Executing {label}{args_str}"
             )
 
-            step_result = self._execute_action_step(step)
+            step_result = self._execute_action_step(effective_step)
             executed_results.append({
                 "step": i,
                 "action": fn_name,
@@ -1222,7 +1396,7 @@ class Cortex(ModelComponent, Monitor):
 
         # Wait for any remaining async actions after the last step
         if self._monitor_active_clients():
-            decision = self._wait_for_active_clients(
+            decision, _ = self._wait_for_active_clients(
                 goal_handle,
                 feedback_msg,
                 plan,
@@ -1248,6 +1422,12 @@ class Cortex(ModelComponent, Monitor):
         summary = "; ".join(f"{r['action']}: {r['result']}" for r in executed_results)
         has_failures = any(r.get("failed") for r in executed_results)
 
+        # If the goal is already in a terminal state e.g on client cancellation,
+        # don't attempt another state transition.
+        if not goal_handle.is_active:
+            self._cancel_all_active_clients()
+            return
+
         if aborted:
             with self._main_goal_lock:
                 self._cancel_all_active_clients()
@@ -1270,7 +1450,7 @@ class Cortex(ModelComponent, Monitor):
                 goal_handle,
                 feedback_msg,
                 plan_len,
-                f"All {plan_len} steps completed.",
+                f"All {plan_len} steps completed. {summary}",
                 completed=True,
             )
             self.get_logger().info(
@@ -1281,7 +1461,12 @@ class Cortex(ModelComponent, Monitor):
                 goal_handle.succeed()
 
     def main_action_callback(self, goal_handle):
-        """Action server callback. Runs two-phase planning and execution.
+        """Action server callback. Iterative plan-execute loop.
+
+        Plans a batch of steps, executes them, then feeds the results back
+        into the planning conversation so the LLM can continue with
+        additional steps if needed. The loop ends when the planner returns
+        no more tool calls or an abort/failure occurs.
 
         :param goal_handle: Incoming action goal
         :return: Action result
@@ -1297,51 +1482,86 @@ class Cortex(ModelComponent, Monitor):
             goal_handle, feedback_msg, 0, f"Received task. Creating a plan for: {task}"
         )
 
-        # Phase 1: Planning
-        plan = self._plan_task(task)
+        all_executed_results: List[Dict] = []
+        total_steps = 0
+        planning_messages = None
 
-        if plan is None:
-            text_output = self._planning_output or ""
-            if text_output:
-                result_msg.success = True
-                self._send_feedback(
+        for _ in range(self.config.max_execution_steps):
+            # Plan (or continue planning with prior results)
+            plan, planning_messages = self._plan_task(task, planning_messages)
+
+            if plan is None:
+                # No more actions needed
+                if all_executed_results:
+                    # We already executed some steps — task is complete
+                    break
+                # First iteration, no plan at all
+                text_output = self._planning_output or ""
+                if text_output:
+                    result_msg.success = True
+                    self._send_feedback(
+                        goal_handle,
+                        feedback_msg,
+                        0,
+                        f"[No actions needed]. {text_output}",
+                        completed=True,
+                    )
+                    self._publish(result={"output": text_output})
+                    with self._main_goal_lock:
+                        goal_handle.succeed()
+                else:
+                    self._send_feedback(
+                        goal_handle,
+                        feedback_msg,
+                        0,
+                        "Planning failed: no response from model.",
+                        completed=True,
+                    )
+                    with self._main_goal_lock:
+                        goal_handle.abort()
+                return result_msg
+
+            plan_description = ", ".join(s["function"]["name"] for s in plan)
+            self._send_feedback(
+                goal_handle,
+                feedback_msg,
+                total_steps,
+                f"Plan: {plan_description}",
+            )
+            self.get_logger().info(f"Plan: {plan_description}")
+
+            # Execute this batch
+            executed_results, aborted = self._execute_plan(
+                plan, goal_handle, feedback_msg
+            )
+            all_executed_results.extend(executed_results)
+            total_steps += len(plan)
+
+            if aborted:
+                self._finalize_goal(
                     goal_handle,
                     feedback_msg,
-                    0,
-                    f"[No actions needed]. {text_output}",
-                    completed=True,
+                    result_msg,
+                    all_executed_results,
+                    total_steps,
+                    True,
                 )
-                # publish planning output if there is an output topic
-                self._publish(result={"output": text_output})
-                with self._main_goal_lock:
-                    goal_handle.succeed()
-            else:
-                self._send_feedback(
-                    goal_handle,
-                    feedback_msg,
-                    0,
-                    "Planning failed: no response from model.",
-                    completed=True,
-                )
-                with self._main_goal_lock:
-                    goal_handle.abort()
-            return result_msg
+                return result_msg
 
-        plan_description = ", ".join(s["function"]["name"] for s in plan)
-        self._send_feedback(
+            # Feed execution results back into the planning conversation
+            # so the LLM can continue with the next steps
+            self._append_execution_results_to_planning(
+                planning_messages, plan, executed_results
+            )
+
+        # All iterations done — finalize
+        self._finalize_goal(
             goal_handle,
             feedback_msg,
-            0,
-            f"Plan created with {len(plan)} steps: {plan_description}",
-        )
-        self.get_logger().info(f"Plan: {plan_description}")
-
-        # Phase 2: Execution
-        executed_results, aborted = self._execute_plan(plan, goal_handle, feedback_msg)
-
-        # Finalize
-        self._finalize_goal(
-            goal_handle, feedback_msg, result_msg, executed_results, len(plan), aborted
+            result_msg,
+            all_executed_results,
+            total_steps,
+            False,
         )
         return result_msg
 

--- a/agents/components/map_encoding.py
+++ b/agents/components/map_encoding.py
@@ -25,6 +25,12 @@ class MapEncoding(Component):
     It takes in map layers, position topic, map occupancy grid topic, and a vector database client.
     Map layers can be arbitrary text based outputs from other components such as MLLMs or Vision.
 
+    .. deprecated::
+        MapEncoding is deprecated. Use the :class:`~agents.components.memory.Memory`
+        component instead, which provides a richer graph-based spatio-temporal
+        memory with perception + interoception encoding, episode-based
+        consolidation, and structured retrieval tools.
+
     :param layers: A list of map layer objects to be encoded.
     :type layers: list[MapLayer]
     :param position: The topic for the current robot position.
@@ -309,27 +315,29 @@ class MapEncoding(Component):
             input.name: input.msg_type.callback(input) for input in all_inputs
         }
 
-    @component_action(description={
-        "type": "function",
-        "function": {
-            "name": "add_point",
-            "description": "Add a labelled point to a spatial map layer.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "layer": {
-                        "type": "string",
-                        "description": "Name of the map layer to add the point to. Should be one of the layers available in this component",
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "add_point",
+                "description": "Add a labelled point to a spatial map layer.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "layer": {
+                            "type": "string",
+                            "description": "Name of the map layer to add the point to. Should be one of the layers available in this component",
+                        },
+                        "point": {
+                            "type": "string",
+                            "description": "A position and label for the point.",
+                        },
                     },
-                    "point": {
-                        "type": "string",
-                        "description": "A position and label for the point.",
-                    },
+                    "required": ["layer", "point"],
                 },
-                "required": ["layer", "point"],
             },
-        },
-    })
+        }
+    )
     def add_point(self, layer: MapLayer, point: Tuple[np.ndarray, str]) -> None:
         """Component action to add a user defined point to the map collection.
         This action can be executed on an event.

--- a/agents/components/memory.py
+++ b/agents/components/memory.py
@@ -218,6 +218,46 @@ class Memory(Component):
             self.model_client.check_connection()
             self.model_client.deinitialize()
 
+    def inspect_component(self) -> str:
+        """Return component info including configured perception layers.
+
+        Appends a ``Perception layers:`` section listing each configured
+        MapLayer (layer name, source topic, and message type). A consumer
+        like Cortex can read this to learn which layer tags observations
+        get stored under. Useful when planning retrieval calls that take
+        a ``layer`` filter, or when deciding whether an LLM-injected memory
+        should share a tag with an existing perception stream.
+        """
+        result = super().inspect_component()
+
+        if self.layers_dict:
+            lines = [
+                "",
+                "Perception layers (layer_name → source topic):",
+                (
+                    "  Each layer tags observations with a label derived from "
+                    "its source topic. Use these names as the 'layer' filter in "
+                    "memory retrieval tools (semantic_search, spatial_query, "
+                    "locate, ...) to narrow results to one stream."
+                ),
+            ]
+            for name, layer in self.layers_dict.items():
+                topic = layer.subscribes_to
+                msg_name = (
+                    topic.msg_type.__name__
+                    if hasattr(topic.msg_type, "__name__")
+                    else str(topic.msg_type)
+                )
+                lines.append(
+                    f"  - {name}  (from topic '{topic.name}', type {msg_name})"
+                )
+            result += "\n".join(lines)
+        else:
+            result += "\nPerception layers: none configured"
+
+        result += f"\nPosition topic: {self.position.name}"
+        return result
+
     def _layers(self, layers: List[MapLayer]):
         """Set up perception layers and callbacks"""
         self.layers_dict = {layer.subscribes_to.name: layer for layer in layers}

--- a/agents/components/memory.py
+++ b/agents/components/memory.py
@@ -1,0 +1,427 @@
+from pathlib import Path
+from typing import Any, Dict, Optional, Union, List
+
+from ..clients.model_base import ModelClient
+from ..config import MemoryConfig
+from ..ros import (
+    Odometry,
+    String,
+    Event,
+    Topic,
+    Detections,
+    DetectionsMultiSource,
+    MapLayer,
+    component_action,
+)
+from ..utils import validate_func_args
+from .component_base import Component, ComponentRunType
+
+# Pull tool schemas from eMEM if installed, else fallback to an empty
+# stub per tool so decoration still succeeds
+try:
+    from emem.tools import TOOL_SCHEMAS as _EMEM_TOOL_SCHEMAS
+except ImportError:
+    _EMEM_TOOL_SCHEMAS = {
+        name: {
+            "name": name,
+            "description": f"{name} (eMEM not installed)",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        for name in (
+            "semantic_search",
+            "spatial_query",
+            "temporal_query",
+            "episode_summary",
+            "get_current_context",
+            "search_gists",
+            "entity_query",
+            "locate",
+            "recall",
+            "body_status",
+        )
+    }
+
+
+def _tool(name: str) -> Dict[str, Any]:
+    """Wrap an eMEM tool schema in OpenAI-format for ``@component_action``."""
+    return {"type": "function", "function": _EMEM_TOOL_SCHEMAS[name]}
+
+
+class Memory(Component):
+    """Spatio-temporal memory component powered by eMEM.
+
+    Encodes perception layer data (text descriptions from vlms, detections) into
+    a graph-based spatio-temporal memory indexed by meaning, location, and time.
+    Provides 10 retrieval tools as component actions and supports episode-based
+    memory consolidation.
+
+    This component uses real-world coordinates from Odometry directly
+    and provides consolidation, entity tracking, and structured retrieval tools
+    instead of flat vector DB storage.
+
+    :param layers: Perception layers to encode (output topics from other components).
+    :type layers: list[MapLayer]
+    :param position: Odometry topic providing the robot's current position.
+    :type position: Topic
+    :param model_client: Model client for memory consolidation (summarization, entity extraction). If not provided, consolidation uses simple text concatenation.
+    :type model_client: Optional[ModelClient]
+    :param embedding_client: Model client for generating embeddings (e.g. OllamaClient with an embedding model). If not provided, falls back to sentence-transformers.
+    :type embedding_client: Optional[ModelClient]
+    :param config: Memory configuration.
+    :type config: Optional[MemoryConfig]
+    :param trigger: Trigger for the execution step (frequency in Hz, topic, or event).
+    :type trigger: Union[Topic, list[Topic], float, Event]
+    :param component_name: ROS node name for this component.
+    :type component_name: str
+
+    Example usage:
+    ```python
+    position = Topic(name="odom", msg_type="Odometry")
+    detections = Topic(name="detections", msg_type="Detections")
+    room_type = Topic(name="room_type", msg_type="String")
+
+    layer1 = MapLayer(subscribes_to=detections, temporal_change=True)
+    layer2 = MapLayer(subscribes_to=room_type, resolution_multiple=3)
+
+    memory = Memory(
+        layers=[layer1, layer2],
+        position=position,
+        model_client=llama_client,
+        embedding_client=embed_client,
+        config=MemoryConfig(db_path="/tmp/robot_memory.db"),
+        trigger=15.0,
+        component_name="memory",
+    )
+    ```
+    """
+
+    @validate_func_args
+    def __init__(
+        self,
+        *,
+        layers: List[MapLayer],
+        position: Topic,
+        model_client: Optional[ModelClient] = None,
+        embedding_client: Optional[ModelClient] = None,
+        config: Optional[MemoryConfig] = None,
+        trigger: Union[Topic, List[Topic], float, Event] = 10.0,
+        component_name: str,
+        **kwargs,
+    ):
+        from importlib.util import find_spec
+
+        if find_spec("emem") is None:
+            raise ImportError(
+                "The Memory component requires the 'emem' package. "
+                "Install it with: pip install emem"
+            )
+
+        self.config: MemoryConfig = config or MemoryConfig()
+        self.allowed_inputs = {
+            "Required": [Odometry],
+            "Optional": [String, Detections, DetectionsMultiSource],
+        }
+
+        self.model_client = model_client
+        self.embedding_client = embedding_client
+
+        self.position = position
+        self.config._position = position
+
+        super().__init__(
+            None,
+            None,
+            self.config,
+            trigger,
+            component_name,
+            **kwargs,
+        )
+
+        self._layers(layers)
+
+    def custom_on_configure(self):
+        """Initialize eMEM and client connections."""
+        self.get_logger().debug(f"Current Status: {self.health_status.value}")
+        super().custom_on_configure()
+
+        # Initialize embedding provider
+        if self.embedding_client:
+            self.embedding_client.check_connection()
+            self.embedding_client.initialize()
+            from emem.embeddings import CallableEmbeddingProvider
+
+            embedding_provider = CallableEmbeddingProvider(self.embedding_client._embed)
+        else:
+            from emem.embeddings import SentenceTransformerProvider
+
+            embedding_provider = SentenceTransformerProvider(
+                self.config.embedding_checkpoint
+            )
+
+        # Initialize LLM client for consolidation
+        llm_client = None
+        if self.model_client:
+            self.model_client.check_connection()
+            self.model_client.initialize()
+            from emem.consolidation import InferenceLLMClient
+
+            llm_client = InferenceLLMClient(self.model_client.inference)
+        else:
+            self.get_logger().warning(
+                "No model_client provided. Memory consolidation will use "
+                "simple text concatenation instead of LLM summarization."
+            )
+
+        # Build eMEM config from component config
+        from emem.config import SpatioTemporalMemoryConfig
+
+        emem_config = SpatioTemporalMemoryConfig(
+            db_path=self.config.db_path,
+            hnsw_path=str(Path(self.config.db_path).with_suffix(".hnsw.bin")),
+            embedding_dim=embedding_provider.dim,
+            working_memory_size=self.config.working_memory_size,
+            flush_interval=self.config.flush_interval,
+            flush_batch_size=self.config.flush_batch_size,
+            consolidation_window=self.config.consolidation_window,
+            consolidation_spatial_eps=self.config.consolidation_spatial_eps,
+            consolidation_min_samples=self.config.consolidation_min_samples,
+            archive_after_seconds=self.config.archive_after_seconds,
+            entity_extract_flush_interval=self.config.entity_extract_flush_interval,
+            entity_extract_time_interval=self.config.entity_extract_time_interval,
+            entity_similarity_threshold=self.config.entity_similarity_threshold,
+            entity_spatial_radius=self.config.entity_spatial_radius,
+            recency_weight=self.config.recency_weight,
+            recency_halflife=self.config.recency_halflife,
+            hnsw_ef_construction=self.config.hnsw_ef_construction,
+            hnsw_m=self.config.hnsw_m,
+            hnsw_ef_search=self.config.hnsw_ef_search,
+            hnsw_max_elements=self.config.hnsw_max_elements,
+        )
+
+        # Create eMEM instance
+        from emem import SpatioTemporalMemory
+
+        self.memory = SpatioTemporalMemory(
+            config=emem_config,
+            embedding_provider=embedding_provider,
+            llm_client=llm_client,
+        )
+
+    def custom_on_deactivate(self):
+        """Close eMEM and deinitialize clients."""
+        if hasattr(self, "memory"):
+            self.memory.close()
+        if self.embedding_client:
+            self.embedding_client.check_connection()
+            self.embedding_client.deinitialize()
+        if self.model_client:
+            self.model_client.check_connection()
+            self.model_client.deinitialize()
+
+    def _layers(self, layers: List[MapLayer]):
+        """Set up perception layers and callbacks"""
+        self.layers_dict = {layer.subscribes_to.name: layer for layer in layers}
+        layer_topics = [layer.subscribes_to for layer in layers]
+        all_inputs = [*layer_topics, self.config._position]
+        self._validate_topics(all_inputs, self.allowed_inputs, "Inputs")
+        self.callbacks = {
+            input.name: input.msg_type.callback(input) for input in all_inputs
+        }
+
+    def _store_layers(self, position, time_stamp) -> None:
+        """Store all layer data at the given position and time."""
+        for name in self.layers_dict:
+            if item := self.callbacks[name].get_output():
+                self.memory.add(
+                    text=item,
+                    x=float(position[0]),
+                    y=float(position[1]),
+                    z=float(position[2]) if len(position) > 2 else 0.0,
+                    layer_name=name,
+                    timestamp=float(time_stamp),
+                )
+
+    def _execution_step(self, **kwargs):
+        """Periodic execution: read position and store layer data."""
+        time_stamp = self.get_ros_time().sec
+        if self.run_type is ComponentRunType.EVENT:
+            trigger = kwargs.get("topic")
+            if trigger:
+                self.get_logger().debug(f"Received trigger on {trigger.name}")
+            else:
+                self.get_logger().debug("Memory got triggered by an event.")
+        else:
+            self.get_logger().debug(f"Executing at {time_stamp}")
+
+        if not self.config.auto_store:
+            return
+
+        position = self.callbacks[self.position.name].get_output()
+        if position is None:
+            self.get_logger().warning(
+                "Position not received, not storing observations."
+            )
+            return
+
+        self._store_layers(position[:3], time_stamp)
+
+    ### Storage actions ###
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "store",
+                "description": (
+                    "Force an immediate snapshot of the latest data on every "
+                    "configured perception layer, tagged with the robot's "
+                    "current odometry position and current time. Normally "
+                    "snapshotting happens automatically at the component's "
+                    "trigger rate — call this only when you need an out-of-band "
+                    "capture (e.g. right after observing something important)."
+                ),
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        }
+    )
+    def store(self) -> None:
+        """Explicitly trigger storage of current layer data."""
+        position = self.callbacks[self.position.name].get_output()
+        if position is None:
+            return
+        time_stamp = self.get_ros_time().sec
+        self._store_layers(position[:3], time_stamp)
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "start_episode",
+                "description": (
+                    "Open a named episode. All observations stored between now "
+                    "and the matching end_episode will be grouped under this "
+                    "name and later consolidated into a searchable summary. "
+                    "Use this when the robot begins a discrete task or activity "
+                    "the operator might ask about later (e.g. 'kitchen patrol', "
+                    "'charging')."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": (
+                                "Human-readable episode name, e.g. 'kitchen "
+                                "patrol', 'delivery to Alice'."
+                            ),
+                        },
+                    },
+                    "required": ["name"],
+                },
+            },
+        }
+    )
+    def start_episode(self, name: str) -> str:
+        """Start a named episode."""
+        return self.memory.start_episode(name)
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "end_episode",
+                "description": (
+                    "Close the currently active episode. This triggers memory "
+                    "consolidation: the episode's observations are clustered, "
+                    "summarized into gists by the LLM, and entities (objects, "
+                    "people, landmarks) are extracted and deduplicated. Call "
+                    "this when the corresponding task is finished."
+                ),
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        }
+    )
+    def end_episode(self) -> str:
+        """End the active episode and trigger consolidation."""
+        return self.memory.end_episode() or "No active episode"
+
+    ### Retrieval actions ###
+
+    @component_action(description=_tool("semantic_search"))
+    def semantic_search(self, **kwargs) -> str:
+        """Search memory by meaning."""
+        return self.memory.dispatch_tool_call("semantic_search", kwargs)
+
+    @component_action(description=_tool("spatial_query"))
+    def spatial_query(self, **kwargs) -> str:
+        """Find observations within a radius of a point."""
+        return self.memory.dispatch_tool_call("spatial_query", kwargs)
+
+    @component_action(description=_tool("temporal_query"))
+    def temporal_query(self, **kwargs) -> str:
+        """Find observations in a time range."""
+        return self.memory.dispatch_tool_call("temporal_query", kwargs)
+
+    @component_action(description=_tool("episode_summary"))
+    def episode_summary(self, **kwargs) -> str:
+        """Get summary of one or more episodes."""
+        return self.memory.dispatch_tool_call("episode_summary", kwargs)
+
+    @component_action(description=_tool("get_current_context"))
+    def get_current_context(self, **kwargs) -> str:
+        """Get situational awareness."""
+        return self.memory.dispatch_tool_call("get_current_context", kwargs)
+
+    @component_action(description=_tool("search_gists"))
+    def search_gists(self, **kwargs) -> str:
+        """Search consolidated memory summaries."""
+        return self.memory.dispatch_tool_call("search_gists", kwargs)
+
+    @component_action(description=_tool("entity_query"))
+    def entity_query(self, **kwargs) -> str:
+        """Find known entities."""
+        return self.memory.dispatch_tool_call("entity_query", kwargs)
+
+    @component_action(description=_tool("locate"))
+    def locate(self, **kwargs) -> str:
+        """Find the spatial location of a concept."""
+        return self.memory.dispatch_tool_call("locate", kwargs)
+
+    @component_action(description=_tool("recall"))
+    def recall(self, **kwargs) -> str:
+        """Recall everything known about a concept."""
+        return self.memory.dispatch_tool_call("recall", kwargs)
+
+    @component_action(description=_tool("body_status"))
+    def body_status(self, **kwargs) -> str:
+        """Get latest body/internal state readings."""
+        return self.memory.dispatch_tool_call("body_status", kwargs)
+
+    ###  LLM tool registration ###
+
+    def register_tools_on(
+        self,
+        llm,
+        tools: Optional[List[str]] = None,
+        send_tool_response_to_model: bool = True,
+    ) -> None:
+        """Register eMEM retrieval tools on an LLM component for tool calling.
+
+        :param llm: The LLM or Cortex component to register tools on.
+        :type llm: LLM
+        :param tools: Optional subset of tool names to register (default: all 10).
+        :type tools: Optional[list[str]]
+        :param send_tool_response_to_model: Whether tool results are sent back to the model for a follow-up response.
+        :type send_tool_response_to_model: bool
+
+        Example usage:
+        ```python
+        memory.register_tools_on(llm, send_tool_response_to_model=True)
+        # Or register a subset:
+        memory.register_tools_on(llm, tools=["semantic_search", "locate", "get_current_context"])
+        ```
+        """
+        for fn, desc in self.memory.get_tools_for_registration():
+            name = desc["function"]["name"]
+            if tools is None or name in tools:
+                llm.register_tool(fn, desc, send_tool_response_to_model)

--- a/agents/components/memory.py
+++ b/agents/components/memory.py
@@ -336,6 +336,115 @@ class Memory(Component):
         description={
             "type": "function",
             "function": {
+                "name": "store_specific_memory",
+                "description": (
+                    "Write a piece of text into memory as a new observation. "
+                    "Use this to record things that did not come in through a "
+                    "perception layer, for example a scene description the "
+                    "planner just produced, a decision made during a task, or "
+                    "a fact the operator just told the robot. "
+                    "By default the note goes into the 'agent_notes' layer, "
+                    "which is separate from perception streams. "
+                    "Only override 'layer_name' if you are confident the note "
+                    "belongs with an existing perception layer reported by "
+                    "inspect_component (e.g. if you are adding a caption to a "
+                    "'scene_description' layer that already stores VLM output); "
+                    "otherwise leave it at the default so hallucinated text "
+                    "does not contaminate detector streams. "
+                    "If coordinates are not provided, the robot's current "
+                    "odometry position is used."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "type": "string",
+                            "description": "The text to remember.",
+                        },
+                        "layer_name": {
+                            "type": "string",
+                            "description": (
+                                "Layer tag to store the note under. Defaults "
+                                "to 'agent_notes'. Only change this if the "
+                                "note genuinely belongs with an existing "
+                                "perception layer visible via inspect_component."
+                            ),
+                            "default": "agent_notes",
+                        },
+                        "x": {
+                            "type": "number",
+                            "description": (
+                                "X coordinate in world-frame meters. Omit to "
+                                "use the robot's current position."
+                            ),
+                        },
+                        "y": {
+                            "type": "number",
+                            "description": (
+                                "Y coordinate in world-frame meters. Omit to "
+                                "use the robot's current position."
+                            ),
+                        },
+                        "z": {
+                            "type": "number",
+                            "description": (
+                                "Z coordinate in meters. Omit to use the "
+                                "robot's current position (or 0 for 2D maps)."
+                            ),
+                        },
+                    },
+                    "required": ["content"],
+                },
+            },
+        }
+    )
+    def store_specific_memory(
+        self,
+        content: str,
+        layer_name: str = "agent_notes",
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+    ) -> bool:
+        """Store an arbitrary piece of text at a given (or current) position.
+
+        :param content: Text to record.
+        :param layer_name: Layer tag to store under. Defaults to ``agent_notes``.
+        :param x: Optional X in world-frame meters. If omitted, current odometry is used.
+        :param y: Optional Y in world-frame meters. If omitted, current odometry is used.
+        :param z: Optional Z in meters. If omitted, current odometry is used.
+        :returns: True if the note was stored, False if position was unavailable.
+        """
+        if x is None or y is None:
+            position = self.callbacks[self.position.name].get_output()
+            if position is None:
+                self.get_logger().warning(
+                    "store_note: no coordinates given and no odometry "
+                    "available, note not stored."
+                )
+                return False
+            px = float(position[0])
+            py = float(position[1])
+            pz = float(position[2]) if len(position) > 2 else 0.0
+        else:
+            px = float(x)
+            py = float(y)
+            pz = float(z) if z is not None else 0.0
+
+        self.memory.add(
+            text=content,
+            x=px,
+            y=py,
+            z=pz,
+            layer_name=layer_name,
+            timestamp=float(self.get_ros_time().sec),
+        )
+        return True
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
                 "name": "start_episode",
                 "description": (
                     "Open a named episode. All observations stored between now "

--- a/agents/components/memory.py
+++ b/agents/components/memory.py
@@ -11,6 +11,7 @@ from ..ros import (
     Detections,
     DetectionsMultiSource,
     MapLayer,
+    ActionPhase,
     component_action,
 )
 from ..utils import validate_func_args
@@ -496,52 +497,54 @@ class Memory(Component):
 
     ### Retrieval actions ###
 
-    @component_action(description=_tool("semantic_search"))
+    @component_action(description=_tool("semantic_search"), phase=ActionPhase.PLANNING)
     def semantic_search(self, **kwargs) -> str:
         """Search memory by meaning."""
         return self.memory.dispatch_tool_call("semantic_search", kwargs)
 
-    @component_action(description=_tool("spatial_query"))
+    @component_action(description=_tool("spatial_query"), phase=ActionPhase.PLANNING)
     def spatial_query(self, **kwargs) -> str:
         """Find observations within a radius of a point."""
         return self.memory.dispatch_tool_call("spatial_query", kwargs)
 
-    @component_action(description=_tool("temporal_query"))
+    @component_action(description=_tool("temporal_query"), phase=ActionPhase.PLANNING)
     def temporal_query(self, **kwargs) -> str:
         """Find observations in a time range."""
         return self.memory.dispatch_tool_call("temporal_query", kwargs)
 
-    @component_action(description=_tool("episode_summary"))
+    @component_action(description=_tool("episode_summary"), phase=ActionPhase.PLANNING)
     def episode_summary(self, **kwargs) -> str:
         """Get summary of one or more episodes."""
         return self.memory.dispatch_tool_call("episode_summary", kwargs)
 
-    @component_action(description=_tool("get_current_context"))
+    @component_action(
+        description=_tool("get_current_context"), phase=ActionPhase.PLANNING
+    )
     def get_current_context(self, **kwargs) -> str:
         """Get situational awareness."""
         return self.memory.dispatch_tool_call("get_current_context", kwargs)
 
-    @component_action(description=_tool("search_gists"))
+    @component_action(description=_tool("search_gists"), phase=ActionPhase.PLANNING)
     def search_gists(self, **kwargs) -> str:
         """Search consolidated memory summaries."""
         return self.memory.dispatch_tool_call("search_gists", kwargs)
 
-    @component_action(description=_tool("entity_query"))
+    @component_action(description=_tool("entity_query"), phase=ActionPhase.PLANNING)
     def entity_query(self, **kwargs) -> str:
         """Find known entities."""
         return self.memory.dispatch_tool_call("entity_query", kwargs)
 
-    @component_action(description=_tool("locate"))
+    @component_action(description=_tool("locate"), phase=ActionPhase.PLANNING)
     def locate(self, **kwargs) -> str:
         """Find the spatial location of a concept."""
         return self.memory.dispatch_tool_call("locate", kwargs)
 
-    @component_action(description=_tool("recall"))
+    @component_action(description=_tool("recall"), phase=ActionPhase.PLANNING)
     def recall(self, **kwargs) -> str:
         """Recall everything known about a concept."""
         return self.memory.dispatch_tool_call("recall", kwargs)
 
-    @component_action(description=_tool("body_status"))
+    @component_action(description=_tool("body_status"), phase=ActionPhase.BOTH)
     def body_status(self, **kwargs) -> str:
         """Get latest body/internal state readings."""
         return self.memory.dispatch_tool_call("body_status", kwargs)

--- a/agents/components/memory.py
+++ b/agents/components/memory.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Any, Dict, Optional, Union, List
+import json
 
 from ..clients.model_base import ModelClient
 from ..config import MemoryConfig
@@ -577,3 +578,48 @@ class Memory(Component):
             name = desc["function"]["name"]
             if tools is None or name in tools:
                 llm.register_tool(fn, desc, send_tool_response_to_model)
+
+    def _update_cmd_args_list(self):
+        """
+        Update launch command arguments
+        """
+        super()._update_cmd_args_list()
+
+        self.launch_cmd_args = [
+            "--layers",
+            self._get_layers_json(),
+        ]
+
+        self.launch_cmd_args = [
+            "--model_client",
+            self._get_client_json(self.model_client),
+        ]
+
+        self.launch_cmd_args = [
+            "--embedding_client",
+            self._get_client_json(self.embedding_client),
+        ]
+
+    def _get_layers_json(self) -> Union[str, bytes, bytearray]:
+        """
+        Serialize component layers to json
+
+        :return: Serialized inputs
+        :rtype:  str | bytes | bytearray
+        """
+        if not hasattr(self, "layers_dict"):
+            return "[]"
+        return json.dumps([layer.to_json() for layer in self.layers_dict.values()])
+
+    def _get_client_json(
+        self, client: Optional[ModelClient]
+    ) -> Union[str, bytes, bytearray]:
+        """
+        Serialize component client to json
+
+        :return: Serialized inputs
+        :rtype:  str | bytes | bytearray
+        """
+        if not client:
+            return ""
+        return json.dumps(client.serialize())

--- a/agents/components/memory.py
+++ b/agents/components/memory.py
@@ -7,11 +7,12 @@ from ..config import MemoryConfig
 from ..ros import (
     Odometry,
     String,
+    StreamingString,
     Event,
     Topic,
     Detections,
     DetectionsMultiSource,
-    MapLayer,
+    MemLayer,
     ActionPhase,
     component_action,
 )
@@ -61,8 +62,12 @@ class Memory(Component):
     and provides consolidation, entity tracking, and structured retrieval tools
     instead of flat vector DB storage.
 
-    :param layers: Perception layers to encode (output topics from other components).
-    :type layers: list[MapLayer]
+    :param layers: Input layers to encode. Each layer subscribes to a topic
+        whose callback produces a string via ``_get_ui_content``. Layers with
+        ``is_internal_state=True`` are written via ``add_body_state`` and
+        retrieved through the ``body_status`` tool; all other layers are
+        perception layers retrieved through ``semantic_search`` and friends.
+    :type layers: list[MemLayer]
     :param position: Odometry topic providing the robot's current position.
     :type position: Topic
     :param model_client: Model client for memory consolidation (summarization, entity extraction). If not provided, consolidation uses simple text concatenation.
@@ -81,12 +86,14 @@ class Memory(Component):
     position = Topic(name="odom", msg_type="Odometry")
     detections = Topic(name="detections", msg_type="Detections")
     room_type = Topic(name="room_type", msg_type="String")
+    battery = Topic(name="battery_state", msg_type="BatteryState")
 
-    layer1 = MapLayer(subscribes_to=detections, temporal_change=True)
-    layer2 = MapLayer(subscribes_to=room_type, resolution_multiple=3)
+    layer1 = MemLayer(subscribes_to=detections, temporal_change=True)
+    layer2 = MemLayer(subscribes_to=room_type, resolution_multiple=3)
+    layer3 = MemLayer(subscribes_to=battery, is_internal_state=True)
 
     memory = Memory(
-        layers=[layer1, layer2],
+        layers=[layer1, layer2, layer3],
         position=position,
         model_client=llama_client,
         embedding_client=embed_client,
@@ -101,7 +108,7 @@ class Memory(Component):
     def __init__(
         self,
         *,
-        layers: List[MapLayer],
+        layers: List[MemLayer],
         position: Topic,
         model_client: Optional[ModelClient] = None,
         embedding_client: Optional[ModelClient] = None,
@@ -121,9 +128,8 @@ class Memory(Component):
         self.config: MemoryConfig = config or MemoryConfig()
         self.allowed_inputs = {
             "Required": [Odometry],
-            "Optional": [String, Detections, DetectionsMultiSource],
+            "Optional": [String, StreamingString, Detections, DetectionsMultiSource],
         }
-
         self.model_client = model_client
         self.embedding_client = embedding_client
 
@@ -221,66 +227,136 @@ class Memory(Component):
             self.model_client.deinitialize()
 
     def inspect_component(self) -> str:
-        """Return component info including configured perception layers.
+        """Return component info including configured layers.
 
-        Appends a ``Perception layers:`` section listing each configured
-        MapLayer (layer name, source topic, and message type). A consumer
+        Appends a ``Perception layers:`` section and, if any are
+        configured, an ``Internal-state layers:`` section. A consumer
         like Cortex can read this to learn which layer tags observations
         get stored under. Useful when planning retrieval calls that take
-        a ``layer`` filter, or when deciding whether an LLM-injected memory
-        should share a tag with an existing perception stream.
+        a ``layer`` filter: perception layers are queried via
+        ``semantic_search`` / ``spatial_query`` / ``locate``, while
+        internal-state layers are queried via ``body_status``.
         """
         result = super().inspect_component()
 
-        if self.layers_dict:
-            lines = [
-                "",
+        def _fmt(name, layer):
+            topic = layer.subscribes_to
+            msg_name = (
+                topic.msg_type.__name__
+                if hasattr(topic.msg_type, "__name__")
+                else str(topic.msg_type)
+            )
+            return f"  - {name}  (from topic '{topic.name}', type {msg_name})"
+
+        perception = {
+            n: lay for n, lay in self.layers_dict.items() if not lay.is_internal_state
+        }
+        internal = {
+            n: lay for n, lay in self.layers_dict.items() if lay.is_internal_state
+        }
+
+        lines = [""]
+        if perception:
+            lines += [
                 "Perception layers (layer_name → source topic):",
                 (
-                    "  Each layer tags observations with a label derived from "
-                    "its source topic. Use these names as the 'layer' filter in "
-                    "memory retrieval tools (semantic_search, spatial_query, "
-                    "locate, ...) to narrow results to one stream."
+                    "  Use these names as the 'layer' filter in perception "
+                    "retrieval tools (semantic_search, spatial_query, locate, "
+                    "...) to narrow results to one stream."
                 ),
             ]
-            for name, layer in self.layers_dict.items():
-                topic = layer.subscribes_to
-                msg_name = (
-                    topic.msg_type.__name__
-                    if hasattr(topic.msg_type, "__name__")
-                    else str(topic.msg_type)
-                )
-                lines.append(
-                    f"  - {name}  (from topic '{topic.name}', type {msg_name})"
-                )
-            result += "\n".join(lines)
+            lines += [_fmt(n, lay) for n, lay in perception.items()]
         else:
-            result += "\nPerception layers: none configured"
+            lines.append("Perception layers: none configured")
 
+        if internal:
+            lines += [
+                "",
+                "Internal-state layers (layer_name → source topic):",
+                (
+                    "  These carry the robot's own state (battery, temperature, "
+                    "joint health, etc.). Query them via body_status(layers=[...]) "
+                    "— they are NOT returned by semantic_search."
+                ),
+            ]
+            lines += [_fmt(n, lay) for n, lay in internal.items()]
+
+        result += "\n".join(lines)
         result += f"\nPosition topic: {self.position.name}"
         return result
 
-    def _layers(self, layers: List[MapLayer]):
-        """Set up perception layers and callbacks"""
+    def _layers(self, layers: List[MemLayer]):
+        """Set up layers and callbacks.
+
+        Perception-layer topics are validated against ``allowed_inputs``
+        so mis-wired topics fail loudly at configuration time. Internal-state
+        layers are *not* validated: their message types come from
+        robot plugins and the plugin contract is that their callback's
+        ``get_output`` returns something representable as a string.
+        """
         self.layers_dict = {layer.subscribes_to.name: layer for layer in layers}
-        layer_topics = [layer.subscribes_to for layer in layers]
-        all_inputs = [*layer_topics, self.config._position]
-        self._validate_topics(all_inputs, self.allowed_inputs, "Inputs")
+
+        perception_topics = [
+            layer.subscribes_to for layer in layers if not layer.is_internal_state
+        ]
+        try:
+            self._validate_topics(
+                [*perception_topics, self.config._position],
+                self.allowed_inputs,
+                "Inputs",
+            )
+        except Exception as e:
+            raise TypeError(
+                f"Memory Layers which do not have `is_internal_state=True` can only be of the allowed datatypes: {[lay.__name__ for lay in self.allowed_inputs['Optional']]} or their subclasses."
+            ) from e
+
+        all_topics = [layer.subscribes_to for layer in layers] + [self.config._position]
         self.callbacks = {
-            input.name: input.msg_type.callback(input) for input in all_inputs
+            input.name: input.msg_type.callback(input) for input in all_topics
         }
 
     def _store_layers(self, position, time_stamp) -> None:
-        """Store all layer data at the given position and time."""
-        for name in self.layers_dict:
-            if item := self.callbacks[name].get_output():
-                self.memory.add(
-                    text=item,
-                    x=float(position[0]),
-                    y=float(position[1]),
-                    z=float(position[2]) if len(position) > 2 else 0.0,
+        """Store all layer data at the given position and time.
+
+        Every layer's text is read via the callback's ``get_output``.
+        Perception callbacks already return semantic strings there; for
+        internal-state layers a plugin-provided callback is expected to
+        return a string (or at worst something that stringifies
+        sensibly). Non-string returns are coerced.
+
+        Layers flagged ``is_internal_state=True`` are routed to
+        ``SpatioTemporalMemory.add_body_state``.
+        """
+        x = float(position[0])
+        y = float(position[1])
+        z = float(position[2]) if len(position) > 2 else 0.0
+        ts = float(time_stamp)
+
+        for name, layer in self.layers_dict.items():
+            raw = self.callbacks[name].get_output()
+            if raw is None:
+                continue
+            text = raw if isinstance(raw, str) else str(raw)
+            if not text:
+                continue
+
+            if layer.is_internal_state:
+                self.memory.add_body_state(
+                    text=text,
                     layer_name=name,
-                    timestamp=float(time_stamp),
+                    x=x,
+                    y=y,
+                    z=z,
+                    timestamp=ts,
+                )
+            else:
+                self.memory.add(
+                    text=text,
+                    x=x,
+                    y=y,
+                    z=z,
+                    layer_name=name,
+                    timestamp=ts,
                 )
 
     def _execution_step(self, **kwargs):

--- a/agents/components/mllm.py
+++ b/agents/components/mllm.py
@@ -1,4 +1,5 @@
 import time
+import json
 from typing import Any, Union, Optional, List, Dict, Literal, MutableMapping
 
 import numpy as np
@@ -257,7 +258,8 @@ class MLLM(LLM):
                     "Use this method when asked to describe something in robot's "
                     "surroundings. Captures a frame from a camera topic and describe what "
                     "is visible in the image using the vision-language model. "
-                    "Returns a text description on components output topics."
+                    "Returns a text description to the caller, which can be used in a"
+                    " subsequent tool call if required."
                 ),
                 "parameters": {
                     "type": "object",
@@ -287,7 +289,7 @@ class MLLM(LLM):
         topic_name: str,
         query: str = "Describe what you see in the image.",
         timeout: float = 0.5,
-    ) -> bool:
+    ) -> str:
         """Capture a frame from an image topic and describe it.
 
         Grabs the latest frame from the specified image input topic,
@@ -306,7 +308,10 @@ class MLLM(LLM):
         try:
             image = self._grab_frame(topic_name, timeout)
             if image is None:
-                return False
+                self.get_logger().error(
+                    "Describe: could not get image from image topic."
+                )
+                raise Exception("Could not get image from image topic.")
 
             inference_input = {
                 "query": [{"role": "user", "content": query}],
@@ -315,16 +320,16 @@ class MLLM(LLM):
             }
 
             result = self._call_inference(inference_input)
-            if not result or not result.get("output"):
+            if not result or not (output := result.get("output")):
                 self.get_logger().error("Describe: inference returned no output.")
-                return False
+                raise Exception("Inference failed and returned no output.")
 
-            self._publish(result)
-            return True
+            # return text output to caller
+            return json.dumps(output)
 
         except Exception as e:
             self.get_logger().error(f"Failed to describe: {e}")
-            return False
+            raise
 
     def _grab_frame(self, topic_name: str, timeout: float) -> Optional[np.ndarray]:
         """Grab a single frame from an image callback.

--- a/agents/components/model_component.py
+++ b/agents/components/model_component.py
@@ -111,7 +111,7 @@ class ModelComponent(Component):
             },
         }
     )
-    def fallback_to_local(self) -> bool:
+    def fallback_to_local(self) -> str:
         """Switch from remote model_client to the built-in local model at runtime.
 
         The local model is deployed on first call (lazy initialization) to avoid
@@ -120,8 +120,9 @@ class ModelComponent(Component):
 
         This is commonly used as a target for Actions in the Event system.
 
-        :return: True if the switch was successful, False otherwise.
-        :rtype: bool
+        :return: A confirmation message describing the switch.
+        :rtype: str
+        :raises RuntimeError: If the local model could not be deployed.
 
         :Example:
 
@@ -146,8 +147,7 @@ class ModelComponent(Component):
         try:
             self._deploy_local_model()
         except Exception as e:
-            self.get_logger().error(f"Failed to deploy local model: {e}")
-            return False
+            raise RuntimeError(f"Failed to deploy local model: {e}") from e
 
         # Deinitialize remote client
         if self.model_client:
@@ -158,7 +158,7 @@ class ModelComponent(Component):
             self.model_client = None
 
         self.get_logger().info("Switched to local model for inference.")
-        return True
+        return f"Component '{self.node_name}' switched to local model for inference."
 
     @component_fallback(
         description={
@@ -179,7 +179,7 @@ class ModelComponent(Component):
             },
         }
     )
-    def change_model_client(self, model_client_name: str) -> bool:
+    def change_model_client(self, model_client_name: str) -> str:
         """
         Hot-swap the active model client at runtime.
 
@@ -191,8 +191,10 @@ class ModelComponent(Component):
 
         :param model_client_name: The key corresponding to the desired client in ``additional_model_clients``.
         :type model_client_name: str
-        :return: True if the swap was successful, False otherwise (e.g., if the name was not found or initialization failed).
-        :rtype: bool
+        :return: A confirmation message describing the swap.
+        :rtype: str
+        :raises RuntimeError: If no additional clients are registered, the
+            requested client name is not found, or initialization fails.
 
         :Example:
 
@@ -211,16 +213,16 @@ class ModelComponent(Component):
         ```
         """
         if not self._additional_model_clients:
-            self.get_logger().error(
-                "Cannot change model client as the component was not given any additional model clients at init."
+            raise RuntimeError(
+                "Cannot change model client as the component was not given any "
+                "additional model clients at init."
             )
-            return False
         new_client = self._additional_model_clients.get(model_client_name, None)
         if not new_client:
-            self.get_logger().info(
-                f"No additional client named {model_client_name} is available in the component. Only the following additional clients were provided {self._additional_model_clients}"
+            raise RuntimeError(
+                f"No additional client named '{model_client_name}' is available. "
+                f"Available clients: {list(self._additional_model_clients.keys())}"
             )
-            return False
 
         self.get_logger().info(f"Changing model client to {model_client_name}")
 
@@ -232,13 +234,15 @@ class ModelComponent(Component):
             # Set the new client
             self.model_client = new_client
             self.model_client.initialize()  # initialize the new client
-        except Exception:
-            self.get_logger().error(
-                "Error encountered during initialization when changing model client"
-            )
-            return False
+        except Exception as e:
+            raise RuntimeError(
+                f"Error initializing new model client '{model_client_name}': {e}"
+            ) from e
 
-        return True
+        return (
+            f"Component '{self.node_name}' switched to model client "
+            f"'{model_client_name}'."
+        )
 
     def inspect_component(self) -> str:
         """Return component info including additional model clients."""

--- a/agents/components/speechtotext.py
+++ b/agents/components/speechtotext.py
@@ -246,7 +246,7 @@ class SpeechToText(ModelComponent):
         """
         assert frames == self.config._block_size
         if status:
-            self.get_logger().warn(f"Status: {status}")
+            self.get_logger().warning(f"Status: {status}")
         try:
             import pyaudio
         except ModuleNotFoundError as e:

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -405,6 +405,10 @@ class Vision(ModelComponent):
         self.get_logger().info(
             f"Started recording video on topic '{topic_name}' for {duration} seconds."
         )
+        # NOTE: We do not wait to join the video recording thread, any failures
+        # will be silent. This can be changed when action execution
+        # infrastructure is in place to allow for monitoring and returning
+        # results from async actions.
 
         return (
             f"Started recording {duration}s video from '{topic_name}' at {fps} FPS. "

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -198,7 +198,7 @@ class Vision(ModelComponent):
         topic_name: str,
         save_path: str = "~/emos/pictures",
         timeout: float = 0.5,
-    ) -> bool:
+    ) -> str:
         """
         Take a picture from a specific input topic and save it to the specified location.
 
@@ -214,93 +214,87 @@ class Vision(ModelComponent):
         :param timeout: Timeout if an image is not available on the topic.
                           Defaults to 0.5 seconds.
         :type timeout: float
-        :return: True if successful, False otherwise.
-        :rtype: bool
-        :raises ValueError: If the provided topic_name is not found in inputs.
+        :return: The full path to the saved image file.
+        :rtype: str
+        :raises ValueError: If the topic is not one of the component inputs.
+        :raises TimeoutError: If no image was received within the timeout.
         """
-        try:
-            # Preflight check for timed components
-            if (
-                self.run_type == ComponentRunType.TIMED
-                and (loop_time := 1 / self.config.loop_rate) > timeout
-            ):
-                self.get_logger().warning(
-                    f"Warning: take_picture timeout ({timeout}s) is strictly shorter than the component's trigger period ({loop_time}s) for this timed component. "
-                    f"The action is highly likely to timeout before the image callback executes. Consider running the component faster or increasing the timeout for this action."
-                )
-            # Expand user path
-            save_path = os.path.expanduser(save_path)
-            os.makedirs(save_path, exist_ok=True)
-
-            # Identify callback type
-            trig_dict = getattr(self, "trig_callbacks", {})
-            target_callback = trig_dict.get(topic_name) or self.callbacks.get(
-                topic_name
+        # Preflight check for timed components
+        if (
+            self.run_type == ComponentRunType.TIMED
+            and (loop_time := 1 / self.config.loop_rate) > timeout
+        ):
+            self.get_logger().warning(
+                f"Warning: take_picture timeout ({timeout}s) is strictly shorter than the component's trigger period ({loop_time}s) for this timed component. "
+                f"The action is highly likely to timeout before the image callback executes. Consider running the component faster or increasing the timeout for this action."
             )
-            if not target_callback:
-                self.get_logger().error(
-                    f"Topic '{topic_name}' is not one of the component inputs. You can only take pictures on topics that are provided as inputs to this component."
-                )
-                return False
+        # Expand user path
+        save_path = os.path.expanduser(save_path)
+        os.makedirs(save_path, exist_ok=True)
 
-            # if target is a trigger, issue a warning
-            is_trigger = topic_name in trig_dict
-            if is_trigger:
-                self.get_logger().warning(
-                    f"Capturing image from trigger '{topic_name}'. Inference paused momentarily."
-                )
-            # save callback state
-            original_callback = target_callback._extra_callback
-            original_get_processed = target_callback._get_processed
+        # Identify callback type
+        trig_dict = getattr(self, "trig_callbacks", {})
+        target_callback = trig_dict.get(topic_name) or self.callbacks.get(topic_name)
+        if not target_callback:
+            raise ValueError(
+                f"Topic '{topic_name}' is not one of the component inputs. "
+                "You can only take pictures on topics that are provided as "
+                "inputs to this component."
+            )
 
-            # Define a single frame interceptor function
-            frames = []
+        # if target is a trigger, issue a warning
+        is_trigger = topic_name in trig_dict
+        if is_trigger:
+            self.get_logger().warning(
+                f"Capturing image from trigger '{topic_name}'. Inference paused momentarily."
+            )
+        # save callback state
+        original_callback = target_callback._extra_callback
+        original_get_processed = target_callback._get_processed
 
-            # extra callback for capturing image
-            def single_frame_interceptor(msg, topic, output=None):
-                if output is not None and not frames:
-                    frames.append(output.copy())
+        # Define a single frame interceptor function
+        frames = []
 
-            # Swap extracallback, wait and restore
-            try:
+        # extra callback for capturing image
+        def single_frame_interceptor(msg, topic, output=None):
+            if output is not None and not frames:
+                frames.append(output.copy())
+
+        # Swap extracallback, wait and restore
+        try:
+            target_callback.on_callback_execute(
+                single_frame_interceptor, get_processed=True
+            )
+
+            start_time = time.time()
+            while (time.time() - start_time) < timeout and not frames:
+                time.sleep(0.01)  # Check frequently
+
+        finally:
+            # Always restore the original callback state
+            if original_callback:
                 target_callback.on_callback_execute(
-                    single_frame_interceptor, get_processed=True
+                    original_callback, get_processed=original_get_processed
                 )
+            else:
+                target_callback._extra_callback = None
 
-                start_time = time.time()
-                while (time.time() - start_time) < timeout and not frames:
-                    time.sleep(0.01)  # Check frequently
+        if not frames:
+            raise TimeoutError(
+                f"Timeout: No image received on '{topic_name}' within {timeout}s."
+            )
 
-            finally:
-                # Always restore the original callback state
-                if original_callback:
-                    target_callback.on_callback_execute(
-                        original_callback, get_processed=original_get_processed
-                    )
-                else:
-                    target_callback._extra_callback = None
+        # Save Image
+        timestamp = int(time.time() * 1000)
+        filename = f"capture_{topic_name}_{timestamp}.jpg"
+        full_path = os.path.join(save_path, filename)
 
-            if not frames:
-                self.get_logger().warning(
-                    f"Timeout: No image received on '{topic_name}'."
-                )
-                return False
+        # Ensure BGR for OpenCV saving
+        save_img = cv2.cvtColor(frames[0], cv2.COLOR_RGB2BGR)
+        cv2.imwrite(full_path, save_img)
+        self.get_logger().info(f"Saved picture to {full_path}")
 
-            # Save Image
-            timestamp = int(time.time() * 1000)
-            filename = f"capture_{topic_name}_{timestamp}.jpg"
-            full_path = os.path.join(save_path, filename)
-
-            # Ensure BGR for OpenCV saving
-            save_img = cv2.cvtColor(frames[0], cv2.COLOR_RGB2BGR)
-            cv2.imwrite(full_path, save_img)
-            self.get_logger().info(f"Saved picture to {full_path}")
-
-            return True
-
-        except Exception as e:
-            self.get_logger().error(f"Failed to take picture: {e}")
-            return False
+        return f"Picture from '{topic_name}' saved to {full_path}"
 
     @component_action(
         description={
@@ -339,7 +333,7 @@ class Vision(ModelComponent):
         duration: float = 5.0,
         save_path: str = "~/emos/videos",
         fps: int = 30,
-    ) -> bool:
+    ) -> str:
         """
         Record a video from a specific input topic for a set duration.
 
@@ -355,70 +349,67 @@ class Vision(ModelComponent):
         :type save_path: str
         :param fps: The frames per second for the recording. Defaults to 20.
         :type fps: int
-        :return: True if the recording thread started successfully, False otherwise.
-        :rtype: bool
-        :raises ValueError: If the topic_name is not registered.
+        :return: A confirmation message describing the started recording.
+        :rtype: str
+        :raises ValueError: If the topic is not one of the component inputs.
         """
-        try:
-            # Preflight checks for timed components
-            if self.run_type == ComponentRunType.TIMED:
-                if self.config.loop_rate < fps:
-                    self.get_logger().warning(
-                        f"Warning: Requested {fps} FPS, but the component's trigger period is {1 / self.config.loop_rate}s "
-                        f"(~{self.config.loop_rate:.2f} FPS max). The recorded video will heavily repeat frames or play too fast. Consider running the component faster or reduce the fps"
-                    )
-
-                if duration < 1 / self.config.loop_rate:
-                    self.get_logger().warning(
-                        f"Warning: Recording duration ({duration}s) is shorter than the component's loop period "
-                        f"({1 / self.config.loop_rate}s). You are likely to capture 0 frames. Consider running the component faster or increase duration."
-                    )
-            # Expand user path
-            save_path = os.path.expanduser(save_path)
-            os.makedirs(save_path, exist_ok=True)
-
-            trig_dict = getattr(self, "trig_callbacks", {})
-            target_callback = trig_dict.get(topic_name) or self.callbacks.get(
-                topic_name
-            )
-            # Identify callback type
-            if not target_callback:
-                self.get_logger().error(
-                    f"Topic '{topic_name}' is not one of the component inputs. You can only record videos on topics that are provided as inputs to this component."
-                )
-                return False
-
-            # if target is a trigger, issue a warning
-            is_trigger = topic_name in trig_dict
-            if is_trigger:
+        # Preflight checks for timed components
+        if self.run_type == ComponentRunType.TIMED:
+            if self.config.loop_rate < fps:
                 self.get_logger().warning(
-                    f"Recording video on trigger topic '{topic_name}'. "
-                    f"Detection or tracking will be PAUSED for {duration} seconds!"
+                    f"Warning: Requested {fps} FPS, but the component's trigger period is {1 / self.config.loop_rate}s "
+                    f"(~{self.config.loop_rate:.2f} FPS max). The recorded video will heavily repeat frames or play too fast. Consider running the component faster or reduce the fps"
                 )
 
-            # Spawn the background thread
-            recording_thread = threading.Thread(
-                target=self._record_video_thread,
-                kwargs={
-                    "target_callback": target_callback,
-                    "topic_name": topic_name,
-                    "duration": duration,
-                    "save_path": save_path,
-                    "fps": fps,
-                    "is_trigger": is_trigger,
-                },
-                daemon=True,
-            )
-            recording_thread.start()
-            self.get_logger().info(
-                f"Started recording video on topic '{topic_name}' for {duration} seconds."
+            if duration < 1 / self.config.loop_rate:
+                self.get_logger().warning(
+                    f"Warning: Recording duration ({duration}s) is shorter than the component's loop period "
+                    f"({1 / self.config.loop_rate}s). You are likely to capture 0 frames. Consider running the component faster or increase duration."
+                )
+        # Expand user path
+        save_path = os.path.expanduser(save_path)
+        os.makedirs(save_path, exist_ok=True)
+
+        trig_dict = getattr(self, "trig_callbacks", {})
+        target_callback = trig_dict.get(topic_name) or self.callbacks.get(topic_name)
+        # Identify callback type
+        if not target_callback:
+            raise ValueError(
+                f"Topic '{topic_name}' is not one of the component inputs. "
+                "You can only record videos on topics that are provided as "
+                "inputs to this component."
             )
 
-            return True
+        # if target is a trigger, issue a warning
+        is_trigger = topic_name in trig_dict
+        if is_trigger:
+            self.get_logger().warning(
+                f"Recording video on trigger topic '{topic_name}'. "
+                f"Detection or tracking will be PAUSED for {duration} seconds!"
+            )
 
-        except Exception as e:
-            self.get_logger().error(f"Failed to start recording: {e}")
-            return False
+        # Spawn the background thread
+        recording_thread = threading.Thread(
+            target=self._record_video_thread,
+            kwargs={
+                "target_callback": target_callback,
+                "topic_name": topic_name,
+                "duration": duration,
+                "save_path": save_path,
+                "fps": fps,
+                "is_trigger": is_trigger,
+            },
+            daemon=True,
+        )
+        recording_thread.start()
+        self.get_logger().info(
+            f"Started recording video on topic '{topic_name}' for {duration} seconds."
+        )
+
+        return (
+            f"Started recording {duration}s video from '{topic_name}' at {fps} FPS. "
+            f"Video will be saved to {save_path}."
+        )
 
     @component_action(
         description={
@@ -446,7 +437,7 @@ class Vision(ModelComponent):
             },
         }
     )
-    def track(self, label: str) -> bool:
+    def track(self, label: str) -> str:
         """Start tracking objects matching the given label.
 
         Configures the remote model server to enable ByteTrack trackers
@@ -456,8 +447,10 @@ class Vision(ModelComponent):
 
         :param label: Object label to track (e.g. 'person', 'cup').
         :type label: str
-        :return: True if tracking was started successfully, False otherwise.
-        :rtype: bool
+        :return: A confirmation message describing the started tracking.
+        :rtype: str
+        :raises RuntimeError: If the component does not have a remote
+            RoboML model client or a Tracking output topic.
         """
         from ..clients.roboml import RoboMLHTTPClient, RoboMLRESPClient
 
@@ -465,42 +458,38 @@ class Vision(ModelComponent):
         if not self.model_client or not isinstance(
             self.model_client, (RoboMLHTTPClient, RoboMLRESPClient)
         ):
-            self.get_logger().error(
+            raise RuntimeError(
                 "Tracking requires a RoboML model client. "
                 "Local models do not support tracking."
             )
-            return False
 
         # must have a Tracking output topic
         has_tracking_output = any(
             t.msg_type in (Trackings, TrackingsMultiSource) for t in self.out_topics
         )
         if not has_tracking_output:
-            self.get_logger().error(
+            raise RuntimeError(
                 "Tracking requires at least one output topic of type "
                 "Trackings or TrackingsMultiSource."
             )
-            return False
 
-        try:
-            with self.safe_restart():
-                init_params = self.model_client.model_init_params
-                # Enable trackers on the model if not already set up
-                if not init_params.get("setup_trackers"):
-                    init_params["setup_trackers"] = True
-                init_params["num_trackers"] = len(self.in_topics)
+        with self.safe_restart():
+            init_params = self.model_client.model_init_params
+            # Enable trackers on the model if not already set up
+            if not init_params.get("setup_trackers"):
+                init_params["setup_trackers"] = True
+            init_params["num_trackers"] = len(self.in_topics)
 
-            self.get_logger().info("Trackers initialized on remote model server.")
+        self.get_logger().info("Trackers initialized on remote model server.")
 
-            # Set the label to track
-            self.config.labels_to_track = [label]
-            self.inference_params = self.config._get_inference_params()
-            self.get_logger().info(f"Now tracking: '{label}'")
-            return True
-
-        except Exception as e:
-            self.get_logger().error(f"Failed to start tracking: {e}")
-            return False
+        # Set the label to track
+        self.config.labels_to_track = [label]
+        self.inference_params = self.config._get_inference_params()
+        self.get_logger().info(f"Now tracking: '{label}'")
+        return (
+            f"Tracking started for label '{label}'. Tracking results are now "
+            "being published on the component's Tracking output topics."
+        )
 
     def _record_video_thread(
         self,

--- a/agents/config.py
+++ b/agents/config.py
@@ -16,6 +16,7 @@ __all__ = [
     "TextToSpeechConfig",
     "SemanticRouterConfig",
     "MapConfig",
+    "MemoryConfig",
     "VideoMessageMakerConfig",
     "VisionConfig",
 ]
@@ -853,6 +854,104 @@ class MapConfig(BaseComponentConfig):
     )
     _map_topic: Optional[Topic] = field(
         default=None, converter=_get_optional_topic, alias="_map_topic"
+    )
+
+
+@define(kw_only=True)
+class MemoryConfig(BaseComponentConfig):
+    """Configuration for the Memory component.
+
+    :param db_path: Path to the eMEM SQLite database file.
+    :type db_path: str
+    :param embedding_checkpoint: Model name for sentence-transformers fallback. Only used when no ``embedding_client`` is provided to the Memory component.
+    :type embedding_checkpoint: str
+    :param auto_store: Automatically store layer data on each execution step. If False, storage only happens via the ``store`` component action.
+    :type auto_store: bool
+    :param embedding_dim: Embedding vector dimension. Must match the dimension of the embedding model used by the embedding_client (e.g. 768 for ``nomic-embed-text``, 384 for ``all-MiniLM-L6-v2``). When using ``CallableEmbeddingProvider``, this is auto-detected.
+    :type embedding_dim: int
+    :param working_memory_size: Max observations held in the in-process buffer before the oldest are dropped. Observations are flushed to persistent storage well before this limit via ``flush_batch_size`` and ``flush_interval``.
+    :type working_memory_size: int
+    :param flush_interval: Seconds between auto-flushes of the working memory buffer to persistent storage. Lower values mean observations become searchable faster but increase write frequency.
+    :type flush_interval: float
+    :param flush_batch_size: Number of observations accumulated before an automatic flush is triggered, regardless of ``flush_interval``.
+    :type flush_batch_size: int
+    :param consolidation_window: Maximum temporal gap in seconds between consecutive observations within the same consolidation chunk. When an episode is consolidated, observations separated by more than this gap produce separate gist summaries. For example, 1800 (30 min) means a multi-session episode spanning days will get one gist per session, not one monolithic summary.
+    :type consolidation_window: float
+    :param consolidation_spatial_eps: DBSCAN epsilon in meters for spatial clustering during time-window consolidation. Observations farther apart than this are placed in separate clusters and produce separate gists. Only applies to non-episodic consolidation.
+    :type consolidation_spatial_eps: float
+    :param consolidation_min_samples: Minimum number of observations required to form a spatial cluster during time-window consolidation. Clusters smaller than this are left in short-term memory.
+    :type consolidation_min_samples: int
+    :param archive_after_seconds: How long (in seconds) observations remain in long-term memory (with full text preserved) before archival drops their text and embeddings, leaving only the gist searchable. Set higher to keep raw observations searchable longer at the cost of storage.
+    :type archive_after_seconds: float
+    :param entity_extract_flush_interval: Trigger entity extraction every N working-memory flushes.
+    :type entity_extract_flush_interval: int
+    :param entity_extract_time_interval: Trigger entity extraction every N seconds, whichever comes first with ``entity_extract_flush_interval``.
+    :type entity_extract_time_interval: float
+    :param entity_similarity_threshold: Cosine similarity threshold (0-1) for merging a newly detected entity with an existing one. Higher values require closer name matches before merging (e.g. 0.85 means "red chair" and "chair" may merge, but "chair" and "table" won't).
+    :type entity_similarity_threshold: float
+    :param entity_spatial_radius: Maximum distance in meters between an existing entity and a new detection for them to be considered the same object. Only entities within this radius AND above the similarity threshold are merged.
+    :type entity_spatial_radius: float
+    :param recency_weight: Alpha multiplier for recency-weighted semantic search. When > 0, recent observations are boosted over older ones at equal semantic distance. Set to 0.0 (default) for pure semantic ordering.
+    :type recency_weight: float
+    :param recency_halflife: Time constant in seconds for recency decay. An observation this many seconds old receives half the recency boost. Only effective when ``recency_weight`` > 0.
+    :type recency_halflife: float
+    :param hnsw_ef_construction: HNSW index build-time quality parameter. Higher values produce a better quality index but take longer to build. Default (200) is suitable for most use cases.
+    :type hnsw_ef_construction: int
+    :param hnsw_m: Number of bidirectional links per node in the HNSW graph. Higher values improve recall but increase memory usage. Default (16) is suitable for most use cases.
+    :type hnsw_m: int
+    :param hnsw_ef_search: HNSW search-time quality parameter. Higher values improve recall at the cost of query latency. Default (50) is suitable for most use cases.
+    :type hnsw_ef_search: int
+    :param hnsw_max_elements: Maximum number of vectors the HNSW index can hold. Should be set higher than the expected total number of observations + gists + entities over the system's lifetime.
+    :type hnsw_max_elements: int
+
+    Example of usage:
+    ```python
+    config = MemoryConfig(db_path="/tmp/robot_memory.db")
+    ```
+    """
+
+    # Memory component specific
+    db_path: str = field(default="memory.db")
+    embedding_checkpoint: str = field(default="all-MiniLM-L6-v2")
+    auto_store: bool = field(default=True)
+    # eMEM config parameters (mirrors emem.SpatioTemporalMemoryConfig)
+    embedding_dim: int = field(default=384, validator=base_validators.gt(0))
+    working_memory_size: int = field(default=50, validator=base_validators.gt(0))
+    flush_interval: float = field(default=2.0, validator=base_validators.gt(0.0))
+    flush_batch_size: int = field(default=5, validator=base_validators.gt(0))
+    consolidation_window: float = field(
+        default=1800.0, validator=base_validators.gt(0.0)
+    )
+    consolidation_spatial_eps: float = field(
+        default=3.0, validator=base_validators.gt(0.0)
+    )
+    consolidation_min_samples: int = field(default=3, validator=base_validators.gt(0))
+    archive_after_seconds: float = field(
+        default=3600.0, validator=base_validators.gt(0.0)
+    )
+    entity_extract_flush_interval: int = field(
+        default=10, validator=base_validators.gt(0)
+    )
+    entity_extract_time_interval: float = field(
+        default=60.0, validator=base_validators.gt(0.0)
+    )
+    entity_similarity_threshold: float = field(
+        default=0.85,
+        validator=base_validators.in_range(min_value=0.0, max_value=1.0),
+    )
+    entity_spatial_radius: float = field(default=5.0, validator=base_validators.gt(0.0))
+    recency_weight: float = field(
+        default=0.0,
+        validator=base_validators.in_range(min_value=0.0, max_value=1.0),
+    )
+    recency_halflife: float = field(default=3600.0, validator=base_validators.gt(0.0))
+    hnsw_ef_construction: int = field(default=200, validator=base_validators.gt(0))
+    hnsw_m: int = field(default=16, validator=base_validators.gt(0))
+    hnsw_ef_search: int = field(default=50, validator=base_validators.gt(0))
+    hnsw_max_elements: int = field(default=100_000, validator=base_validators.gt(0))
+    # internal - serialized topic
+    _position: Optional[Topic] = field(
+        default=None, converter=_get_optional_topic, alias="_position"
     )
 
 

--- a/agents/config.py
+++ b/agents/config.py
@@ -869,8 +869,6 @@ class MemoryConfig(BaseComponentConfig):
     :type embedding_checkpoint: str
     :param auto_store: Automatically store layer data on each execution step. If False, storage only happens via the ``store`` component action.
     :type auto_store: bool
-    :param embedding_dim: Embedding vector dimension. Must match the dimension of the embedding model used by the embedding_client (e.g. 768 for ``nomic-embed-text``, 384 for ``all-MiniLM-L6-v2``). When using ``CallableEmbeddingProvider``, this is auto-detected.
-    :type embedding_dim: int
     :param working_memory_size: Max observations held in the in-process buffer before the oldest are dropped. Observations are flushed to persistent storage well before this limit via ``flush_batch_size`` and ``flush_interval``.
     :type working_memory_size: int
     :param flush_interval: Seconds between auto-flushes of the working memory buffer to persistent storage. Lower values mean observations become searchable faster but increase write frequency.
@@ -917,7 +915,6 @@ class MemoryConfig(BaseComponentConfig):
     embedding_checkpoint: str = field(default="all-MiniLM-L6-v2")
     auto_store: bool = field(default=True)
     # eMEM config parameters (mirrors emem.SpatioTemporalMemoryConfig)
-    embedding_dim: int = field(default=384, validator=base_validators.gt(0))
     working_memory_size: int = field(default=50, validator=base_validators.gt(0))
     flush_interval: float = field(default=2.0, validator=base_validators.gt(0.0))
     flush_batch_size: int = field(default=5, validator=base_validators.gt(0))

--- a/agents/config.py
+++ b/agents/config.py
@@ -188,16 +188,18 @@ class CortexConfig(LLMConfig):
         execution plan. Plans with more steps are truncated. Default is 10.
     :type max_execution_steps: int
     :param confirmation_temperature: Temperature for the per-step confirmation LLM
-        calls. Lower values give more deterministic responses. Default is 0.2.
+        calls. Used for both the decision and resolving tool call arguments
+        from prior step results. Default is 0.3.
     :type confirmation_temperature: float
     :param confirmation_max_tokens: Maximum tokens for confirmation responses.
-        Kept low since only EXECUTE/SKIP/ABORT is expected. Default is 100.
+        Must be large enough to accommodate a tool call with resolved arguments
+        when the LLM returns EXECUTE. Default is 500.
     :type confirmation_max_tokens: int
     :param temperature: Temperature used for the planning LLM call.
         Default is 0.8 and must be greater than 0.0.
     :type temperature: float
     :param max_new_tokens: The maximum number of new tokens to generate during planning.
-        Default is 500 and must be greater than 0.
+        Default is 1000 (inherited from LLMConfig) and must be greater than 0.
     :type max_new_tokens: int
     :param enable_rag: Enable Retrieval Augmented Generation to provide context
         during planning. Requires a ``db_client`` to be passed to the Cortex component.
@@ -228,9 +230,9 @@ class CortexConfig(LLMConfig):
     max_planning_steps: int = field(default=10, validator=base_validators.gt(0))
     max_execution_steps: int = field(default=10, validator=base_validators.gt(0))
     confirmation_temperature: float = field(
-        default=0.2, validator=base_validators.gt(0.0)
+        default=0.3, validator=base_validators.gt(0.0)
     )
-    confirmation_max_tokens: int = field(default=1000, validator=base_validators.gt(0))
+    confirmation_max_tokens: int = field(default=500, validator=base_validators.gt(0))
     monitoring_interval: float = field(default=2.0, validator=base_validators.gt(0.0))
 
     def _get_inference_params(self) -> Dict:

--- a/agents/config.py
+++ b/agents/config.py
@@ -175,8 +175,11 @@ class CortexConfig(LLMConfig):
        this phase. Controlled by ``max_planning_steps``.
     2. **Execution** — Each planned step is executed sequentially. Before each
        step, a brief LLM confirmation call decides: EXECUTE, SKIP, or ABORT,
-       based on the original plan and results so far. Controlled by
-       ``max_execution_steps``.
+       based on the original plan and results so far. After a plan is fully
+       executed, Cortex feeds the results back to the planner and may produce
+       a follow-up plan, repeating the plan-execute loop until the planner
+       signals completion. Both the per-plan length and the number of
+       plan-execute iterations are capped by ``max_execution_steps``.
 
     The ``chat_history`` and ``stream`` fields are enforced by the component
     (``chat_history=True``, ``stream=False``) and cannot be overridden.
@@ -184,8 +187,13 @@ class CortexConfig(LLMConfig):
     :param max_planning_steps: Maximum number of LLM calls allowed during the
         planning phase (e.g. inspect_component calls). Default is 10.
     :type max_planning_steps: int
-    :param max_execution_steps: Maximum number of action steps allowed in the
-        execution plan. Plans with more steps are truncated. Default is 10.
+    :param max_execution_steps: Caps two things at once: (1) the maximum
+        number of action steps allowed in any single execution plan, plans
+        with more steps are truncated; and (2) the maximum number of
+        plan-execute iterations Cortex will run before giving up if the
+        planner never signals completion. The worst-case total number of
+        actions executed for one task is therefore ``max_execution_steps²``.
+        Default is 10.
     :type max_execution_steps: int
     :param confirmation_temperature: Temperature for the per-step confirmation LLM
         calls. Used for both the decision and resolving tool call arguments

--- a/agents/launcher.py
+++ b/agents/launcher.py
@@ -71,7 +71,8 @@ class Launcher(BaseLauncher):
                 cortex_monitor = component
                 break
         if cortex_monitor:
-            # remove the Cortex component from the lists of components to monitor, as it will be the monitor itself
+            # remove the Cortex component from the lists of components to monitor,
+            # as it will be the monitor itself
             self._components.remove(cortex_monitor)
             components_names.remove(cortex_monitor.node_name)
             if cortex_monitor in services_components:
@@ -80,6 +81,8 @@ class Launcher(BaseLauncher):
                 action_components.remove(cortex_monitor)
             if cortex_monitor.node_name in all_components_to_activate_on_start:
                 all_components_to_activate_on_start.remove(cortex_monitor.node_name)
+
+            # set cortex as the monitor node now
             self.monitor_node = cortex_monitor
             self.monitor_node._init_internal_monitor(
                 components_names=components_names,

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -103,6 +103,7 @@ __all__ = [
     "ComponentRunType",
     "Launcher",
     "Monitor",
+    "MemLayer",
     "MapLayer",
     "Route",
     "MutuallyExclusiveCallbackGroup",
@@ -831,21 +832,32 @@ def _get_np_coordinates(
 
 
 @define(kw_only=True)
-class MapLayer(BaseAttrs):
-    """A MapLayer represents a single input for a MapEncoding component. It can subscribe to a specific text topic.
+class MemLayer(BaseAttrs):
+    """A MemLayer represents a single input layer for a ``Memory`` or
+    ``MapEncoding`` component. It subscribes to a topic whose callback
+    produces a string representation (via ``_get_ui_content``) that can be
+    stored as an observation.
 
-    :param subscribes_to: The topic that this map layer is subscribed to.
+    :param subscribes_to: The topic that this layer is subscribed to.
     :type subscribes_to: Topic
-    :param temporal_change: Indicates whether the map should store changes over time for the same position. Defaults to False.
+    :param temporal_change: Indicates whether the map should store changes over time for the same position. Defaults to False. (``MapEncoding`` only.)
     :type temporal_change: bool
-    :param resolution_multiple: A positive multiplication factor for the base resolution of the map grid, for fine or coarse graining the map. Defaults to 1.
+    :param resolution_multiple: A positive multiplication factor for the base resolution of the map grid, for fine or coarse graining the map. Defaults to 1. (``MapEncoding`` only.)
     :type resolution_multiple: int
     :param pre_defined: An optional list of pre-defined data points in the layer. Each datapoint is a tuple of [position, text], where position is a numpy array of coordinates.
     :type pre_defined: list[tuple[np.ndarray, str]]
+    :param is_internal_state: If True, observations from this layer are
+        treated as internal state (interoception) by ``Memory``: they are
+        written via ``add_body_state`` and are retrieved through the
+        ``body_status`` tool rather than the perception tools. Use this
+        for robot-internal signals like battery, temperature, or joint
+        health. Defaults to False. (``Memory`` only.)
+    :type is_internal_state: bool
 
     Example of usage:
     ```python
-    my_map_layer = MapLayer(subscribes_to='my_topic', temporal_change=True)
+    my_layer = MemLayer(subscribes_to='my_topic', temporal_change=True)
+    battery_layer = MemLayer(subscribes_to='battery_state', is_internal_state=True)
     ```
     """
 
@@ -857,6 +869,11 @@ class MapLayer(BaseAttrs):
     pre_defined: List[Union[List, Tuple[np.ndarray, str]]] = field(
         default=Factory(list), converter=_get_np_coordinates
     )
+    is_internal_state: bool = field(default=False)
+
+
+# Backwards-compatible alias
+MapLayer = MemLayer
 
 
 @define(kw_only=True)

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -7,7 +7,6 @@ from importlib.util import find_spec
 from rclpy.logging import get_logger
 
 from sensor_msgs.msg import JointState as JointStateROS
-from lifecycle_msgs.msg import State as LifecycleStateMsg
 
 # FROM SUGARCOAT
 from ros_sugar.supported_types import (
@@ -117,7 +116,6 @@ __all__ = [
     "ActionClientHandler",
     "get_ros_msg_fields_dict",
     "ros_msg_to_str",
-    "LifecycleStateMsg",
     "get_methods_with_decorator",
 ]
 

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -1,6 +1,7 @@
 """The following classes provide wrappers for data being transmitted via ROS topics. These classes form the inputs and outputs of [Components](agents.components.md)."""
 
-from typing import Union, Any, Dict, List, Tuple, Optional
+from enum import Enum
+from typing import Callable, Union, Any, Dict, List, Optional, Tuple
 import numpy as np
 from attrs import define, field, Factory
 from importlib.util import find_spec
@@ -35,7 +36,7 @@ from ros_sugar.core import BaseComponent, Monitor
 from ros_sugar.core.component import MutuallyExclusiveCallbackGroup
 from ros_sugar import UI_EXTENSIONS
 from ros_sugar.utils import (
-    component_action,
+    component_action as _sugar_component_action,
     component_fallback,
     get_methods_with_decorator,
 )
@@ -117,7 +118,82 @@ __all__ = [
     "get_ros_msg_fields_dict",
     "ros_msg_to_str",
     "get_methods_with_decorator",
+    "ActionPhase",
 ]
+
+
+# =========================================================================
+# Sugarcoat Overrides
+# =========================================================================
+
+
+class ActionPhase(str, Enum):
+    """Cognitive phase in which a component action should be exposed.
+
+    Read by Cortex when discovering tools on managed components.
+
+    - ``PLANNING``: tool is only registered with the planner. Use for
+      research / introspection tools that the planner calls while
+      building a plan but that the executor has no reason to invoke.
+    - ``EXECUTION``: tool is only registered with the executor. This is
+      the default and matches the historical behavior of bare
+      ``@component_action``. Use for state-changing actions (``say``,
+      ``store_specific_memory``, ``start_episode``, ...).
+    - ``BOTH``: tool is registered with both. Use for retrieval tools
+      that the planner benefits from calling before emitting a plan
+      (e.g. ``describe``, ``locate``) and that the executor may
+      also need at run time.
+    """
+
+    PLANNING = "planning"
+    EXECUTION = "execution"
+    BOTH = "both"
+
+
+def component_action(
+    function: Optional[Callable] = None,
+    *,
+    description: Optional[Dict] = None,
+    active: bool = False,
+    phase: Union[ActionPhase, str] = ActionPhase.EXECUTION,
+):
+    """Wrapper around sugarcoat's ``component_action`` decorator.
+
+    Delegates to ``ros_sugar.utils.component_action`` for the core
+    behavior and additionally tags the method with ``_action_phase``
+    — a hint to Cortex about whether the tool is a planning tool,
+    an execution tool, or both.
+
+    Can be used the same way as sugarcoat's decorator:
+
+        @component_action(description={...}, phase=ActionPhase.BOTH)
+        def c(self) -> str: ...
+
+    If ``phase`` is not specified the action defaults to
+    ``ActionPhase.EXECUTION``, preserving the previous behavior.
+
+    :param function: The method being decorated (set when the decorator
+        is used without parentheses).
+    :param description: OpenAI-format tool description dict, forwarded
+        verbatim to sugarcoat.
+    :param active: If True, sugarcoat will reject calls while the
+        component is not in the active lifecycle state.
+    :param phase: Cognitive phase. Defaults to
+        :attr:`ActionPhase.EXECUTION`.
+    """
+    phase_value = phase.value if isinstance(phase, ActionPhase) else str(phase)
+
+    def _wrap(func: Callable) -> Callable:
+        wrapped = _sugar_component_action(
+            function=func, description=description, active=active
+        )
+        wrapped._action_phase = phase_value
+        return wrapped
+
+    if function is not None:
+        return _wrap(function)
+    return _wrap
+
 
 # =========================================================================
 # Additional Datatypes (Augment Sugarcoat datatypes)

--- a/examples/complete_agent_multiprocessing.py
+++ b/examples/complete_agent_multiprocessing.py
@@ -17,7 +17,7 @@ from agents.clients import OllamaClient
 from agents.models import Whisper, TransformersTTS, VisionModel, OllamaModel
 from agents.vectordbs import ChromaDB
 from agents.config import VisionConfig, LLMConfig, MapConfig, SemanticRouterConfig
-from agents.ros import Topic, FixedInput, MapLayer, Route, Launcher
+from agents.ros import Topic, FixedInput, MapLayer, Route, Launcher, Action
 
 
 ### Setup our models and vectordb ###
@@ -250,26 +250,36 @@ router = SemanticRouter(
     component_name="router",
 )
 
+# Per-component fallback strategies.
+all_components = [
+    mllm,
+    llm,
+    goto,
+    introspector,
+    map,
+    router,
+    speech_to_text,
+    text_to_speech,
+    vision,
+]
+for component in all_components:
+    component.on_fail(  # on any failure
+        action=Action(component.restart),
+        max_retries=2,
+    )
+    component.fallback_rate = 1 / 10  # 0.1 Hz -- check for failures every 10s
+
 # Launch the components
 launcher = Launcher()
 launcher.enable_ui(
     inputs=[query_topic, audio_in], outputs=[detections_topic, query_answer, goal_point]
 )
 launcher.add_pkg(
-    components=[
-        mllm,
-        llm,
-        goto,
-        introspector,
-        map,
-        router,
-        speech_to_text,
-        text_to_speech,
-        vision,
-    ],
+    components=all_components,
     package_name="automatika_embodied_agents",
     multiprocessing=True,
 )
-launcher.on_process_fail()
-launcher.fallback_rate = 1 / 10  # 0.1 Hz or 10 seconds
+# Process-level crash recovery: respawn any multi-process component whose
+# process exits unexpectedly, up to ``max_retries`` times.
+launcher.on_process_fail(max_retries=3)
 launcher.bringup()

--- a/examples/complete_agent_multiprocessing.py
+++ b/examples/complete_agent_multiprocessing.py
@@ -270,6 +270,6 @@ launcher.add_pkg(
     package_name="automatika_embodied_agents",
     multiprocessing=True,
 )
-launcher.on_fail(action_name="restart")
+launcher.on_process_fail()
 launcher.fallback_rate = 1 / 10  # 0.1 Hz or 10 seconds
 launcher.bringup()

--- a/examples/memory_with_cortex.py
+++ b/examples/memory_with_cortex.py
@@ -1,0 +1,158 @@
+"""Spatio-temporal memory wired into a Cortex planner.
+
+This example showcases the use of the Memory component with Cortex. Memory
+exposes two distinct retrieval surfaces:
+
+- **Perception** (scene descriptions, detections) — retrieved via semantic,
+  spatial, temporal, and episodic queries.
+- **Interoception** (internal body state such as battery level) — layers
+  marked ``is_internal_state=True``, retreived via body state tool.
+
+Cortex auto-discovers both and can proactively check body state before
+acting.
+
+Send Cortex a natural-language goal like:
+
+    # Perception queries
+    "Where did you last see the fridge?"
+    "Summarize what happened in the last 10 minutes."
+    "What is currently around you?"
+
+    # Body / interoception queries
+    "What is your current battery level?"
+    "How are you feeling?"
+
+Usage:
+    python3 examples/memory_with_cortex.py
+
+    # Open localhost:5001 in the browser and send a goal through the UI.
+
+    # This example includes a ``battery_layer`` subscribed to /battery_level.
+    # If no real battery publisher exists, fake one from another terminal:
+    #
+    #     ros2 topic pub /battery_level std_msgs/msg/Float32 "{data: 42.0}"
+    #
+    # (use ``-r 1`` to publish at 1 Hz, or re-run with a different value to
+    # simulate battery drain)
+
+Requirements:
+    - Ollama running locally with:
+        - a VLM (e.g. ``gemma4:latest``)
+        - a planner LLM (e.g. the same ``gemma4:latest``)
+        - an embedding model (e.g. ``nomic-embed-text-v2-moe:latest``)
+    - ``emem`` installed in the Python env the launcher uses
+"""
+
+from agents.clients import OllamaClient
+from agents.components import Cortex, Memory, VLM, TextToSpeech, Vision
+from agents.config import (
+    CortexConfig,
+    MemoryConfig,
+    TextToSpeechConfig,
+    VisionConfig,
+)
+from agents.models import OllamaModel
+from agents.ros import FixedInput, Launcher, MemLayer, Topic
+
+
+# -- Shared perception topics --
+image_in = Topic(name="/image_raw", msg_type="Image")
+position = Topic(name="/odom", msg_type="Odometry")
+
+
+# -- Vision component: object detection --
+detections_out = Topic(name="detections", msg_type="Detections")
+
+vision = Vision(
+    inputs=[image_in],
+    outputs=[detections_out],
+    config=VisionConfig(threshold=0.5, enable_local_classifier=True),
+    trigger=1.0,
+    component_name="vision",
+)
+
+
+# -- VLM component: scene captioning --
+# Output goes into memory as the 'scene_description' layer AND into TTS
+# as spoken feedback (same topic, two subscribers).
+scene_query = FixedInput(
+    name="scene_query",
+    msg_type="String",
+    fixed=(
+        "Describe the scene in one concise sentence. Focus on the room type, "
+        "notable objects, and any people present."
+    ),
+)
+scene_description = Topic(name="scene_description", msg_type="String")
+
+vlm_model = OllamaModel(name="gemma4", checkpoint="gemma4:latest")
+vlm_client = OllamaClient(vlm_model)
+
+captioner = VLM(
+    inputs=[scene_query, image_in],
+    outputs=[scene_description],
+    model_client=vlm_client,
+    trigger=10.0,
+    component_name="captioner",
+)
+
+
+# -- Memory component --
+embedding_model = OllamaModel(
+    name="embeddings", checkpoint="nomic-embed-text-v2-moe:latest"
+)
+embedding_client = OllamaClient(embedding_model)
+
+detections_layer = MemLayer(subscribes_to=detections_out, temporal_change=True)
+scene_layer = MemLayer(subscribes_to=scene_description)
+
+# Add an interoception layer
+battery_layer = MemLayer(
+    subscribes_to=Topic(name="/battery_level", msg_type="Float32"),
+    is_internal_state=True,
+)
+
+memory = Memory(
+    layers=[detections_layer, scene_layer, battery_layer],
+    position=position,
+    model_client=vlm_client,
+    embedding_client=embedding_client,
+    config=MemoryConfig(
+        db_path="/tmp/memory_with_cortex.db",
+        consolidation_window=300.0,
+        archive_after_seconds=1800.0,
+    ),
+    trigger=10.0,
+    component_name="memory",
+)
+
+
+# -- Text-to-Speech: speak Cortex's final responses --
+tts_in = Topic(name="cortex_output", msg_type="StreamingString")
+tts = TextToSpeech(
+    inputs=[tts_in],
+    config=TextToSpeechConfig(enable_local_model=True, play_on_device=True),
+    trigger=tts_in,
+    component_name="tts",
+)
+
+
+# -- Cortex --
+cortex = Cortex(
+    output=tts_in,  # Cortex streams its replies to the TTS input
+    model_client=vlm_client,
+    config=CortexConfig(max_execution_steps=10),
+    component_name="cortex",
+)
+
+
+# -- Launch --
+launcher = Launcher()
+launcher.enable_ui(inputs=[cortex.ui_main_action_input], outputs=[tts_in])
+launcher.add_pkg(
+    components=[vision, captioner, memory, tts, cortex],
+    multiprocessing=True,
+    package_name="automatika_embodied_agents",
+)
+launcher.on_process_fail()
+launcher.bringup()

--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 86.5%</title>
+    <title>interrogate: 87.0%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">86.5%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">86.5%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">87.0%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">87.0%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 87.1%</title>
+    <title>interrogate: 87.2%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">87.1%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">87.1%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">87.2%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">87.2%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 87.2%</title>
+    <title>interrogate: 87.0%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">87.2%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">87.2%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">87.0%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">87.0%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 87.0%</title>
+    <title>interrogate: 87.1%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">87.0%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">87.0%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">87.1%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">87.1%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 87.1%</title>
+    <title>interrogate: 87.0%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">87.1%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">87.1%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">87.0%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">87.0%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/scripts/executable
+++ b/scripts/executable
@@ -26,6 +26,7 @@ from agents.ros import (
 # Python3.8 compatible NoneType
 NoneType = type(None)
 
+
 def _parse_args() -> Tuple[argparse.Namespace, List[str]]:
     """Parse arguments."""
     parser = argparse.ArgumentParser(description="Component Executable Config")
@@ -73,6 +74,11 @@ def _parse_args() -> Tuple[argparse.Namespace, List[str]]:
         "--db_client",
         type=str,
         help="DB Client",
+    )
+    parser.add_argument(
+        "--embedding_client",
+        type=str,
+        help="Embedding Client for Memory Component",
     )
     parser.add_argument(
         "--additional_model_clients",
@@ -379,6 +385,26 @@ def main():
             position=config._position,
             map_topic=config._map_topic,
             db_client=db_client,
+            config=config,
+            trigger=trigger,
+            component_name=component_name,
+            config_file=config_file,
+        )
+
+    elif component_type == all_components.Memory.__name__:
+        embedding_client_json = json.loads(args.embedding_client)
+        embedding_client = (
+            getattr(clients, embedding_client_json["client_type"])(
+                **embedding_client_json
+            )
+            if embedding_client_json
+            else None
+        )
+        component = comp_class(
+            layers=layers,
+            position=config._position,
+            model_client=model_client,
+            embedding_client=embedding_client,
             config=config,
             trigger=trigger,
             component_name=component_name,

--- a/tests/test_cortex.py
+++ b/tests/test_cortex.py
@@ -17,6 +17,25 @@ def _make_mock_action(name="test_action", description="A test action"):
     return action
 
 
+def _make_cortex(actions, mock_model_client, component_name, **cortex_kwargs):
+    """Construct a Cortex and run the action-registration step that the
+    Launcher normally triggers through ``_init_internal_monitor``.
+    Tests that assert on ``_execution_tools`` /
+    ``_execution_tool_descriptions`` need this because registration was
+    deliberately moved out of ``__init__`` so that Monitor init cannot
+    overwrite the registry (see commit 8d7eb95)."""
+    comp = Cortex(
+        outputs=[Topic(name="out", msg_type="String")],
+        actions=actions,
+        model_client=mock_model_client,
+        config=cortex_kwargs.pop("config", CortexConfig()),
+        component_name=component_name,
+        **cortex_kwargs,
+    )
+    comp._setup_internal_action_events(comp._behavioral_actions)
+    return comp
+
+
 class TestCortexConstruction:
     def test_with_model_client(self, rclpy_init, mock_model_client):
         comp = Cortex(
@@ -104,11 +123,9 @@ class TestCortexConstruction:
 class TestCortexActions:
     def test_action_registers_tool_description(self, rclpy_init, mock_model_client):
         action = _make_mock_action(name="navigate", description="Go somewhere")
-        comp = Cortex(
-            outputs=[Topic(name="out", msg_type="String")],
+        comp = _make_cortex(
             actions=[action],
-            model_client=mock_model_client,
-            config=CortexConfig(),
+            mock_model_client=mock_model_client,
             component_name="test_cortex_tools",
         )
 
@@ -119,11 +136,9 @@ class TestCortexActions:
 
     def test_action_registers_in_execution_tools(self, rclpy_init, mock_model_client):
         action = _make_mock_action(name="grasp", description="Grasp object")
-        comp = Cortex(
-            outputs=[Topic(name="out", msg_type="String")],
+        comp = _make_cortex(
             actions=[action],
-            model_client=mock_model_client,
-            config=CortexConfig(),
+            mock_model_client=mock_model_client,
             component_name="test_cortex_events",
         )
 
@@ -135,11 +150,9 @@ class TestCortexActions:
             _make_mock_action(name="grasp", description="Grasp object"),
             _make_mock_action(name="release", description="Release object"),
         ]
-        comp = Cortex(
-            outputs=[Topic(name="out", msg_type="String")],
+        comp = _make_cortex(
             actions=actions,
-            model_client=mock_model_client,
-            config=CortexConfig(),
+            mock_model_client=mock_model_client,
             component_name="test_cortex_multi",
         )
 

--- a/tests/test_cortex.py
+++ b/tests/test_cortex.py
@@ -184,7 +184,7 @@ class TestCortexPlanning:
         )
         mock_component_internals(comp)
 
-        plan = comp._plan_task("fetch a cup")
+        plan, _ = comp._plan_task("fetch a cup")
         assert plan is not None
         assert len(plan) == 2
         assert plan[0]["function"]["name"] == "navigate"
@@ -195,7 +195,6 @@ class TestCortexPlanning:
             "output": "I don't need to do anything.",
         }
         comp = Cortex(
-            outputs=[Topic(name="out", msg_type="String")],
             actions=[_make_mock_action()],
             model_client=mock_model_client,
             config=CortexConfig(),
@@ -203,7 +202,7 @@ class TestCortexPlanning:
         )
         mock_component_internals(comp)
 
-        plan = comp._plan_task("just say hello")
+        plan, _ = comp._plan_task("just say hello")
         assert plan is None
         assert comp._planning_output == "I don't need to do anything."
 
@@ -215,7 +214,6 @@ class TestCortexPlanning:
             ],
         }
         comp = Cortex(
-            outputs=[Topic(name="out", msg_type="String")],
             actions=[_make_mock_action()],
             model_client=mock_model_client,
             config=CortexConfig(max_execution_steps=5),
@@ -223,7 +221,7 @@ class TestCortexPlanning:
         )
         mock_component_internals(comp)
 
-        plan = comp._plan_task("big task")
+        plan, _ = comp._plan_task("big task")
         assert len(plan) == 5
 
     def test_plan_with_inspect_then_execute(self, rclpy_init, mock_model_client):
@@ -250,7 +248,6 @@ class TestCortexPlanning:
             },
         ]
         comp = Cortex(
-            outputs=[Topic(name="out", msg_type="String")],
             actions=[
                 _make_mock_action(name="navigate", description="Go"),
             ],
@@ -259,20 +256,17 @@ class TestCortexPlanning:
             component_name="test_cortex_plan_loop",
         )
         mock_component_internals(comp)
-        # Add inspect_component as a planning tool (normally done during activation)
         comp._planning_tools.add("inspect_component")
         comp._managed_components = {}
 
-        plan = comp._plan_task("find an object")
+        plan, _ = comp._plan_task("find an object")
         assert plan is not None
         assert len(plan) == 1
         assert plan[0]["function"]["name"] == "navigate"
-        # LLM was called twice (one inspect, one action)
         assert mock_model_client.inference.call_count == 2
 
     def test_plan_exhausts_max_planning_steps(self, rclpy_init, mock_model_client):
         """Planning loop exits when max_planning_steps is reached."""
-        # LLM always calls inspect_component, never produces action tools
         mock_model_client.inference.return_value = {
             "output": "Still researching...",
             "tool_calls": [
@@ -285,7 +279,6 @@ class TestCortexPlanning:
             ],
         }
         comp = Cortex(
-            outputs=[Topic(name="out", msg_type="String")],
             actions=[_make_mock_action()],
             model_client=mock_model_client,
             config=CortexConfig(max_planning_steps=3),
@@ -295,7 +288,7 @@ class TestCortexPlanning:
         comp._planning_tools.add("inspect_component")
         comp._managed_components = {}
 
-        plan = comp._plan_task("complex task")
+        plan, _ = comp._plan_task("complex task")
         assert plan is None
         assert mock_model_client.inference.call_count == 3
 
@@ -313,8 +306,9 @@ class TestCortexConfirmation:
         mock_component_internals(comp)
 
         plan = [{"function": {"name": "navigate", "arguments": {}}}]
-        decision = comp._confirm_step(plan, [], 0)
+        decision, resolved = comp._confirm_step(plan, [], 0)
         assert decision == "EXECUTE"
+        assert resolved is None
 
     def test_confirm_skip(self, rclpy_init, mock_model_client):
         mock_model_client.inference.return_value = {"output": "SKIP: already done"}
@@ -328,8 +322,9 @@ class TestCortexConfirmation:
         mock_component_internals(comp)
 
         plan = [{"function": {"name": "navigate", "arguments": {}}}]
-        decision = comp._confirm_step(plan, [], 0)
+        decision, resolved = comp._confirm_step(plan, [], 0)
         assert decision == "SKIP"
+        assert resolved is None
 
     def test_confirm_abort(self, rclpy_init, mock_model_client):
         mock_model_client.inference.return_value = {"output": "ABORT: unsafe condition"}
@@ -343,8 +338,9 @@ class TestCortexConfirmation:
         mock_component_internals(comp)
 
         plan = [{"function": {"name": "navigate", "arguments": {}}}]
-        decision = comp._confirm_step(plan, [], 0)
+        decision, resolved = comp._confirm_step(plan, [], 0)
         assert decision == "ABORT"
+        assert resolved is None
 
     def test_confirm_defaults_to_execute(self, rclpy_init, mock_model_client):
         mock_model_client.inference.return_value = {"output": "Sure, go ahead!"}
@@ -358,8 +354,35 @@ class TestCortexConfirmation:
         mock_component_internals(comp)
 
         plan = [{"function": {"name": "navigate", "arguments": {}}}]
-        decision = comp._confirm_step(plan, [], 0)
+        decision, _ = comp._confirm_step(plan, [], 0)
         assert decision == "EXECUTE"
+
+    def test_confirm_execute_with_resolved_args(self, rclpy_init, mock_model_client):
+        """When the LLM returns EXECUTE with a tool call, the resolved step is returned."""
+        mock_model_client.inference.return_value = {
+            "output": "EXECUTE",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "tts.say",
+                        "arguments": {"text": "A red cup on the table"},
+                    }
+                },
+            ],
+        }
+        comp = Cortex(
+            actions=[_make_mock_action()],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_confirm_resolved",
+        )
+        mock_component_internals(comp)
+
+        plan = [{"function": {"name": "tts.say", "arguments": {"text": "placeholder"}}}]
+        decision, resolved = comp._confirm_step(plan, [], 0)
+        assert decision == "EXECUTE"
+        assert resolved is not None
+        assert resolved["function"]["arguments"]["text"] == "A red cup on the table"
 
 
 class TestNoLLMMethods:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,425 @@
+"""Tests for the Memory component — requires rclpy and the ``emem`` package.
+
+These tests exercise the Memory component's construction, layer routing,
+and write path without standing up a real eMEM backend: the
+``SpatioTemporalMemory`` instance on the component is replaced with a
+``MagicMock`` so we can assert exactly how observations get dispatched
+between ``add`` (perception) and ``add_body_state`` (internal state).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agents.config import MemoryConfig
+from agents.ros import MemLayer, MapLayer, Topic
+from agents.components.memory import Memory
+
+
+def _prep_for_inspect(component):
+    """Minimal patching so ``inspect_component`` can run on a component
+    that has not gone through the full ROS lifecycle. Memory doesn't
+    have an inference_params path, so we don't reuse the shared helper
+    in conftest (which assumes LLM components)."""
+    component.get_logger = MagicMock()
+    component.health_status = MagicMock()
+    return component
+
+
+@pytest.fixture
+def odom_topic():
+    return Topic(name="odom", msg_type="Odometry")
+
+
+@pytest.fixture
+def detections_topic():
+    return Topic(name="detections", msg_type="String")
+
+
+@pytest.fixture
+def scene_topic():
+    return Topic(name="scene", msg_type="String")
+
+
+@pytest.fixture
+def battery_topic():
+    return Topic(name="battery", msg_type="String")
+
+
+@pytest.fixture
+def cpu_temp_topic():
+    return Topic(name="cpu_temp", msg_type="String")
+
+
+def _build_memory(layers, position, component_name, tmp_path):
+    """Construct a Memory component with a temp db path."""
+    return Memory(
+        layers=layers,
+        position=position,
+        config=MemoryConfig(db_path=str(tmp_path / f"{component_name}.db")),
+        component_name=component_name,
+    )
+
+
+def _stub_memory_backend(component):
+    """Replace component.memory with a MagicMock so we can assert calls."""
+    component.memory = MagicMock()
+    return component.memory
+
+
+def _stub_callback(component, topic_name, value):
+    """Replace a callback with a MagicMock whose ``get_output`` returns ``value``.
+
+    ``_get_ui_content`` is also stubbed so we can assert the component
+    does NOT call it (the current design uses ``get_output`` only).
+    """
+    cb = MagicMock()
+    cb.get_output = MagicMock(return_value=value)
+    cb._get_ui_content = MagicMock(return_value=value)
+    component.callbacks[topic_name] = cb
+    return cb
+
+
+class TestMemLayerAlias:
+    def test_map_layer_is_mem_layer(self):
+        assert MapLayer is MemLayer
+
+    def test_is_internal_state_defaults_false(self, detections_topic):
+        layer = MemLayer(subscribes_to=detections_topic)
+        assert layer.is_internal_state is False
+
+    def test_is_internal_state_can_be_set(self, battery_topic):
+        layer = MemLayer(subscribes_to=battery_topic, is_internal_state=True)
+        assert layer.is_internal_state is True
+
+    def test_is_internal_state_roundtrips_through_json(self, battery_topic):
+        import json
+
+        layer = MemLayer(subscribes_to=battery_topic, is_internal_state=True)
+        data = json.loads(layer.to_json())
+        assert data["is_internal_state"] is True
+        rehydrated = MapLayer(**data)
+        assert rehydrated.is_internal_state is True
+
+
+class TestMemoryConstruction:
+    def test_construct_with_perception_layer(
+        self, rclpy_init, odom_topic, detections_topic, tmp_path
+    ):
+        layer = MemLayer(subscribes_to=detections_topic)
+        comp = _build_memory([layer], odom_topic, "mem_perception", tmp_path)
+        assert "detections" in comp.layers_dict
+        assert comp.layers_dict["detections"].is_internal_state is False
+
+    def test_construct_with_internal_state_layer(
+        self, rclpy_init, odom_topic, battery_topic, tmp_path
+    ):
+        layer = MemLayer(subscribes_to=battery_topic, is_internal_state=True)
+        comp = _build_memory([layer], odom_topic, "mem_internal", tmp_path)
+        assert comp.layers_dict["battery"].is_internal_state is True
+
+    def test_construct_with_mixed_layers(
+        self,
+        rclpy_init,
+        odom_topic,
+        detections_topic,
+        battery_topic,
+        tmp_path,
+    ):
+        layers = [
+            MemLayer(subscribes_to=detections_topic),
+            MemLayer(subscribes_to=battery_topic, is_internal_state=True),
+        ]
+        comp = _build_memory(layers, odom_topic, "mem_mixed", tmp_path)
+        assert set(comp.layers_dict.keys()) == {"detections", "battery"}
+        assert comp.layers_dict["detections"].is_internal_state is False
+        assert comp.layers_dict["battery"].is_internal_state is True
+
+    def test_callbacks_created_for_layers_and_position(
+        self,
+        rclpy_init,
+        odom_topic,
+        detections_topic,
+        battery_topic,
+        tmp_path,
+    ):
+        layers = [
+            MemLayer(subscribes_to=detections_topic),
+            MemLayer(subscribes_to=battery_topic, is_internal_state=True),
+        ]
+        comp = _build_memory(layers, odom_topic, "mem_cb", tmp_path)
+        assert set(comp.callbacks.keys()) == {"detections", "battery", "odom"}
+
+    def test_perception_layer_with_disallowed_type_raises(
+        self, rclpy_init, odom_topic, tmp_path
+    ):
+        """A perception-layer topic whose msg_type is outside the allowed
+        set (e.g. Image) must be rejected at configuration time so mis-wired
+        topics fail loudly instead of silently blowing up in the embedder."""
+        image_topic = Topic(name="camera", msg_type="Image")
+        with pytest.raises(TypeError):
+            _build_memory(
+                [MemLayer(subscribes_to=image_topic)],
+                odom_topic,
+                "mem_bad_type",
+                tmp_path,
+            )
+
+    def test_internal_state_layer_skips_type_validation(
+        self, rclpy_init, odom_topic, tmp_path
+    ):
+        """Internal-state layers are not validated — their message types
+        come from robot plugins and the component trusts the plugin's
+        callback contract."""
+        # Image is not in allowed_inputs but flagging the layer as
+        # internal-state must bypass the validator.
+        image_topic = Topic(name="thermal_camera", msg_type="Image")
+        comp = _build_memory(
+            [MemLayer(subscribes_to=image_topic, is_internal_state=True)],
+            odom_topic,
+            "mem_plugin_bypass",
+            tmp_path,
+        )
+        assert "thermal_camera" in comp.layers_dict
+        assert comp.layers_dict["thermal_camera"].is_internal_state is True
+
+
+class TestStoreLayers:
+    def test_perception_layer_routes_to_add(
+        self, rclpy_init, odom_topic, detections_topic, tmp_path
+    ):
+        comp = _build_memory(
+            [MemLayer(subscribes_to=detections_topic)],
+            odom_topic,
+            "mem_route_add",
+            tmp_path,
+        )
+        backend = _stub_memory_backend(comp)
+        _stub_callback(comp, "detections", "chair, table")
+
+        comp._store_layers(position=[1.0, 2.0, 0.0], time_stamp=10)
+
+        backend.add.assert_called_once()
+        kwargs = backend.add.call_args.kwargs
+        assert kwargs["text"] == "chair, table"
+        assert kwargs["layer_name"] == "detections"
+        assert kwargs["x"] == 1.0
+        assert kwargs["y"] == 2.0
+        assert kwargs["z"] == 0.0
+        assert kwargs["timestamp"] == 10.0
+        backend.add_body_state.assert_not_called()
+
+    def test_internal_state_layer_routes_to_add_body_state(
+        self, rclpy_init, odom_topic, battery_topic, tmp_path
+    ):
+        comp = _build_memory(
+            [MemLayer(subscribes_to=battery_topic, is_internal_state=True)],
+            odom_topic,
+            "mem_route_body",
+            tmp_path,
+        )
+        backend = _stub_memory_backend(comp)
+        _stub_callback(comp, "battery", "battery: 42%")
+
+        comp._store_layers(position=[5.0, 5.0, 0.0], time_stamp=20)
+
+        backend.add_body_state.assert_called_once()
+        kwargs = backend.add_body_state.call_args.kwargs
+        assert kwargs["text"] == "battery: 42%"
+        assert kwargs["layer_name"] == "battery"
+        assert kwargs["x"] == 5.0
+        assert kwargs["y"] == 5.0
+        assert kwargs["z"] == 0.0
+        assert kwargs["timestamp"] == 20.0
+        backend.add.assert_not_called()
+
+    def test_mixed_layers_route_independently(
+        self,
+        rclpy_init,
+        odom_topic,
+        detections_topic,
+        battery_topic,
+        tmp_path,
+    ):
+        comp = _build_memory(
+            [
+                MemLayer(subscribes_to=detections_topic),
+                MemLayer(subscribes_to=battery_topic, is_internal_state=True),
+            ],
+            odom_topic,
+            "mem_mixed_route",
+            tmp_path,
+        )
+        backend = _stub_memory_backend(comp)
+        _stub_callback(comp, "detections", "chair, table")
+        _stub_callback(comp, "battery", "battery: 42%")
+
+        comp._store_layers(position=[7.0, 8.0, 0.1], time_stamp=30)
+
+        backend.add.assert_called_once()
+        assert backend.add.call_args.kwargs["layer_name"] == "detections"
+        backend.add_body_state.assert_called_once()
+        assert backend.add_body_state.call_args.kwargs["layer_name"] == "battery"
+
+        # Both calls share the same position so spatial-interoceptive
+        # associations work downstream.
+        assert backend.add.call_args.kwargs["x"] == 7.0
+        assert backend.add_body_state.call_args.kwargs["x"] == 7.0
+        assert backend.add.call_args.kwargs["z"] == 0.1
+        assert backend.add_body_state.call_args.kwargs["z"] == 0.1
+
+    def test_store_layers_uses_get_output_not_ui_content(
+        self, rclpy_init, odom_topic, detections_topic, tmp_path
+    ):
+        """_store_layers must read text through get_output. _get_ui_content
+        is intended for UI rendering (which may produce annotated JPEGs
+        for image-bearing callbacks) and must not be on the memory path."""
+        comp = _build_memory(
+            [MemLayer(subscribes_to=detections_topic)],
+            odom_topic,
+            "mem_text_source",
+            tmp_path,
+        )
+        _stub_memory_backend(comp)
+
+        cb = MagicMock()
+        cb.get_output = MagicMock(return_value="from_get_output")
+        cb._get_ui_content = MagicMock(return_value="from_ui_content")
+        comp.callbacks["detections"] = cb
+
+        comp._store_layers(position=[0.0, 0.0, 0.0], time_stamp=1)
+
+        cb.get_output.assert_called_once()
+        cb._get_ui_content.assert_not_called()
+        assert comp.memory.add.call_args.kwargs["text"] == "from_get_output"
+
+    def test_store_layers_stringifies_non_string_output(
+        self, rclpy_init, odom_topic, battery_topic, tmp_path
+    ):
+        """If a plugin callback for an internal-state topic returns
+        something that isn't a string, the component should coerce it
+        via ``str(...)`` as a defensive fallback rather than crashing
+        later in the embedding path."""
+        comp = _build_memory(
+            [MemLayer(subscribes_to=battery_topic, is_internal_state=True)],
+            odom_topic,
+            "mem_stringify",
+            tmp_path,
+        )
+        backend = _stub_memory_backend(comp)
+        cb = MagicMock()
+        cb.get_output = MagicMock(return_value=42)  # non-string
+        comp.callbacks["battery"] = cb
+
+        comp._store_layers(position=[0.0, 0.0, 0.0], time_stamp=0)
+
+        backend.add_body_state.assert_called_once()
+        assert backend.add_body_state.call_args.kwargs["text"] == "42"
+
+    def test_empty_callback_output_is_skipped(
+        self, rclpy_init, odom_topic, detections_topic, tmp_path
+    ):
+        comp = _build_memory(
+            [MemLayer(subscribes_to=detections_topic)],
+            odom_topic,
+            "mem_empty",
+            tmp_path,
+        )
+        backend = _stub_memory_backend(comp)
+        _stub_callback(comp, "detections", None)
+
+        comp._store_layers(position=[0.0, 0.0, 0.0], time_stamp=0)
+
+        backend.add.assert_not_called()
+        backend.add_body_state.assert_not_called()
+
+    def test_position_without_z_defaults_to_zero(
+        self, rclpy_init, odom_topic, detections_topic, tmp_path
+    ):
+        comp = _build_memory(
+            [MemLayer(subscribes_to=detections_topic)],
+            odom_topic,
+            "mem_2d",
+            tmp_path,
+        )
+        backend = _stub_memory_backend(comp)
+        _stub_callback(comp, "detections", "something")
+
+        comp._store_layers(position=[1.5, 2.5], time_stamp=0)
+
+        assert backend.add.call_args.kwargs["z"] == 0.0
+
+
+class TestInspectComponent:
+    def test_perception_only(self, rclpy_init, odom_topic, detections_topic, tmp_path):
+        comp = _build_memory(
+            [MemLayer(subscribes_to=detections_topic)],
+            odom_topic,
+            "mem_inspect_perception",
+            tmp_path,
+        )
+        _prep_for_inspect(comp)
+
+        result = comp.inspect_component()
+        assert "Perception layers" in result
+        assert "detections" in result
+        assert "Internal-state layers" not in result
+
+    def test_internal_state_only(self, rclpy_init, odom_topic, battery_topic, tmp_path):
+        comp = _build_memory(
+            [MemLayer(subscribes_to=battery_topic, is_internal_state=True)],
+            odom_topic,
+            "mem_inspect_internal",
+            tmp_path,
+        )
+        _prep_for_inspect(comp)
+
+        result = comp.inspect_component()
+        assert "Internal-state layers" in result
+        assert "battery" in result
+        assert "body_status" in result
+        assert "Perception layers: none configured" in result
+
+    def test_mixed_layers_both_sections(
+        self,
+        rclpy_init,
+        odom_topic,
+        detections_topic,
+        battery_topic,
+        cpu_temp_topic,
+        tmp_path,
+    ):
+        comp = _build_memory(
+            [
+                MemLayer(subscribes_to=detections_topic),
+                MemLayer(subscribes_to=battery_topic, is_internal_state=True),
+                MemLayer(subscribes_to=cpu_temp_topic, is_internal_state=True),
+            ],
+            odom_topic,
+            "mem_inspect_mixed",
+            tmp_path,
+        )
+        _prep_for_inspect(comp)
+
+        result = comp.inspect_component()
+        assert "Perception layers" in result
+        assert "Internal-state layers" in result
+        assert "detections" in result
+        assert "battery" in result
+        assert "cpu_temp" in result
+        # Perception section must appear before internal-state section.
+        assert result.index("Perception layers") < result.index("Internal-state layers")
+
+    def test_inspect_includes_position_topic(
+        self, rclpy_init, odom_topic, detections_topic, tmp_path
+    ):
+        comp = _build_memory(
+            [MemLayer(subscribes_to=detections_topic)],
+            odom_topic,
+            "mem_inspect_pos",
+            tmp_path,
+        )
+        _prep_for_inspect(comp)
+
+        result = comp.inspect_component()
+        assert "odom" in result


### PR DESCRIPTION
## Summary

Closes #27.

- Adds a **Memory** component built on eMEM, replacing MapEncoding as the spatio-temporal memory primitive. Exposes two retrieval surfaces — perception (semantic/spatial/temporal/episodic queries) and interoception (internal body state via `is_internal_state=True` layers surfaced through the `body_status` tool). MapEncoding is marked deprecated.
- Reworks **Cortex** planning/execution: iterative plan-execute-replan loop that feeds executed component action outputs back into planning, action-phase classification (PLANNING / EXECUTION / BOTH) for component actions, per-task summary with proper failure handling, and a memory-specific prompt augmentation that lets Cortex auto-discover Memory tools and decide between perception queries, body queries, and action tasks.
- Adds an example recipe (`examples/memory_with_cortex.py`) wiring Vision + VLM captioning + Memory (with perception + battery interoception layers) + TTS + Cortex, plus a companion `tests/test_memory.py`.
- Component actions and fallbacks now raise errors and return meaningful response strings on the happy path, making failures observable to Cortex during planning/execution.
- Updates multiprocessing example to the new per-component fallback API (`on_algorithm_fail` + `fallback_rate` per component) plus the launcher-level `on_process_fail` for process-crash recovery; `launcher.on_fail()` is gone upstream.
- Fixes init/deinit of Ollama embedding models (capability probing via `client.show()`), and adds serialization/deserialization of model + embedding clients for Memory.