### PR TITLE
Cortex robot-plugin integration: plugin actions as tools + robot identity

### DIFF
--- a/agents/clients/chroma.py
+++ b/agents/clients/chroma.py
@@ -36,7 +36,7 @@ class ChromaClient(DBClient):
             logging_level=logging_level,
             **kwargs,
         )
-        self.url = f"{self.host}:{self.port}/api/v2"
+        self.url = f"{self._build_url()}/api/v2"
 
         # create httpx client
         self.client = httpx.Client(base_url=self.url, timeout=self.response_timeout)

--- a/agents/clients/chroma.py
+++ b/agents/clients/chroma.py
@@ -36,7 +36,7 @@ class ChromaClient(DBClient):
             logging_level=logging_level,
             **kwargs,
         )
-        self.url = f"http://{self.host}:{self.port}/api/v2"
+        self.url = f"{self.host}:{self.port}/api/v2"
 
         # create httpx client
         self.client = httpx.Client(base_url=self.url, timeout=self.response_timeout)

--- a/agents/clients/db_base.py
+++ b/agents/clients/db_base.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Dict, Union
 from rclpy import logging
 
 from ..vectordbs import DB
-from ..utils import validate_func_args
+from ..utils import validate_func_args, build_url
 
 
 class DBClient(ABC):
@@ -24,7 +24,10 @@ class DBClient(ABC):
         """__init__.
         :param db:
         :type db: DB
-        :param host:
+        :param host: Hostname or IP of the database server. May include a scheme
+            (e.g. ``https://my-endpoint.com``) to target a TLS endpoint, in
+            which case it is used verbatim; a bare host (the default
+            ``127.0.0.1``) is prefixed with ``http`` and the ``port`` appended.
         :type host: Optional[str]
         :param port:
         :type port: Optional[int]
@@ -51,6 +54,15 @@ class DBClient(ABC):
             self.db_type, logging.get_logging_severity_from_string(logging_level)
         )
         self.response_timeout = response_timeout
+
+    def _build_url(self, default_scheme: str = "http") -> str:
+        """Construct the connection URL from ``host`` and ``port``.
+
+        :param default_scheme: Scheme to use for a bare host. Defaults to ``http``.
+        :type default_scheme: str
+        :rtype: str
+        """
+        return build_url(self.host, self.port, default_scheme)
 
     def serialize(self) -> Dict:
         """Get client json

--- a/agents/clients/generic.py
+++ b/agents/clients/generic.py
@@ -72,7 +72,7 @@ class GenericHTTPClient(ModelClient):
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
         header = {} if not self.api_key else {"Authorization": f"Bearer {self.api_key}"}
 
