### PR TITLE
Adapt UI/API integration to sugarcoat's front-end-agnostic API and add prior memories to MemLayers

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -4,7 +4,7 @@ from importlib.metadata import version, PackageNotFoundError
 from packaging import version as pkg_version
 
 # Define the minimum required version of sugarcoat
-MIN_SUGARCOAT_VERSION = "0.7.1"
+MIN_SUGARCOAT_VERSION = "0.8.0"
 
 
 def _print_sugarcoat_error(current_version=None):

--- a/agents/callbacks.py
+++ b/agents/callbacks.py
@@ -28,6 +28,24 @@ __all__ = ["GenericCallback", "TextCallback"]
 
 
 class StreamingStringCallback(TextCallback):
+    def __init__(self, input_topic, node_name: str = "") -> None:
+        super().__init__(input_topic, node_name)
+        # Full text of the current stream, accumulated across chunks
+        self._stream_text: str = ""
+
+    def callback(self, msg) -> None:
+        # self.msg is still the previous message here unless the stream is new or
+        # completed
+        if getattr(self.msg, "done", True):
+            self._stream_text = ""
+        self._stream_text += msg.data
+        super().callback(msg)
+
+    def _get_ui_content(self, **_) -> str:
+        """Full text of the current stream, so latest-value readers never miss
+        coalesced chunks."""
+        return self._stream_text
+
     def _get_output(self, **_) -> Optional[str]:
         """Gets text.
         :rtype: str | None
@@ -410,5 +428,5 @@ class JointStateCallback(GenericCallback):
             joints_names=self.msg.name,
             positions=np.array(self.msg.position),
             velocities=np.array(self.msg.velocity),
-            efforts=np.array(self.msg.effort)
+            efforts=np.array(self.msg.effort),
         )

--- a/agents/components/map_encoding.py
+++ b/agents/components/map_encoding.py
@@ -14,6 +14,7 @@ from ..ros import (
     Detections,
     DetectionsMultiSource,
     MapLayer,
+    PriorMemory,
     component_action,
 )
 from ..utils import validate_func_args
@@ -54,8 +55,8 @@ class MapEncoding(Component):
     map_topic = Topic(name="map", msg_type="OccupancyGrid")
     config = MapConfig(map_name="map")
     db_client = DBClient(db=ChromaDB("database_name"))
-    layers = [MapLayer(subscribes_to=text1, resolution_multiple=3),
-              MapLayer(subscribes_to=detections1, temporal_change=True)]  # text1 and detections1 are String topics that are being published on by other components
+    layers = [MapLayer(subscribes_to=text1),
+              MapLayer(subscribes_to=detections1)]  # text1 and detections1 are String topics that are being published on by other components
     map_encoding_component = MapEncoding(
         layers=layers,
         position=position_topic,
@@ -116,8 +117,8 @@ class MapEncoding(Component):
 
         # fill out pre-defined points in layers
         for layer in self.layers_dict.values():
-            if layer.pre_defined and len(layer.pre_defined) > 0:
-                self._fill_out_pre_defined(layer, layer.pre_defined)
+            if layer.prior_memories and len(layer.prior_memories) > 0:
+                self._fill_out_prior_memories(layer, layer.prior_memories)
 
     def custom_on_deactivate(self):
         """deactivate."""
@@ -125,17 +126,17 @@ class MapEncoding(Component):
         self.db_client.check_connection()
         self.db_client.deinitialize()
 
-    def _fill_out_pre_defined(
+    def _fill_out_prior_memories(
         self,
         layer: MapLayer,
-        points: Union[List[Tuple[np.ndarray, str]], Tuple[np.ndarray, str]],
+        points: Union[List[PriorMemory], PriorMemory],
     ) -> None:
         """Fill out any pre-defined points in the MapLayer.
 
         :param layer:
         :type layer: MapLayer
         :param points:
-        :type points: list[tuple[np.ndarray, str]] | tuple[np.ndarray, str]
+        :type points: list[PriorMemory] | PriorMemory
         :rtype: None
         """
         self.get_logger().info(
@@ -157,24 +158,23 @@ class MapEncoding(Component):
         if not isinstance(points, List):
             points = [points]
 
-        # add pre_defined points
+        # add prior_memories points
         for data in points:
-            coordinates_string = np.array2string(data[0], separator=",")[1:-1]
+            position = data.position if data.position is not None else (0.0, 0.0, 0.0)
+            coordinates_string = np.array2string(np.array(position), separator=",")[
+                1:-1
+            ]
             # Create metadata
             metadata = {
                 "layer_name": layer_name,
                 "coordinates": coordinates_string,
                 "timestamp": time_stamp,
-                "temporal_change": layer.temporal_change,
+                "temporal_change": False,
             }
 
-            id = (
-                f"{layer_name}:{coordinates_string}:0"
-                if not layer.temporal_change
-                else f"{layer_name}:{coordinates_string}:{time_stamp}"
-            )
+            id = f"{layer_name}:{coordinates_string}:0"
             to_be_added["ids"].append(id)
-            to_be_added["documents"].append(data[1])
+            to_be_added["documents"].append(data.text)
             to_be_added["metadatas"].append(metadata)
 
         self.db_client.add(to_be_added)
@@ -210,29 +210,18 @@ class MapEncoding(Component):
                 # create layer metadata
                 metadata = {}
                 metadata["layer_name"] = name
-                # set layer specific space coordinate based on resolution multiple
-                relative_coordinates = map_coordinates // layer.resolution_multiple
                 # convert ndarray to string for serialization and vectordb storage
-                coordinates_string = np.array2string(
-                    relative_coordinates, separator=","
-                )[1:-1]
+                coordinates_string = np.array2string(map_coordinates, separator=",")[
+                    1:-1
+                ]
                 metadata["coordinates"] = coordinates_string
-                # set time_stamp and temporal_change flag
-                metadata["temporal_change"] = layer.temporal_change
+                metadata["temporal_change"] = False
                 metadata["time_stamp"] = time_stamp
 
-                # create ids and assign to appropriate dict based on temporal_change
-                if layer.temporal_change:
-                    to_be_added["ids"].append(
-                        f"{name}:{coordinates_string}:{time_stamp}"
-                    )
-                    to_be_added["metadatas"].append(metadata)
-                    to_be_added["documents"].append(item)
-                else:
-                    # time value remains 0 if layer assumed to be temporary static
-                    to_be_checked["ids"].append(f"{name}:{coordinates_string}:0")
-                    to_be_checked["metadatas"].append(metadata)
-                    to_be_checked["documents"].append(item)
+                # time value remains 0 as layers are treated as temporally static
+                to_be_checked["ids"].append(f"{name}:{coordinates_string}:0")
+                to_be_checked["metadatas"].append(metadata)
+                to_be_checked["documents"].append(item)
 
         # check for null
         if not to_be_added["ids"]:
@@ -338,17 +327,17 @@ class MapEncoding(Component):
             },
         }
     )
-    def add_point(self, layer: MapLayer, point: Tuple[np.ndarray, str]) -> None:
+    def add_point(self, layer: MapLayer, point: PriorMemory) -> None:
         """Component action to add a user defined point to the map collection.
         This action can be executed on an event.
 
         :param layer: Layer to which the point should be added
         :type layer: MapLayer
-        :param point: A tuple of position (numpy array) and text data (str)
-        :type point: tuple[np.ndarray, str]
+        :param point: A pre-defined observation carrying text and an optional position
+        :type point: PriorMemory
         :rtype: None
         """
-        self._fill_out_pre_defined(layer, point)
+        self._fill_out_prior_memories(layer, point)
 
     def _update_cmd_args_list(self):
         """