-        self.url = f"http://{self.host}:{self.port}"
+        self.url = f"{self.host}:{self.port}"
 
         # Create a synchronous httpx client
         self.client = httpx.Client(

--- a/agents/clients/generic.py
+++ b/agents/clients/generic.py
@@ -41,7 +41,11 @@ class GenericHTTPClient(ModelClient):
         Initializes the Client.
         :param model: The model to be used for inference.
         :type model: Union[Model, Dict]
-        :param host: The hostname of the API server.
+        :param host: The hostname of the API server. May include a scheme to
+                     target a TLS endpoint (e.g. ``https://api.openai.com/v1``),
+                     in which case it is used verbatim and ``port`` is ignored;
+                     a bare host (the default ``127.0.0.1``) is prefixed with
+                     ``http`` and the ``port`` appended.
         :type host: str
         :param port: The port of the API server.
         :type port: Optional[int]
@@ -72,7 +76,7 @@ class GenericHTTPClient(ModelClient):
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
         header = {} if not self.api_key else {"Authorization": f"Bearer {self.api_key}"}
 
-        self.url = f"{self.host}:{self.port}"
+        self.url = self._build_url()
 
         # Create a synchronous httpx client
         self.client = httpx.Client(

--- a/agents/clients/model_base.py
+++ b/agents/clients/model_base.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Dict, Union, Generator, MutableMapping
 from rclpy import logging
 
 from ..models import Model
-from ..utils import validate_func_args
+from ..utils import validate_func_args, build_url
 
 
 class ModelClient(ABC):
@@ -24,7 +24,10 @@ class ModelClient(ABC):
         """__init__.
         :param model:
         :type model: Model
-        :param host:
+        :param host: Hostname or IP of the model server. May include a scheme
+            (e.g. ``https://my-endpoint.com``) to target a TLS endpoint, in
+            which case it is used verbatim; a bare host (the default
+            ``127.0.0.1``) is prefixed with ``http`` and the ``port`` appended.
         :type host: Optional[str]
         :param port:
         :type port: Optional[int]
@@ -54,6 +57,15 @@ class ModelClient(ABC):
             self.model_name, logging.get_logging_severity_from_string(logging_level)
         )
         self.inference_timeout = inference_timeout
+
+    def _build_url(self, default_scheme: str = "http") -> str:
+        """Construct the connection URL from ``host`` and ``port``.
+
+        :param default_scheme: Scheme to use for a bare host. Defaults to ``http``.
+        :type default_scheme: str
+        :rtype: str
+        """
+        return build_url(self.host, self.port, default_scheme)
 
     def serialize(self) -> Dict:
         """Get client json

--- a/agents/clients/ollama.py
+++ b/agents/clients/ollama.py
@@ -24,8 +24,6 @@ class OllamaClient(ModelClient):
     ):
         try:
             from ollama import Client
-
-            self.client = Client(host=f"{host}:{port}")
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError(
                 "In order to use the OllamaClient, you need ollama-python package installed. You can install it with 'pip install ollama'"
@@ -43,6 +41,7 @@ class OllamaClient(ModelClient):
             logging_level=logging_level,
             **kwargs,
         )
+        self.client = Client(host=self._build_url())
         self._check_connection()
 
     @property
@@ -59,7 +58,7 @@ class OllamaClient(ModelClient):
         # Ping remote server to check connection
         self.logger.info("Checking connection with remote_host Ollama")
         try:
-            httpx.get(f"{self.host}:{self.port}").raise_for_status()
+            httpx.get(self._build_url()).raise_for_status()
         except Exception:
             self.logger.error(
                 f"""Failed to connect to Ollama server at {self.host}:{self.port}

--- a/agents/clients/ollama.py
+++ b/agents/clients/ollama.py
@@ -59,7 +59,7 @@ class OllamaClient(ModelClient):
         # Ping remote server to check connection
         self.logger.info("Checking connection with remote_host Ollama")
         try:
-            httpx.get(f"http://{self.host}:{self.port}").raise_for_status()
+            httpx.get(f"{self.host}:{self.port}").raise_for_status()
         except Exception:
             self.logger.error(
                 f"""Failed to connect to Ollama server at {self.host}:{self.port}

--- a/agents/clients/roboml.py
+++ b/agents/clients/roboml.py
@@ -63,7 +63,7 @@ class RoboMLHTTPClient(ModelClient):
             logging_level=logging_level,
             **kwargs,
         )
-        self.url = f"{self.host}:{self.port}"
+        self.url = self._build_url()
 
         # create httpx client
         self.client = httpx.Client(base_url=self.url, timeout=self.inference_timeout)
@@ -239,7 +239,7 @@ class RoboMLWSClient(RoboMLHTTPClient):
         self.request_queue: Optional[queue.Queue] = None
         self.response_queue: Optional[queue.Queue] = None
         self.websocket_endpoint = (
-            f"ws://{self.host}:{self.port}/{self.model_name}/ws_inference"
+            f"{self._build_url('ws')}/{self.model_name}/ws_inference"
         )
 
     def _inference(self) -> Optional[Dict]:

--- a/agents/clients/roboml.py
+++ b/agents/clients/roboml.py
@@ -63,7 +63,7 @@ class RoboMLHTTPClient(ModelClient):
             logging_level=logging_level,
             **kwargs,
         )
-        self.url = f"http://{self.host}:{self.port}"
+        self.url = f"{self.host}:{self.port}"
 
         # create httpx client
         self.client = httpx.Client(base_url=self.url, timeout=self.inference_timeout)

--- a/agents/components/cortex.py
+++ b/agents/components/cortex.py
@@ -158,6 +158,11 @@ class Cortex(ModelComponent, Monitor):
         # based on discovered managed components (e.g. to handle Memory)
         self._effective_planning_prompt = self._PLANNING_PROMPT
 
+        # Planning-prompt addenda. The effective planning prompt is always
+        # _PLANNING_PROMPT + _robot_description + _memory_addendum
+        self._robot_description = ""   # set by set_robot_description()
+        self._memory_addendum = ""     # set by _augment_planning_prompt_for_memory()
+
         # Initialize messages buffer
         self.messages: List[Dict] = [
             {"role": "system", "content": self._effective_planning_prompt}
@@ -298,6 +303,146 @@ class Cortex(ModelComponent, Monitor):
             self._execution_tools.add(name)
             self._execution_tool_descriptions.append(tool_description)
 
+    def add_plugin_actions(self, plugin: Any) -> None:
+        """Expose a robot plugin's actions to cortex as execution tools.
+
+        Each `robot.ActionRegistry` factory on ``plugin`` is
+        materialized once, namespaced as ``{plugin_ns}.{action_name}`` and gets
+        added as a behavioral action.
+
+        :param plugin: A `robot.RobotPlugin` instance with
+            an ``actions`` registry. Plugins without actions are a no-op.
+        """
+        if plugin is None or not getattr(plugin, "actions", None):
+            return
+
+        # Namespace: plugin display name lowercased, spaces -> underscores;
+        # falls back to "robot" if the plugin author left metadata.name empty.
+        metadata_name = getattr(getattr(plugin, "metadata", None), "name", "") or ""
+        ns = metadata_name.strip().lower().replace(" ", "_") or "robot"
+
+        tool_descriptions = plugin.actions.tool_descriptions(namespace=ns)
+        if not tool_descriptions:
+            return
+
+        registered: List[str] = []
+        for tool_desc in tool_descriptions:
+            tool_name = tool_desc["function"]["name"]
+            if tool_name in self._execution_tools:
+                self.get_logger().warning(
+                    f"Plugin action '{tool_name}' collides with an existing "
+                    "tool; skipping."
+                )
+                continue
+
+            # Materialize the Action from the factory
+            local_name = tool_name.split(".", 1)[1]
+            factory = getattr(plugin.actions, local_name)
+            try:
+                action = factory()
+            except Exception as e:
+                self.get_logger().error(
+                    f"Failed to materialize plugin action '{tool_name}': {e}"
+                )
+                continue
+            action.action_name = tool_name
+            if not action.description:
+                action._description = tool_desc["function"].get("description", "")
+
+            Monitor.add_internal_event_action_pair(
+                self, event_id=tool_name, action=action
+            )
+            self._execution_tools.add(tool_name)
+            self._execution_tool_descriptions.append(tool_desc)
+            registered.append(tool_name)
+
+        if registered:
+            self.get_logger().info(
+                f"Registered {len(registered)} plugin action(s) from '{ns}' "
+                f"as Cortex execution tools: {registered}"
+            )
+
+    def set_robot_description(self, plugin: Any) -> None:
+        """Augment the planning prompt with the attached robot's identity.
+
+        When a robot plugin is attached, Cortex is embodied in a specific
+        physical robot. This builds a compact identity addendum from the
+        plugin's metadata and prepends it to the planning prompt, so the agent
+        can answer "who/what are you" questions about its own body instead of
+        hallucinating a generic robot.
+
+        :param plugin: A `robot.RobotPlugin` instance, or ``None``.
+        """
+        if plugin is None:
+            return
+        try:
+            desc = plugin.describe()
+        except Exception as e:
+            self.get_logger().error(f"Failed to read robot plugin description: {e}")
+            return
+
+        meta = desc.get("metadata", {})
+        name = meta.get("name", "") or "Unknown"
+        vendor = meta.get("vendor", "") or "unknown vendor"
+        version = meta.get("version", "") or "unspecified"
+        blurb = meta.get("description", "") or "(no description provided)"
+
+        feedback_keys = [f["key"] for f in desc.get("feedbacks", [])]
+        command_keys = [c["key"] for c in desc.get("commands", [])]
+        action_names = [a["name"] for a in desc.get("actions", [])]
+
+        # Namespace the plugin actions get registered under as execution tools
+        ns = name.strip().lower().replace(" ", "_") or "robot"
+
+        def _join(items: List[str]) -> str:
+            return ", ".join(items) if items else "(none)"
+
+        if action_names:
+            action_hint = (
+                f"The robot actions above are available to you as execution "
+                f"tools (named '{ns}.<action>', e.g. '{ns}.{action_names[0]}'); "
+                "use them when a task calls for a physical behaviour."
+            )
+        else:
+            action_hint = ""
+
+        self._robot_description = (
+            "\n\n=== Robot Identity ===\n"
+            "You are not a disembodied assistant -- you are the intelligence "
+            "of a physical robot. Answer questions about who or what you are "
+            "based on the following, never on guesswork:\n"
+            f"  - Name: {name}\n"
+            f"  - Vendor: {vendor}\n"
+            f"  - Version: {version}\n"
+            f"  - Description: {blurb}\n"
+            "Capabilities exposed through your robot body:\n"
+            f"  - Sensor feedback you receive: {_join(feedback_keys)}\n"
+            f"  - Commands you can issue: {_join(command_keys)}\n"
+            f"  - Built-in robot actions: {_join(action_names)}\n"
+            + action_hint
+        )
+
+        self._compose_planning_prompt()
+        self.get_logger().info(
+            f"Planning prompt augmented with robot identity for '{name}'."
+        )
+
+    def _compose_planning_prompt(self) -> None:
+        """Rebuild the effective planning prompt from the base prompt plus
+        every active addendum (robot identity, memory guidance).
+
+        Single source of truth and Idempotent.
+        """
+        self._effective_planning_prompt = (
+            self._PLANNING_PROMPT
+            + self._robot_description
+            + self._memory_addendum
+        )
+        self.config._system_prompt = self._effective_planning_prompt
+        self.messages = [
+            {"role": "system", "content": self._effective_planning_prompt}
+        ]
+
     # =========================================================================
     # Lifecycle
     # =========================================================================
@@ -316,6 +461,10 @@ class Cortex(ModelComponent, Monitor):
             Monitor.activate(self)
             self._register_system_tools()
             self._augment_planning_prompt_for_memory()
+        # Always (re)compose so the planning prompt reflects every addendum
+        # set so far -- robot identity, memory guidance, or neither --
+        # regardless of which augmentation paths ran.
+        self._compose_planning_prompt()
 
         # Display all the tools registered
         planning_names = [
@@ -442,9 +591,8 @@ class Cortex(ModelComponent, Monitor):
             f"plan between '{start_ep_tool}' and '{end_ep_tool}'."
         )
 
-        self._effective_planning_prompt = self._PLANNING_PROMPT + addendum
-        self.config._system_prompt = self._effective_planning_prompt
-        self.messages = [{"role": "system", "content": self._effective_planning_prompt}]
+        self._memory_addendum = addendum
+        self._compose_planning_prompt()
         self.get_logger().info(
             f"Planning prompt augmented for Memory component '{memory_comp.node_name}'."
         )

--- a/agents/components/cortex.py
+++ b/agents/components/cortex.py
@@ -22,6 +22,7 @@ from ..ros import (
     ServiceClientHandler,
     ros_msg_to_str,
     get_methods_with_decorator,
+    get_logger
 )
 from ..utils import (
     validate_func_args,
@@ -329,7 +330,7 @@ class Cortex(ModelComponent, Monitor):
         for tool_desc in tool_descriptions:
             tool_name = tool_desc["function"]["name"]
             if tool_name in self._execution_tools:
-                self.get_logger().warning(
+                get_logger('cortex').warning(
                     f"Plugin action '{tool_name}' collides with an existing "
                     "tool; skipping."
                 )
@@ -341,7 +342,7 @@ class Cortex(ModelComponent, Monitor):
             try:
                 action = factory()
             except Exception as e:
-                self.get_logger().error(
+                get_logger('cortex').error(
                     f"Failed to materialize plugin action '{tool_name}': {e}"
                 )
                 continue
@@ -357,7 +358,7 @@ class Cortex(ModelComponent, Monitor):
             registered.append(tool_name)
 
         if registered:
-            self.get_logger().info(
+            get_logger('cortex').info(
                 f"Registered {len(registered)} plugin action(s) from '{ns}' "
                 f"as Cortex execution tools: {registered}"
             )
@@ -378,7 +379,7 @@ class Cortex(ModelComponent, Monitor):
         try:
             desc = plugin.describe()
         except Exception as e:
-            self.get_logger().error(f"Failed to read robot plugin description: {e}")
+            get_logger('cortex').error(f"Failed to read robot plugin description: {e}")
             return
 
         meta = desc.get("metadata", {})
@@ -423,7 +424,7 @@ class Cortex(ModelComponent, Monitor):
         )
 
         self._compose_planning_prompt()
-        self.get_logger().info(
+        get_logger('cortex').info(
             f"Planning prompt augmented with robot identity for '{name}'."
         )
 

--- a/agents/components/texttospeech.py
+++ b/agents/components/texttospeech.py
@@ -422,15 +422,16 @@ class TextToSpeech(ModelComponent):
         :param text: The text to be spoken out loud.
         :type text: str
         """
-        try:
-            # Stop current playback if active, so new speech isn't queued
-            # behind stale audio
-            if self._playback_thread and self._playback_thread.is_alive():
-                self.stop_playback()
-            self._execution_step(text=text)
-            return True
-        except Exception:
-            return False
+        # Stop current playback if active, so new speech isn't queued
+        # behind stale audio
+        if (
+            hasattr(self, "_playback_thread")
+            and self._playback_thread
+            and self._playback_thread.is_alive()
+        ):
+            self.stop_playback()
+        self._execution_step(text=text)
+        return True
 
     def _handle_websocket_streaming(self) -> Optional[List]:
         """Handle streaming output from a websocket client"""

--- a/agents/launcher.py
+++ b/agents/launcher.py
@@ -94,6 +94,13 @@ class Launcher(BaseLauncher):
                 activate_on_start=all_components_to_activate_on_start,
                 activation_timeout=self._components_activation_timeout,
             )
+            # Expose the robot plugin's actions to Cortex as execution tools
+            # and augment its planning prompt with the robot's identity.
+            # Must run after _init_internal_monitor and before _setup_additional_internal_actions
+            if self._robot_plugin is not None:
+                cortex_monitor.add_plugin_actions(self._robot_plugin)
+                cortex_monitor.set_robot_description(self._robot_plugin)
+
             # Add any additional internal actions related to the monitor (e.g. events handling actions)
             self._setup_additional_internal_actions(
                 self.monitor_node._additional_internal_actions

--- a/agents/utils/__init__.py
+++ b/agents/utils/__init__.py
@@ -14,6 +14,7 @@ from .utils import (
     load_model,
     load_model_repo,
     flatten,
+    build_url,
     build_lerobot_features_from_dataset_info,
     find_missing_values,
     _LANGUAGE_CODES,
@@ -22,6 +23,7 @@ from .utils import (
 __all__ = [
     "_LANGUAGE_CODES",
     "build_lerobot_features_from_dataset_info",
+    "build_url",
     "find_missing_values",
     "flatten",
     "create_detection_context",

--- a/agents/utils/utils.py
+++ b/agents/utils/utils.py
@@ -29,6 +29,37 @@ from jinja2.environment import Template
 from .pluralize import pluralize
 
 
+def build_url(
+    host: Optional[str], port: Optional[int] = None, default_scheme: str = "http"
+) -> str:
+    """Construct a connection URL from a host and port.
+
+    If ``host`` already carries a scheme (e.g. ``https://`` or ``ws://``), it is
+    respected verbatim, allowing a client to be pointed at a TLS endpoint. If
+    ``host`` is a bare hostname/IP, ``default_scheme`` is prepended and ``port``
+    (when given) appended, preserving the historical ``http://127.0.0.1:8000``
+    style defaults.
+
+    :param host: Hostname/IP, optionally scheme-prefixed. Falls back to
+        ``127.0.0.1`` when falsy.
+    :type host: Optional[str]
+    :param port: Port to append for a bare host. Ignored when ``host`` already
+        carries a scheme (a full endpoint is assumed). Defaults to None.
+    :type port: Optional[int]
+    :param default_scheme: Scheme to prepend to a bare host, e.g. ``http`` or
+        ``ws``. Defaults to ``http``.
+    :type default_scheme: str
+    :returns: A fully-qualified URL.
+    :rtype: str
+    """
+    host = (host or "127.0.0.1").strip().rstrip("/")
+    if "://" in host:
+        # Full endpoint provided: respect it verbatim.
+        return host
+    base = f"{default_scheme}://{host}"
+    return f"{base}:{port}" if port is not None else base
+
+
 def draw_detection_bounding_boxes(
     img: np.ndarray, bounding_boxes: List, labels: List, handle_bbox2d_msg: bool = True
 ) -> np.ndarray:

--- a/scripts/executable
+++ b/scripts/executable
@@ -107,6 +107,11 @@ def _parse_args() -> Tuple[argparse.Namespace, List[str]]:
         type=str,
         help="Additional type modules from derived packages",
     )
+    parser.add_argument(
+        "--robot_plugin",
+        type=str,
+        help="Serialized robot plugin spec and feedback-bus endpoint",
+    )
 
     return parser.parse_known_args()
 
@@ -270,6 +275,10 @@ def _setup_component_post_init(component: Any, args: argparse.Namespace) -> None
     # Set external processors
     if args.external_processors:
         component._external_processors_json = args.external_processors
+
+    # Rebuild the robot plugin and connect it to the HOST feedback bus
+    if args.robot_plugin:
+        component._robot_plugin_json = args.robot_plugin
 
     # Set additional model clients if any
     component.additional_model_clients = (

--- a/tests/test_cortex.py
+++ b/tests/test_cortex.py
@@ -410,3 +410,292 @@ class TestNoLLMMethods:
         )
         assert not hasattr(comp, "register_tool")
         assert not hasattr(comp, "set_component_prompt")
+
+
+def _make_mock_plugin(name="Lite3", action_names=("sit_stand", "stop")):
+    """Mock a `~ros_sugar.robot.RobotPlugin` exposing two zero-arg actions.
+
+    Mirrors the real surface that `Cortex.add_plugin_actions` consumes:
+    ``plugin.metadata.name`` for the namespace, ``plugin.actions`` with a
+    ``tool_descriptions(namespace=...)`` method and per-name factories
+    accessed via ``getattr(plugin.actions, name)``.
+    """
+    plugin = MagicMock()
+    plugin.metadata = MagicMock()
+    plugin.metadata.name = name
+
+    plugin.actions = MagicMock()
+    plugin.actions.tool_descriptions.side_effect = lambda namespace=None: [
+        {
+            "type": "function",
+            "function": {
+                "name": f"{namespace}.{n}" if namespace else n,
+                "description": f"Do {n}",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                },
+            },
+        }
+        for n in action_names
+    ]
+    # Each factory call returns a fresh mock Action (so action_name can be set
+    # independently per registration).
+    plugin.actions.configure_mock(**{
+        n: MagicMock(return_value=_make_mock_action(name=n, description=f"Do {n}"))
+        for n in action_names
+    })
+    return plugin
+
+
+class TestCortexPluginActions:
+    """The plugin-action bridge: factories on a `RobotPlugin` registered as
+    namespaced execution tools, dispatchable via the same internal-event
+    path as constructor-supplied behavioral actions."""
+
+    def test_register_plugin_actions(self, rclpy_init, mock_model_client):
+        plugin = _make_mock_plugin(name="Lite3", action_names=("sit_stand", "stop"))
+        comp = Cortex(
+            outputs=[Topic(name="out", msg_type="String")],
+            actions=[],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_plugin",
+        )
+
+        mock_component_internals(comp)
+        comp.add_plugin_actions(plugin)
+
+        assert "lite3.sit_stand" in comp._execution_tools
+        assert "lite3.stop" in comp._execution_tools
+        assert "lite3.sit_stand" in comp._additional_internal_actions
+        assert "lite3.stop" in comp._additional_internal_actions
+        names = [t["function"]["name"] for t in comp._execution_tool_descriptions]
+        assert "lite3.sit_stand" in names
+        assert "lite3.stop" in names
+
+    def test_namespace_falls_back_to_robot_when_metadata_name_empty(
+        self, rclpy_init, mock_model_client
+    ):
+        plugin = _make_mock_plugin(name="", action_names=("dock",))
+        comp = Cortex(
+            outputs=[Topic(name="out", msg_type="String")],
+            actions=[],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_plugin_default_ns",
+        )
+
+        mock_component_internals(comp)
+        comp.add_plugin_actions(plugin)
+
+        assert "robot.dock" in comp._execution_tools
+
+    def test_namespace_normalizes_whitespace(self, rclpy_init, mock_model_client):
+        plugin = _make_mock_plugin(name="My Robot", action_names=("dock",))
+        comp = Cortex(
+            outputs=[Topic(name="out", msg_type="String")],
+            actions=[],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_plugin_ns_norm",
+        )
+
+        mock_component_internals(comp)
+        comp.add_plugin_actions(plugin)
+
+        assert "my_robot.dock" in comp._execution_tools
+
+    def test_does_not_double_register_on_collision(
+        self, rclpy_init, mock_model_client
+    ):
+        plugin = _make_mock_plugin(name="Lite3", action_names=("stop",))
+        comp = Cortex(
+            outputs=[Topic(name="out", msg_type="String")],
+            actions=[],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_plugin_collision",
+        )
+
+        mock_component_internals(comp)
+        comp.add_plugin_actions(plugin)
+        comp.add_plugin_actions(plugin)  # second call should skip with a warning
+
+        assert sum(
+            1
+            for t in comp._execution_tool_descriptions
+            if t["function"]["name"] == "lite3.stop"
+        ) == 1
+
+    def test_none_plugin_is_noop(self, rclpy_init, mock_model_client):
+        comp = Cortex(
+            outputs=[Topic(name="out", msg_type="String")],
+            actions=[],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_plugin_none",
+        )
+
+        comp.add_plugin_actions(None)
+
+        assert len(comp._execution_tools) == 0
+        assert len(comp._execution_tool_descriptions) == 0
+
+    def test_plugin_without_actions_is_noop(self, rclpy_init, mock_model_client):
+        plugin = MagicMock()
+        plugin.actions = None
+        comp = Cortex(
+            outputs=[Topic(name="out", msg_type="String")],
+            actions=[],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_plugin_no_actions",
+        )
+
+        mock_component_internals(comp)
+        comp.add_plugin_actions(plugin)
+
+        assert len(comp._execution_tools) == 0
+        assert len(comp._execution_tool_descriptions) == 0
+
+    def test_factory_failure_logged_and_skipped(
+        self, rclpy_init, mock_model_client
+    ):
+        plugin = _make_mock_plugin(name="Lite3", action_names=("ok", "broken"))
+        plugin.actions.broken.side_effect = RuntimeError("boom")
+        comp = Cortex(
+            outputs=[Topic(name="out", msg_type="String")],
+            actions=[],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_plugin_factory_fail",
+        )
+
+        mock_component_internals(comp)
+        comp.add_plugin_actions(plugin)
+
+        assert "lite3.ok" in comp._execution_tools
+        assert "lite3.broken" not in comp._execution_tools
+
+
+def _make_mock_plugin_with_describe(
+    name="Lite3",
+    vendor="DeepRobotics",
+    version="1.0",
+    description="A four-legged quadruped robot.",
+):
+    """Mock a `RobotPlugin` exposing the ``describe()`` surface that
+    ``Cortex.set_robot_description`` consumes."""
+    plugin = MagicMock()
+    plugin.describe.return_value = {
+        "metadata": {
+            "name": name,
+            "vendor": vendor,
+            "version": version,
+            "description": description,
+        },
+        "feedbacks": [{"key": "Odometry"}, {"key": "Imu"}, {"key": "Float64"}],
+        "commands": [{"key": "Twist"}],
+        "actions": [{"name": "sit_stand"}, {"name": "stop"}],
+        "events": [{"name": "low_battery"}],
+    }
+    return plugin
+
+
+class TestCortexRobotDescription:
+    """``set_robot_description`` augments the planning prompt with the
+    attached robot's identity so the agent answers "who are you" correctly."""
+
+    def test_description_augments_planning_prompt(
+        self, rclpy_init, mock_model_client
+    ):
+        plugin = _make_mock_plugin_with_describe(
+            name="Lite3", description="A nimble quadruped."
+        )
+        comp = Cortex(
+            outputs=[Topic(name="out", msg_type="String")],
+            actions=[],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_robot_desc",
+        )
+        mock_component_internals(comp)
+
+        comp.set_robot_description(plugin)
+
+        prompt = comp._effective_planning_prompt
+        assert "Robot Identity" in prompt
+        assert "Lite3" in prompt
+        assert "DeepRobotics" in prompt
+        assert "A nimble quadruped." in prompt
+        # Capability overview is summarized
+        assert "Odometry" in prompt and "Twist" in prompt
+        # The base planning prompt is preserved
+        assert comp._PLANNING_PROMPT in prompt
+        # config + messages buffer kept in sync
+        assert comp.config._system_prompt == prompt
+        assert comp.messages[0]["content"] == prompt
+
+    def test_none_plugin_is_noop(self, rclpy_init, mock_model_client):
+        comp = Cortex(
+            outputs=[Topic(name="out", msg_type="String")],
+            actions=[],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_robot_desc_none",
+        )
+        mock_component_internals(comp)
+
+        comp.set_robot_description(None)
+
+        assert comp._robot_description == ""
+        assert comp._effective_planning_prompt == comp._PLANNING_PROMPT
+
+    def test_memory_augmentation_preserves_robot_description(
+        self, rclpy_init, mock_model_client
+    ):
+        """``_augment_planning_prompt_for_memory`` composes on top of the
+        robot identity rather than clobbering it."""
+        plugin = _make_mock_plugin_with_describe(name="Lite3")
+        comp = Cortex(
+            outputs=[Topic(name="out", msg_type="String")],
+            actions=[],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_robot_desc_memory",
+        )
+        mock_component_internals(comp)
+        comp.set_robot_description(plugin)
+
+        # No Memory component -> _augment_planning_prompt_for_memory early-returns;
+        # the robot identity must survive untouched.
+        comp._managed_components = {}
+        comp._augment_planning_prompt_for_memory()
+        assert "Robot Identity" in comp._effective_planning_prompt
+
+    def test_compose_is_single_source_of_truth(
+        self, rclpy_init, mock_model_client
+    ):
+        """Both addendum slots compose into the prompt regardless of which
+        augmentation ran -- the composer always rebuilds from both."""
+        plugin = _make_mock_plugin_with_describe(name="Lite3")
+        comp = Cortex(
+            outputs=[Topic(name="out", msg_type="String")],
+            actions=[],
+            model_client=mock_model_client,
+            config=CortexConfig(),
+            component_name="test_cortex_compose",
+        )
+        mock_component_internals(comp)
+
+        # Memory addendum set first, robot description second
+        comp._memory_addendum = "\n\n=== Memory Guidance ===\nstub"
+        comp._compose_planning_prompt()
+        comp.set_robot_description(plugin)
+
+        prompt = comp._effective_planning_prompt
+        assert comp._PLANNING_PROMPT in prompt
+        assert "Robot Identity" in prompt
+        assert "Memory Guidance" in prompt


### PR DESCRIPTION
## Summary

Integrates Sugarcoat robot plugins with the Cortex component. When a recipe attaches a robot plugin, its actions become LLM-callable tools and its identity augments the planning prompt, so the agent can both *act through* the robot and *reason about* what robot it is.

Depends on the Sugarcoat robot plugin framework (separate PR).

## What's new

- **Plugin actions as execution tools** — `Cortex.add_plugin_actions(plugin)` materializes each `ActionRegistry` factory, namespaces it as `{robot}.{action}` (e.g. `lite3.sit_stand`), and registers it via the Monitor's internal-event path so the planner can call it like any behavioral action. OpenAI-style tool descriptions (with any state-machine guidance the plugin author baked in) flow through unchanged.
- **Robot identity in the planning prompt** — `Cortex.set_robot_description(plugin)` builds a compact identity block (name, vendor, description, sensor/command/action overview) from the plugin's `describe()` and prepends it to the planning prompt, so "who/what are you" questions are answered from fact, not guesswork.
- **Single-source prompt composition** — `_compose_planning_prompt()` rebuilds the planning prompt from `_PLANNING_PROMPT` + robot-identity + memory addenda. Each augmentation writes only its own slot, so robot identity and memory guidance compose regardless of which ran (fixes the case where the identity was dropped when no Memory component was present).
- **Launcher hook** — `Launcher._init_monitor_node` calls both methods (hasattr-guarded) after `_init_internal_monitor` and before the internal-action handlers are wired.
- **Multiprocess plugin support** — the component `executable` now parses `--robot_plugin` and reconstructs the plugin client in the subprocess, so plugin-backed topics/actions work under `multiprocessing=True`.

## Incidental fixes on this branch

- Pre-activation methods use a pre-init logger (they run before the node's logger exists).
- `TextToSpeech.say` lets exceptions propagate to `execute_method` instead of swallowing them, and guards the `_playback_thread` attribute check.
- HTTP clients no longer hardcode the `http://` scheme, so TLS (`https://`) endpoints are reachable.