--- a/agents/components/memory.py
+++ b/agents/components/memory.py
@@ -88,8 +88,11 @@ class Memory(Component):
     room_type = Topic(name="room_type", msg_type="String")
     battery = Topic(name="battery_state", msg_type="BatteryState")
 
-    layer1 = MemLayer(subscribes_to=detections, temporal_change=True)
-    layer2 = MemLayer(subscribes_to=room_type, resolution_multiple=3)
+    layer1 = MemLayer(subscribes_to=detections)
+    layer2 = MemLayer(
+        subscribes_to=room_type,
+        prior_memories=[PriorMemory(text="kitchen", position=(2.0, 1.0, 0.0))],
+    )
     layer3 = MemLayer(subscribes_to=battery, is_internal_state=True)
 
     memory = Memory(
@@ -214,6 +217,35 @@ class Memory(Component):
             embedding_provider=embedding_provider,
             llm_client=llm_client,
         )
+
+        # Seed any pre-defined observations configured on the layers
+        self._seed_prior_memories()
+
+    def _seed_prior_memories(self) -> None:
+        """Seed memory with each layer's pre-defined observations.
+
+        Runs once after eMEM is initialized. Each observation uses its own
+        position and timestamp when provided, otherwise the origin and
+        the component's current time.
+        """
+        for name, layer in self.layers_dict.items():
+            for obs in layer.prior_memories:
+                if not obs.text:
+                    continue
+                x, y, z = obs.position if obs.position is not None else (0.0, 0.0, 0.0)
+                ts = (
+                    obs.timestamp
+                    if obs.timestamp is not None
+                    else float(self.get_ros_time().sec)
+                )
+                if layer.is_internal_state:
+                    self.memory.add_body_state(
+                        text=obs.text, layer_name=name, x=x, y=y, z=z, timestamp=ts
+                    )
+                else:
+                    self.memory.add(
+                        text=obs.text, x=x, y=y, z=z, layer_name=name, timestamp=ts
+                    )
 
     def custom_on_deactivate(self):
         """Close eMEM and deinitialize clients."""

--- a/agents/models.py
+++ b/agents/models.py
@@ -391,27 +391,33 @@ class TransformersMLLM(TransformersLLM):
 
 @define(kw_only=True)
 class RoboBrain2(Model):
-    """[RoboBrain 2.0 by BAAI](https://github.com/FlagOpen/RoboBrain2.0) supports interactive reasoning with long-horizon planning and closed-loop feedback, spatial perception for precise point and bbox prediction from complex instructions and temporal perception for future trajectory estimation.
-        @article{RoboBrain2.0TechnicalReport,
-        title={RoboBrain 2.0 Technical Report},
-        author={BAAI RoboBrain Team},
-        journal={arXiv preprint arXiv:2507.02029},
-        year={2025}
+    """[RoboBrain 2.0](https://github.com/FlagOpen/RoboBrain2.0) and [RoboBrain2.5](https://github.com/FlagOpen/RoboBrain2.5) models from BAAI; support interactive reasoning with long-horizon planning and closed-loop feedback, spatial perception for precise point and bbox prediction from complex instructions and temporal perception for future trajectory estimation.
+            @article{RoboBrain2.0TechnicalReport,
+            title={RoboBrain 2.0 Technical Report},
+            author={BAAI RoboBrain Team},
+            journal={arXiv preprint arXiv:2507.02029},
+            year={2025}
+        }
+            @article{tan2026robobrain25depthsight,
+      title={RoboBrain 2.5: Depth in Sight, Time in Mind},
+      author={Tan, Huajie and Zhou, Enshen and Li, Zhiyu and Xu, Yijie and Ji, Yuheng and Chen, Xiansheng and Chi, Cheng and Wang, Pengwei and Jia, Huizhu and Ao, Yulong and Cao, Mingyu and Chen, Sixiang and Li, Zhe and Liu, Mengzhen and Wang, Zixiao and Rong, Shanyu and Lyu, Yaoxu and Zhao, Zhongxia and Co, Peterson and Li, Yibo and Han, Yi and Xie, Shaoxuan and Yao, Guocai and Wang, Songjing and Zhang, Leiduo and Yang, Xi and Jiao, Yance and Shi, Donghai and Xie, Kunchang and Nie, Shaokai and Men, Chunlei and Lin, Yonghua and Wang, Zhongyuan and Huang, Tiejun and Zhang, Shanghang},
+      journal={arXiv preprint arXiv:2601.14352},
+      year={2026}
     }
-    :param name: An arbitrary name given to the model.
-    :type name: str
-    :param checkpoint: The name of the pre-trained model's checkpoint. Default is "BAAI/RoboBrain2.0-3B". For available checkpoints consult [RoboBrain2 Model Collection](https://huggingface.co/collections/BAAI/robobrain20-6841eeb1df55c207a4ea0036) on HuggingFace.
-    :type checkpoint: str
-    :param init_timeout: The timeout in seconds for the initialization process. Defaults to None.
-    :type init_timeout: int, optional
+        :param name: An arbitrary name given to the model.
+        :type name: str
+        :param checkpoint: The name of the pre-trained model's checkpoint. Default is "BAAI/RoboBrain2.5-4B". For available checkpoints consult [RoboBrain2 and RoboBrain2.5 Model Collections](https://huggingface.co/collections/BAAI) on HuggingFace or ModelScope.
+        :type checkpoint: str
+        :param init_timeout: The timeout in seconds for the initialization process. Defaults to None.
+        :type init_timeout: int, optional
 
-    Example usage:
-    ```python
-    robobrain = RoboBrain2(name='robobrain', checkpoint="BAAI/RoboBrain2.0-32B")
-    ```
+        Example usage:
+        ```python
+        robobrain = RoboBrain2(name='robobrain', checkpoint="BAAI/RoboBrain2.5-8B-NV")
+        ```
     """
 
-    checkpoint: str = field(default="BAAI/RoboBrain2.0-3B")
+    checkpoint: str = field(default="BAAI/RoboBrain2.5-4B")
 
     def _get_init_params(self) -> Dict:
         """Get init params for model initialization."""

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -247,6 +247,7 @@ class Video(SupportedType):
 
     _ros_type = ROSVideo
     callback = VideoCallback
+    _ui_rate_sampled = True  # lists of continuous frames
 
     @classmethod
     def convert(
@@ -283,6 +284,7 @@ class Detections(SupportedType):
 
     _ros_type = Detections2D
     callback = DetectionsCallback
+    _ui_rate_sampled = True  # camera-rate frames + bbox drawing/JPEG encode
 
     @classmethod
     def convert(
@@ -343,6 +345,7 @@ class DetectionsMultiSource(SupportedType):
 
     _ros_type = Detections2DMultiSource
     callback = DetectionsMultiSourceCallback
+    _ui_rate_sampled = True  # camera-rate frames + bbox drawing/JPEG encode
 
     @classmethod
     def convert(cls, output: List, images: List, **_) -> Detections2DMultiSource:
@@ -371,6 +374,7 @@ class PointsOfInterest(SupportedType):
 
     _ros_type = ROSPointsOfInterest
     callback = PointsOfInterestCallback  # not defined
+    _ui_rate_sampled = True  # camera-rate frames + point drawing/JPEG encode
 
     @classmethod
     def convert(
@@ -525,6 +529,7 @@ class RGBD(SupportedType):
     """
 
     callback = RGBDCallback
+    _ui_rate_sampled = True  # camera-rate RGB-D frames
 
     @classmethod
     def get_ros_type(cls) -> type:

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -108,6 +108,7 @@ __all__ = [
     "Monitor",
     "MemLayer",
     "MapLayer",
+    "PriorMemory",
     "Route",
     "MutuallyExclusiveCallbackGroup",
     "Event",
@@ -830,52 +831,102 @@ def _get_topic_or_action(
     return Topic(**entity)
 
 
-def _get_np_coordinates(
-    pre_defined: List[Union[List, Tuple[np.ndarray, str]]],
-) -> List[Union[List, Tuple[np.ndarray, str]]]:
-    pre_defined_list = []
-    for item in pre_defined:
-        pre_defined_list.append((np.array(item[0]), item[1]))
-    return pre_defined_list
+def _to_position(
+    value: Optional[Union[List[float], Tuple[float, ...]]],
+) -> Optional[Tuple[float, float, float]]:
+    """Normalize a position into an ``(x, y, z)`` float tuple (or ``None``)."""
+    if value is None:
+        return None
+    coords = tuple(float(v) for v in value)
+    if len(coords) != 3:
+        raise ValueError(
+            f"PriorMemory position must have 3 coordinates (x, y, z), got {len(coords)}"
+        )
+    return coords
+
+
+@define(kw_only=True)
+class PriorMemory(BaseAttrs):
+    """A piece of prior knowledge used to seed a ``Memory`` layer at startup,
+    before any live data arrives on the layer's topic.
+
+    :param text: The memory text to store.
+    :type text: str
+    :param position: Optional world-frame ``(x, y, z)`` coordinates in
+        meters. If omitted, the memory is stored at the origin
+        ``(0.0, 0.0, 0.0)``.
+    :type position: Optional[tuple[float, float, float]]
+    :param timestamp: Optional POSIX timestamp in seconds to tag the
+        memory with. If omitted, the component's current time is used
+        when the memory is seeded.
+    :type timestamp: Optional[float]
+
+    Example of usage:
+    ```python
+    PriorMemory(text="charging dock", position=(1.5, 0.0, 0.0))
+    ```
+    """
+
+    text: str = field()
+    position: Optional[Tuple[float, float, float]] = field(
+        default=None, converter=_to_position
+    )
+    timestamp: Optional[float] = field(default=None)
+
+
+def _get_prior_memories(
+    value: List[Union["PriorMemory", Dict]],
+) -> List["PriorMemory"]:
+    """Converter to rebuild ``PriorMemory`` items from dicts."""
+    memories = []
+    for item in value:
+        if isinstance(item, PriorMemory):
+            memories.append(item)
+        elif isinstance(item, dict):
+            memories.append(PriorMemory(**item))
+        else:
+            raise TypeError(
+                "prior_memories items must be a PriorMemory or a dict, got "
+                f"{type(item).__name__}"
+            )
+    return memories
 
 
 @define(kw_only=True)
 class MemLayer(BaseAttrs):
-    """A MemLayer represents a single input layer for a ``Memory`` or
-    ``MapEncoding`` component. It subscribes to a topic whose callback
-    produces a string representation (via ``_get_ui_content``) that can be
-    stored as an observation.
+    """A MemLayer represents a single input layer for a ``Memory`` component.
+    It subscribes to a topic whose callback produces a string representation
+    that is stored as an observation.
 
     :param subscribes_to: The topic that this layer is subscribed to.
     :type subscribes_to: Topic
-    :param temporal_change: Indicates whether the map should store changes over time for the same position. Defaults to False. (``MapEncoding`` only.)
-    :type temporal_change: bool
-    :param resolution_multiple: A positive multiplication factor for the base resolution of the map grid, for fine or coarse graining the map. Defaults to 1. (``MapEncoding`` only.)
-    :type resolution_multiple: int
-    :param pre_defined: An optional list of pre-defined data points in the layer. Each datapoint is a tuple of [position, text], where position is a numpy array of coordinates.
-    :type pre_defined: list[tuple[np.ndarray, str]]
+    :param prior_memories: An optional list of PriorMemory entries
+        used to seed the layer with prior knowledge at startup, before any
+        live data arrives on the topic. Each entry carries the memory text,
+        an optional world-frame ``(x, y, z)`` position, and an optional
+        timestamp.
+    :type prior_memories: list[PriorMemory]
     :param is_internal_state: If True, observations from this layer are
         treated as internal state (interoception) by ``Memory``: they are
         written via ``add_body_state`` and are retrieved through the
         ``body_status`` tool rather than the perception tools. Use this
         for robot-internal signals like battery, temperature, or joint
-        health. Defaults to False. (``Memory`` only.)
+        health. Defaults to False.
     :type is_internal_state: bool
 
     Example of usage:
     ```python
-    my_layer = MemLayer(subscribes_to='my_topic', temporal_change=True)
+    my_layer = MemLayer(
+        subscribes_to='my_topic',
+        prior_memories=[PriorMemory(text="entrance", position=(0.0, 0.0, 0.0))],
+    )
     battery_layer = MemLayer(subscribes_to='battery_state', is_internal_state=True)
     ```
     """
 
     subscribes_to: Topic = field(converter=_get_topic)
-    temporal_change: bool = field(default=False)
-    resolution_multiple: int = field(
-        default=1, validator=base_validators.in_range(min_value=0.1, max_value=10)
-    )
-    pre_defined: List[Union[List, Tuple[np.ndarray, str]]] = field(
-        default=Factory(list), converter=_get_np_coordinates
+    prior_memories: List[PriorMemory] = field(
+        default=Factory(list), converter=_get_prior_memories
     )
     is_internal_state: bool = field(default=False)
 

--- a/agents/ui_elements.py
+++ b/agents/ui_elements.py
@@ -8,14 +8,18 @@ from .ros import (
 from ros_sugar.ui_node.elements import (
     _out_image_element,
     _log_text_element,
-    augment_text_in_logging_card,
+    replace_text_in_logging_card,
 )
 
 
 def _log_streaming_string_element(logging_card, output: str, data_src: str):
-    """Render StreamingString output in the logging card"""
+    """Render StreamingString output in the logging card.
+
+    ``output`` is the full text of the current stream, so the entry text is
+    replaced on each update rather than appended.
+    """
     if getattr(logging_card.children[-1], "id", None) == "streaming-text":
-        return augment_text_in_logging_card(
+        return replace_text_in_logging_card(
             logging_card, output, target_id="streaming-text"
         )
     else:

--- a/examples/complete_agent.py
+++ b/examples/complete_agent.py
@@ -137,7 +137,7 @@ position = Topic(name="odom", msg_type="Odometry")
 
 memory = Memory(
     layers=[
-        MemLayer(subscribes_to=detections_topic, temporal_change=True),
+        MemLayer(subscribes_to=detections_topic),
         MemLayer(subscribes_to=introspection_answer),
     ],
     position=position,

--- a/examples/complete_agent_multiprocessing.py
+++ b/examples/complete_agent_multiprocessing.py
@@ -137,7 +137,7 @@ position = Topic(name="odom", msg_type="Odometry")
 
 memory = Memory(
     layers=[
-        MemLayer(subscribes_to=detections_topic, temporal_change=True),
+        MemLayer(subscribes_to=detections_topic),
         MemLayer(subscribes_to=introspection_answer),
     ],
     position=position,

--- a/examples/go_to_x.py
+++ b/examples/go_to_x.py
@@ -34,7 +34,7 @@ embedding_client = OllamaClient(
 )
 
 memory = Memory(
-    layers=[MemLayer(subscribes_to=detections_topic, temporal_change=True)],
+    layers=[MemLayer(subscribes_to=detections_topic)],
     position=position,
     embedding_client=embedding_client,
     config=MemoryConfig(db_path="/tmp/go_to_x.db"),

--- a/examples/memory_with_cortex.py
+++ b/examples/memory_with_cortex.py
@@ -103,7 +103,7 @@ embedding_model = OllamaModel(
 )
 embedding_client = OllamaClient(embedding_model)
 
-detections_layer = MemLayer(subscribes_to=detections_out, temporal_change=True)
+detections_layer = MemLayer(subscribes_to=detections_out)
 scene_layer = MemLayer(subscribes_to=scene_description)
 
 # Add an interoception layer

--- a/examples/semantic_map.py
+++ b/examples/semantic_map.py
@@ -62,7 +62,7 @@ introspector.add_publisher_preprocessor(introspection_answer, introspection_vali
 
 # -- Memory component --
 # Two perception layers: detections (high temporal change) and scene labels.
-detections_layer = MemLayer(subscribes_to=detections_topic, temporal_change=True)
+detections_layer = MemLayer(subscribes_to=detections_topic)
 scene_layer = MemLayer(subscribes_to=introspection_answer)
 
 # Memory uses real-world coordinates from Odometry directly.

--- a/examples/tool_calling.py
+++ b/examples/tool_calling.py
@@ -33,7 +33,7 @@ embedding_client = OllamaClient(
 )
 
 memory = Memory(
-    layers=[MemLayer(subscribes_to=detections_topic, temporal_change=True)],
+    layers=[MemLayer(subscribes_to=detections_topic)],
     position=position,
     embedding_client=embedding_client,
     config=MemoryConfig(db_path="/tmp/tool_calling.db"),


### PR DESCRIPTION
Companion to automatika-robotics/sugarcoat#56 — adapts EmbodiedAgents to the new JSON/WebSocket API and stream-transport model, and adds prior-knowledge seeding for memory layers.

> **Dependency**: requires sugarcoat `feature/ui_endpoints` (sugarcoat#56). `agents/ui_elements.py` imports the new `replace_text_in_logging_card` helper, and the stream-mode attribute is only honored by the new API.

## UI/API adaptation

**Heavy streaming types are rate-sampled by default.** Sugarcoat's API now picks each output topic's transport from `SupportedType._ui_rate_sampled`: rate-sampled for continuous high-bandwidth types, per-message event push for everything else. `Detections`, `DetectionsMultiSource`, `PointsOfInterest`, `RGBD` and `Video` are camera-rate image streams with expensive UI conversions (bbox/point drawing + JPEG encoding), so they now declare `_ui_rate_sampled = True` — matching sugarcoat's `Image`/`CompressedImage`/`OccupancyGrid`. Clients can still override per connection with `?rate=<hz>` / `?rate=0`.

**`StreamingString` accumulates the current stream.** The UI/API now delivers output content by waking on each message and reading the latest value. For token streams, delta chunks could coalesce under load and drop tokens. `StreamingStringCallback` now accumulates the current stream's full text (reset on each new stream, using the `done` flag):

- `_get_ui_content()` returns the full text so far → latest-value readers (browser log, `WS /api/outputs/{name}`) are lossless by construction, and mid-stream consumers see the current stream from its start.
- `_get_output()` is unchanged — components consuming `StreamingString` inputs (TTS, memory, MLLM) keep the chunk contract.
- `_log_streaming_string_element` now replaces the streaming entry's text instead of appending (the payload is the full prefix). The text still renders piecemeal, token by token.

## Prior memories for MemLayers

- New `PriorMemory` primitive: a piece of prior knowledge (`text`, optional world-frame `position`, optional `timestamp`) used to seed a layer before any live data arrives.
- `MemLayer`/`MapLayer` take `prior_memories` (replacing `pre_defined`); the `Memory` component seeds them into eMEM at startup (`_seed_prior_memories`), routing internal-state layers through `add_body_state` and spatial layers through `add`.
- Removed redundant layer attributes `temporal_change` and `resolution_multiple`; `MapEncoding` updated accordingly. Examples updated.

## Breaking changes

- `MemLayer`/`MapLayer`: `pre_defined` → `prior_memories` (now `PriorMemory` items); `temporal_change` and `resolution_multiple` removed.
- `StreamingStringCallback._get_ui_content()` returns the accumulated stream text rather than the latest chunk (UI consumers only; `_get_output()` unchanged).
