### PR TITLE
(feature) Updates VLA stack for latest LeRobot policies and modernizes the local models stack

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install pip
+      - name: Install pip and optional ROS message packages
         run: |
           apt-get update
-          apt-get install -y python3-pip
+          apt-get install -y python3-pip \
+              ros-${{ matrix.ros_distro }}-control-msgs \
+              ros-${{ matrix.ros_distro }}-realsense2-camera-msgs
 
       - name: Build workspace
         run: |

--- a/agents/callbacks.py
+++ b/agents/callbacks.py
@@ -149,14 +149,28 @@ class RGBDCallback(GenericCallback):
                 "RGBD message cannot be read from a fixed file"
             )
 
-    def _get_output(self, get_depth=False, **_) -> Optional[np.ndarray]:
+    def _get_output(
+        self, get_depth=False, depth_only=False, **_
+    ) -> Optional[np.ndarray]:
         """
         Gets RGBD image as a numpy array.
-        :returns:   Image and Depth as nd_array
+        Returns the RGB part by default. With `get_depth`, returns RGB and
+        depth concatenated as (H, W, 4). With `depth_only`, returns just the
+        depth part as (H, W, 1).
+        :returns:   Image and/or Depth as nd_array
         :rtype:     np.ndarray
         """
         if not self.msg or not self.msg.rgb:
             return None
+
+        if depth_only:
+            if not self.msg.depth:
+                return None
+            if not getattr(self, "depth_encoding", None):
+                self.depth_encoding = process_encoding(self.msg.depth.encoding)
+            depth = image_pre_processing(self.msg.depth, *self.depth_encoding)
+            # Ensure depth has shape (H, W, 1)
+            return np.expand_dims(depth, axis=-1)
 
         # pre-process and reshape the RGB image
         if not getattr(self, "rgb_encoding", None):

--- a/agents/clients/__init__.py
+++ b/agents/clients/__init__.py
@@ -36,7 +36,7 @@ Some clients might need additional dependacies, which are provided in the follow
 
 * - **LeRobot**
   - [LeRobotClient](agents.clients.lerobot.LeRobotClient)
-  - A GRPC based asynchronous client for vision-language-action (VLA) policies served on LeRobot Policy Server. Supports various robot action policies available in LeRobot package by HuggingFace. It can be invoked with the generic wrapper [LeRobotPolicy](agents.models.md#classes).
+  - A GRPC based asynchronous client for vision-language-action (VLA) policies served on LeRobot Policy Server. Supports all robot action policies servable by the LeRobot Async Policy Server (LeRobot >= 0.6.0), including SmolVLA, Pi0/Pi0.5, NVIDIA GR00T N1.7, ACT and Diffusion policies. It can be invoked with the generic wrapper [LeRobotPolicy](agents.models.md#classes).
     Requires grpc and torch (at least the CPU version):<br/>
     `pip install grpcio`<br/>
     `pip install torch --index-url https://download.pytorch.org/whl/cpu`

--- a/agents/clients/lerobot.py
+++ b/agents/clients/lerobot.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import Dict, Union
+from typing import Dict, Union, get_args
 import time
 import pickle
 import threading
@@ -13,7 +13,12 @@ from .lerobot_transport.utils import (
 
 __all__ = ["LeRobotClient"]
 
-LEROBOT_MIN_VERSION = "0.4.2"
+LEROBOT_MIN_VERSION = "0.6.0"
+
+# Policy types accepted by the LeRobot Async Policy Server (its SUPPORTED_POLICIES).
+SERVER_SUPPORTED_POLICIES = list(
+    get_args(LeRobotPolicy.__annotations__["policy_type"])
+)
 
 
 class LeRobotClient(ModelClient):
@@ -106,6 +111,7 @@ class LeRobotClient(ModelClient):
             lerobot_features=self.model_init_params["features"],
             actions_per_chunk=self.model_init_params["actions_per_chunk"],
             device=self.model_init_params["device"],
+            rename_map=self.model_init_params.get("rename_map") or {},
         )
 
         try:
@@ -114,7 +120,7 @@ class LeRobotClient(ModelClient):
 
         except Exception as e:
             self.logger.error(
-                f"Failed to initialize model {self.model_init_params['checkpoint']} on LeRobot Policy Server, please ensure that the checkpoint name or path is correct. Received the following error: {e}"
+                f"Failed to initialize model {self.model_init_params['checkpoint']} on LeRobot Policy Server, please ensure that the checkpoint name or path is correct and that the policy type '{self.model_init_params['policy_type']}' is one supported by the server: {SERVER_SUPPORTED_POLICIES}. Received the following error: {e}"
             )
             raise
         self.logger.info(

--- a/agents/components/__init__.py
+++ b/agents/components/__init__.py
@@ -14,7 +14,7 @@ A Component is the main execution unit in _EmbodiedAgents_ and in essence each c
   - Leverages multimodal LLMs (e.g., Llava) for understanding and processing both text and image data. Inherits all functionalities of the LLM component.
 
 * - **[VLA](agents.components.vla.md)**
-  - Provides an interface to utilize Vision Language Action (VLA) models for manipulation and control tasks. It can use VLA Policies (such as SmolVLA, Pi0 etc.) served with HuggingFace LeRobot Async Policy Server and publish them to common topic formats in MoveIt Servo and ROS2 Control.
+  - Provides an interface to utilize Vision Language Action (VLA) models for manipulation and control tasks. It can use VLA Policies (such as SmolVLA, Pi0/Pi0.5, NVIDIA GR00T N1.7 etc.) served with HuggingFace LeRobot Async Policy Server and publish them to common topic formats in MoveIt Servo and ROS2 Control.
 
 * - **[SpeechToText](agents.components.speechtotext.md)**
   - Converts spoken audio into text using speech-to-text models (e.g., Whisper). Suitable for voice command recognition. It also implements small on-board models for Voice Activity Detection (VAD) and Wakeword recognition, using audio capture devices onboard the robot.

--- a/agents/components/llm.py
+++ b/agents/components/llm.py
@@ -188,6 +188,7 @@ class LLM(ModelComponent):
         if self.config.stream:
             # initialize think block state for streaming
             self._in_think_block: bool = False
+            self._swallow_stream_ws: bool = False
             # initialize result buffers
             self.result_partial: List = []
             self.result_complete: List = []
@@ -286,7 +287,14 @@ class LLM(ModelComponent):
     def _strip_think_tokens(self, text: str) -> str:
         """Strip <think>...</think> blocks from model output."""
         if self.config.strip_think_tokens:
-            return strip_think_tokens(text)
+            stripped = strip_think_tokens(text)
+            if not stripped and "<think>" in text:
+                self.get_logger().warning(
+                    "Model output was an unterminated <think> block — generation"
+                    " likely hit max_new_tokens before an answer was produced."
+                    " Increase max_new_tokens or disable thinking in the model."
+                )
+            return stripped
         return text
 
     def _deploy_local_model(self):
@@ -508,9 +516,16 @@ class LLM(ModelComponent):
                 return
             if "</think>" in token:
                 self._in_think_block = False
+                # swallow the whitespace models emit after the think block
+                self._swallow_stream_ws = True
                 return
             if self._in_think_block:
                 return
+            if self._swallow_stream_ws:
+                token = token.lstrip()
+                if not token:
+                    return
+                self._swallow_stream_ws = False
         if self.config.break_character:
             self.result_partial.append(token)
             if self.config.break_character in token:
@@ -534,6 +549,7 @@ class LLM(ModelComponent):
         appending the complete message to the message history.
         """
         self._in_think_block = False
+        self._swallow_stream_ws = False
         # Send remaining result after break character or termination if any
         if self.config.break_character:
             if self.result_partial:

--- a/agents/components/llm.py
+++ b/agents/components/llm.py
@@ -548,6 +548,12 @@ class LLM(ModelComponent):
         Finalizes the stream by publishing any remaining partial results and
         appending the complete message to the message history.
         """
+        if self._in_think_block:
+            self.get_logger().warning(
+                "Model output was an unterminated <think> block — generation"
+                " likely hit max_new_tokens before an answer was produced."
+                " Increase max_new_tokens or disable thinking in the model."
+            )
         self._in_think_block = False
         self._swallow_stream_ws = False
         # Send remaining result after break character or termination if any

--- a/agents/components/llm.py
+++ b/agents/components/llm.py
@@ -587,8 +587,9 @@ class LLM(ModelComponent):
 
     def __handle_streaming_generator(self, result: MutableMapping) -> Optional[List]:
         """Handle streaming output"""
+        stream = result["output"]
         try:
-            for token in result["output"]:
+            for token in stream:
                 # Handle ollama client result format
                 if isinstance(self.model_client, OllamaClient):
                     token = token["message"]["content"]
@@ -603,6 +604,11 @@ class LLM(ModelComponent):
             self.get_logger().error(str(e))
             # raise a fallback trigger via health status
             self.health_status.set_fail_algorithm()
+        finally:
+            # Finalize the generator even when iteration was abandoned by an
+            # exception (so the iterator doesnt wait for garbage collection)
+            if close := getattr(stream, "close", None):
+                close()
 
     def _execution_step(self, *args, **kwargs):
         """_execution_step.

--- a/agents/components/llm.py
+++ b/agents/components/llm.py
@@ -299,6 +299,7 @@ class LLM(ModelComponent):
             model_path=self.config.local_model_path,
             device=self.config.device_local_model,
             ncpu=self.config.ncpu_local_model,
+            model_options=self.config.local_model_options,
         )
 
     def _handle_rag_query(self, query: str) -> Optional[str]:

--- a/agents/components/mllm.py
+++ b/agents/components/mllm.py
@@ -160,6 +160,7 @@ class MLLM(LLM):
             model_path=self.config.local_model_path,
             device=self.config.device_local_model,
             ncpu=self.config.ncpu_local_model,
+            model_options=self.config.local_model_options,
         )
 
     def _create_input(self, *_, **kwargs) -> Optional[Dict[str, Any]]:

--- a/agents/components/semantic_router.py
+++ b/agents/components/semantic_router.py
@@ -134,9 +134,13 @@ class SemanticRouter(LLM):
                 component_config.stream = False
                 component_config.enable_rag = False
                 component_config.chat_history = False
+                component_config.strip_think_tokens = True
             else:
                 component_config = LLMConfig(
-                    stream=False, enable_rag=False, chat_history=False
+                    stream=False,
+                    enable_rag=False,
+                    chat_history=False,
+                    strip_think_tokens=True,
                 )
         elif db_client:
             self.routing_mode = RouterMode.VECTOR
@@ -151,6 +155,7 @@ class SemanticRouter(LLM):
             component_config.stream = False
             component_config.enable_rag = False
             component_config.chat_history = False
+            component_config.strip_think_tokens = True
         else:
             raise ValueError(
                 "A semantic router must be initiated with a DB Client (vector mode), a model client with an LLM model or an LLMConfig with enable_local_model=True (agentic mode)."
@@ -290,6 +295,9 @@ class SemanticRouter(LLM):
         if self.routing_mode is RouterMode.LLM:
             self.get_logger().info("SemanticRouter starting in LLM (Agentic) Mode.")
             self._setup_llm_routes(self.routes_dict)
+            # deploy local LLM when routing agentically without a model client
+            if not self.model_client and self.config.enable_local_model:
+                self._deploy_local_model()
         else:
             self.get_logger().info(
                 "SemanticRouter starting in VECTOR (Embedding) Mode."

--- a/agents/components/speechtotext.py
+++ b/agents/components/speechtotext.py
@@ -12,8 +12,8 @@ from ..ros import Audio, String, Topic
 from ..utils import (
     validate_func_args,
     VADStatus,
-    WakeWordStatus,
     load_model,
+    load_model_archive,
     load_model_repo,
 )
 from .model_component import ModelComponent
@@ -160,23 +160,24 @@ class SpeechToText(ModelComponent):
                 )
             )
             if self.config.enable_wakeword:
-                from ..utils.voice import WakeWord, AudioFeatures
+                from ..utils.voice import WakeWordSpotter
 
-                self.audio_features = AudioFeatures(
-                    melspectogram_model_path=load_model(
-                        "melspec", self.config.melspectrogram_model_path
-                    ),
-                    embedding_model_path=load_model(
-                        "voice_embeddings", self.config.embedding_model_path
-                    ),
-                    ncpu=self.config.ncpu_wakeword,
-                    device=self.config.device_wakeword,
+                wakeword_model_path = (
+                    load_model_archive("wakeword_kws", self.config.wakeword_model_path)
+                    if self.config.wakeword_model_path.startswith((
+                        "http://",
+                        "https://",
+                    ))
+                    else load_model_repo(
+                        "wakeword_kws", self.config.wakeword_model_path
+                    )
                 )
-                self.wake_word = WakeWord(
-                    model_path=load_model(
-                        "hey_jarvis", self.config.wakeword_model_path
-                    ),
+
+                self.wake_word = WakeWordSpotter(
+                    model_path=wakeword_model_path,
+                    phrase=self.config.wakeword_phrase,
                     threshold=self.config.wakeword_threshold,
+                    sample_rate=self.config._sample_rate,
                     ncpu=self.config.ncpu_wakeword,
                     device=self.config.device_wakeword,
                 )
@@ -259,8 +260,11 @@ class SpeechToText(ModelComponent):
 
         # if wake word is enabled then store speech when its triggered
         if self.config.enable_wakeword:
-            # create audio embeddings for wakeword classifier
-            self.audio_features(np_frames)
+            # feed the keyword spotter until the wake phrase is detected
+            if not self.wake_word_triggered:
+                if detected := self.wake_word.process(np_frames):
+                    self.get_logger().debug(f"Wake phrase detected: {detected}")
+                    self.wake_word_triggered = True
             if self.wake_word_triggered:
                 self.speech_buffer.append(indata)
 
@@ -325,26 +329,16 @@ class SpeechToText(ModelComponent):
     def __process_vad_output(self, vad_output: VADStatus):
         """Process VAD Status"""
         if vad_output is VADStatus.START:
-            # When someone starts speaking, check for wakeword if enabled
             self.get_logger().debug("Speech started")
-            if self.config.enable_wakeword:
-                self.wake_word(
-                    self.audio_features.get_embeddings(self.wake_word.model_input)
-                )
         elif vad_output is VADStatus.ONGOING:
             self.get_logger().debug("Speech ongoing")
-            if self.config.enable_wakeword:
-                wake_status = self.wake_word(
-                    self.audio_features.get_embeddings(self.wake_word.model_input)
-                )
-                if wake_status is WakeWordStatus.END:
-                    self.get_logger().debug("Wakeword ended")
-                    self.wake_word_triggered = True
         elif vad_output is VADStatus.END:
             # Send audio when speech finishes
             self.get_logger().debug("Speech ended")
             if self.config.enable_wakeword:
                 self.wake_word_triggered = False
+                # fresh spotter stream so stale audio does not linger
+                self.wake_word.reset()
             # Only send to STT if there is buffered speech
             if self.speech_buffer:
                 if self.config.stream:

--- a/agents/components/speechtotext.py
+++ b/agents/components/speechtotext.py
@@ -222,6 +222,7 @@ class SpeechToText(ModelComponent):
             ncpu=self.config.ncpu_local_model,
             sample_rate=self.config._sample_rate,
             language=self.config.language or "en",
+            model_options=self.config.local_model_options,
         )
         # Local STT does not support streaming
         if self.config.stream:

--- a/agents/components/texttospeech.py
+++ b/agents/components/texttospeech.py
@@ -1,6 +1,7 @@
 import queue
 import socket
 import threading
+from collections.abc import Iterator
 from io import BytesIO
 from typing import Any, Union, Optional, List, Dict
 import base64
@@ -146,14 +147,11 @@ class TextToSpeech(ModelComponent):
             model_path=load_model_repo("local_tts", self.config.local_model_path),
             device=self.config.device_local_model,
             ncpu=self.config.ncpu_local_model,
+            speaker_id=self.config.speaker_id,
+            stream=self.config.stream,
+            model_options=self.config.local_model_options,
         )
-        # Local TTS does not support streaming
-        if self.config.stream:
-            self.get_logger().warning(
-                "Local TTS model does not support streaming. Setting stream to False."
-            )
-            self.config.stream = False
-            self.inference_params = self.config.get_inference_params()
+        self.inference_params = self.config.get_inference_params()
 
     def __get_audio_bytes(self, chunk: Union[bytes, str]) -> bytes:
         """Get audio bytes"""
@@ -489,11 +487,19 @@ class TextToSpeech(ModelComponent):
         # conduct inference
         result = self._call_inference(inference_input)
         if result:
-            if self.config.play_on_device:
-                self._play(result["output"])
+            output = result["output"]
+            # handle streaming local model generator of audio chunks
+            if isinstance(output, Iterator):
+                for chunk in output:
+                    if self.config.play_on_device:
+                        self._play(chunk)
+                    self._publish({"output": chunk})
+            else:
+                if self.config.play_on_device:
+                    self._play(output)
 
-            # publish result
-            self._publish(result)
+                # publish result
+                self._publish(result)
 
     def _warmup(self):
         """Warm up and stat check"""
@@ -503,17 +509,23 @@ class TextToSpeech(ModelComponent):
             **self.inference_params,
         }
 
+        def _drain(result):
+            # Consume streaming model generator
+            if result and isinstance(result.get("output"), Iterator):
+                for _ in result["output"]:
+                    pass
+
         # Run inference once to warm up and once to measure time
         if self.model_client:
             self.model_client.inference(inference_input)
         elif hasattr(self, "local_model"):
-            self.local_model(inference_input)
+            _drain(self.local_model(inference_input))
 
         start_time = time.time()
         if self.model_client:
             self.model_client.inference(inference_input)
         elif hasattr(self, "local_model"):
-            self.local_model(inference_input)
+            _drain(self.local_model(inference_input))
         elapsed_time = time.time() - start_time
 
         self.get_logger().warning(f"Approximate Inference time: {elapsed_time} seconds")

--- a/agents/components/vla.py
+++ b/agents/components/vla.py
@@ -783,8 +783,8 @@ class VLA(ModelComponent):
             self.get_logger().error(
                 "Inputs were not received within the specified timeout period, aborting action."
             )
-            self._action_cleanup()
             with self._main_goal_lock:
+                self._action_cleanup()
                 goal_handle.abort()
                 return task_result
 
@@ -793,9 +793,18 @@ class VLA(ModelComponent):
                 start_time = time.perf_counter()
                 # Check if goal is canceled
                 if not goal_handle.is_active or goal_handle.is_cancel_requested:
-                    self._action_cleanup()
-                    self.get_logger().info("Goal Canceled")
-                    return task_result
+                    with self._main_goal_lock:
+                        self._action_cleanup()
+                        if goal_handle.is_cancel_requested:
+                            goal_handle.canceled()
+                            self.get_logger().info("Goal canceled by client")
+                        else:
+                            # an inactive goal was already transitioned elsewhere
+                            # nothing to transition
+                            self.get_logger().info(
+                                "Goal already terminated (preempted by a new goal), stopping execution"
+                            )
+                        return task_result
 
                 # Get new observations from inputs
                 model_observations = self._create_input(task)

--- a/agents/components/vla.py
+++ b/agents/components/vla.py
@@ -27,9 +27,12 @@ from ..ros import (
     VisionLanguageAction,
     run_external_processor,
 )
+from ..callbacks import RGBDCallback
 from ..utils import validate_func_args, find_missing_values
 from ..utils.actions import (
+    AGGREGATE_FUNCTIONS,
     JointsData,
+    _as_depth_frame,
     parse_urdf_joints,
     check_joint_limits,
     cap_actions_with_limits,
@@ -41,7 +44,64 @@ from .model_component import ModelComponent
 
 
 class VLA(ModelComponent):
-    """Vision-Language-Agent (VLA) Component."""
+    """
+    This component utilizes Vision-Language-Action (VLA) policies served on the LeRobot Async Policy Server (e.g. SmolVLA, Pi0/Pi0.5, NVIDIA GR00T N1.7, ACT, Diffusion) for robot manipulation and control tasks.
+
+    The component runs as a ROS2 Action Server exposing the `<component_name>/manipulate_with_vla` action which takes a natural language task description as its goal. While a goal is active, the component continuously streams observations (mapped joint states and camera images) to the policy server at `observation_sending_rate` and publishes the received action chunks as joint commands at `action_sending_rate`. Overlapping action chunks from consecutive inferences are merged using the aggregation strategy set in the config (or a custom callable set with `set_aggregation_function`). Goal termination is configured with `set_termination_trigger` (after a number of timesteps, on a key press, or on an event).
+
+    :param inputs: The input topics for the VLA component.
+        This should be a list of Topic objects, containing exactly one JointState topic and at least one Image (or RGBD) topic. The camera topics should be mapped to the dataset camera names in `camera_inputs_map` of the config.
+    :type inputs: list[Topic]
+    :param outputs: The output topics for the VLA component.
+        This should be a list of Topic objects. JointState, JointTrajectory and JointJog types are handled automatically, covering common input formats for MoveIt Servo and ROS2 Control.
+    :type outputs: list[Topic]
+    :param model_client: The model client for the VLA component.
+        This must be an instance of LeRobotClient, connected to a running LeRobot Async Policy Server which serves the policy defined in a LeRobotPolicy model.
+    :type model_client: LeRobotClient
+    :param config: The configuration for the VLA component.
+        This should be an instance of VLAConfig. `joint_names_map` and `camera_inputs_map` are required to map the dataset feature names to the robot's joints and camera topics.
+    :type config: VLAConfig
+    :param component_name: The name of the VLA component.
+        This should be a string.
+    :type component_name: str
+
+    Example usage:
+    ```python
+    joint_states = Topic(name="joint_states", msg_type="JointState")
+    camera = Topic(name="camera/image_raw", msg_type="Image")
+    joint_cmd = Topic(name="joint_cmd", msg_type="JointState")
+
+    policy = LeRobotPolicy(
+        name="pick_policy",
+        checkpoint="my_hf_user/smolvla_finetuned",
+        policy_type="smolvla",
+        dataset_info_file="https://huggingface.co/datasets/my_hf_user/my_dataset/resolve/main/meta/info.json",
+    )
+    model_client = LeRobotClient(model=policy, host="127.0.0.1", port=8080)
+
+    config = VLAConfig(
+        joint_names_map={
+            "shoulder_pan.pos": "Rotation",
+            "elbow_flex.pos": "Elbow",
+        },
+        camera_inputs_map={"front": camera},
+        robot_urdf_file="./my_robot.urdf",
+    )
+    vla_component = VLA(
+        inputs=[joint_states, camera],
+        outputs=[joint_cmd],
+        model_client=model_client,
+        config=config,
+        component_name="vla",
+    )
+    vla_component.set_termination_trigger(mode="timesteps", max_timesteps=200)
+    ```
+
+    A task can then be sent to the running component as a ROS2 action goal, e.g. from the command line:
+    ```shell
+    ros2 action send_goal /vla/manipulate_with_vla automatika_embodied_agents/action/VisionLanguageAction "{task: 'pick up the orange'}"
+    ```
+    """
 
     @validate_func_args
     def __init__(
@@ -141,7 +201,22 @@ class VLA(ModelComponent):
                 "Could not find a topic of type JointState. VLA component needs at least one topic of type JointState as input."
             )
 
+        # Record expected channels per camera from the dataset features.
+        # Single channel features (H, W, 1) are treated as depth cameras
+        features = self.model_client.model_init_params.get("features") or {}
+        self._camera_channels: Dict[str, int] = {}
+        for cam_key in self.config.camera_inputs_map:
+            feature = features.get(f"observation.images.{cam_key}") or {}
+            shape = feature.get("shape") or ()
+            self._camera_channels[cam_key] = (
+                int(shape[-1]) if len(shape) == 3 else 3
+            )
+
+        # Resolve the aggregation preset from config
+        self._aggregator_function = AGGREGATE_FUNCTIONS[self.config.aggregate_fn_name]
+
         # Assign external aggregator function in case its provided
+        # (takes precedence over the config preset)
         if agg_fun := self._external_processors.get("aggregator_function", None):
             # Get the first element of the tuple and the only function in that list
             self._aggregator_function = partial(
@@ -243,6 +318,11 @@ class VLA(ModelComponent):
                 self.config.camera_inputs_map,
                 prefix="observation",
                 image_shape=(480, 640, 3),
+            )
+            # Refresh the init params captured at client construction, so the
+            # auto-generated spec reaches the policy server.
+            self.model_client.model_init_params = (
+                self.model_client._model._get_init_params()
             )
             logger.warning(
                 "You have not provided a dataset file for the model. Feature specification are required for initializing the policy on LeRobot Policy Server. We are going to auto-generate a feature spec from `joint_names_map` and `camera_inputs_map` that you provided. Please make sure their keys correspond to the names of features and actions used when training the model. Policy init might fail."
@@ -418,12 +498,22 @@ class VLA(ModelComponent):
         # Get images
         images = {}
         for key, value in self.config.camera_inputs_map.items():
-            img_out = self.callbacks[value["name"]].get_output(clear_last=True)
+            # Camera map values are dicts after config serialization and
+            # Topic objects when launched in-process
+            topic_name = value["name"] if isinstance(value, dict) else value.name
+            callback = self.callbacks[topic_name]
+            expects_depth = self._camera_channels.get(key) == 1
+            if expects_depth and isinstance(callback, RGBDCallback):
+                img_out = callback.get_output(clear_last=True, depth_only=True)
+            else:
+                img_out = callback.get_output(clear_last=True)
             if img_out is None:
                 self.get_logger().warning(
-                    f"Did not receive an image for topic: {value['name']}, not sending input for inference"
+                    f"Did not receive an image for topic: {topic_name}, not sending input for inference"
                 )
                 return
+            if expects_depth:
+                img_out = _as_depth_frame(img_out)
             images[key] = img_out
 
         # Combine state, images and task

--- a/agents/components/vla.py
+++ b/agents/components/vla.py
@@ -34,6 +34,7 @@ from ..utils.actions import (
     JointsData,
     _as_depth_frame,
     parse_urdf_joints,
+    convert_joint_limits_units,
     check_joint_limits,
     cap_actions_with_limits,
     create_observation_spec,
@@ -394,6 +395,20 @@ class VLA(ModelComponent):
                     f"Your 'joint_names_map' includes robot joint names not found in the URDF. "
                     f"Missing: {missing_in_urdf}. Available in URDF: {list(limits.keys())}"
                 )
+
+            # URDF <limit> values are radians; convert them into the unit
+            # space of the policy's actions if the config says so
+            limits = convert_joint_limits_units(limits, self.config.policy_action_units)
+            if self.config.policy_action_units == "radians":
+                logger.info(
+                    "URDF joint limits used as radians (policy_action_units='radians'). "
+                    "If your policy outputs normalized motor positions (e.g. LeRobot "
+                    "SO-100/101 datasets), set policy_action_units='normalized'."
+                )
+
+            # Manual config limits override URDF-derived ones per joint
+            if self.config.joint_limits:
+                limits = {**limits, **self.config.joint_limits}
             return limits
 
         # Fallback to config limits
@@ -553,6 +568,37 @@ class VLA(ModelComponent):
             if self.robot_joints_limits
             else action_to_pub_data
         )
+
+        # NOTE: Unit mismatch heuristic: if most early actions are getting capped,
+        # the limits are almost certainly in a different unit space than the
+        # policy's actions. Issue a warning once.
+        if self.robot_joints_limits and not getattr(
+            self, "_cap_mismatch_warned", False
+        ):
+            self._cap_actions_seen = getattr(self, "_cap_actions_seen", 0) + len(
+                np.atleast_1d(safe_action)
+            )
+            self._cap_actions_capped = getattr(self, "_cap_actions_capped", 0) + int(
+                np.sum(
+                    ~np.isclose(
+                        np.asarray(safe_action, dtype=np.float64),
+                        np.asarray(action_to_pub_data, dtype=np.float64),
+                    )
+                )
+            )
+            if self._cap_actions_seen >= 100:
+                capped_frac = self._cap_actions_capped / self._cap_actions_seen
+                if capped_frac > 0.5:
+                    self.get_logger().warning(
+                        f"{capped_frac:.0%} of the first {self._cap_actions_seen} action "
+                        "values were capped by joint limits — this usually means the "
+                        "limits and the policy's actions are in different unit spaces. "
+                        "URDF limits are radians; if your policy outputs normalized "
+                        "motor positions (e.g. LeRobot SO-100/101 datasets), set "
+                        "policy_action_units='normalized' in VLAConfig or provide "
+                        "'joint_limits' manually in the policy's units."
+                    )
+                self._cap_mismatch_warned = True
 
         # TODO: Add smoothing for bigger deltas between new action and currect state
 

--- a/agents/components/vla.py
+++ b/agents/components/vla.py
@@ -550,10 +550,12 @@ class VLA(ModelComponent):
             else:
                 return
 
-        # Create publishing action
+        # Create publishing action. The point should be reached within one
+        # action tick
         action_data = JointsData(
             joints_names=self._dataset_sorted_joint_names
             or list(self.config.joint_names_map.values()),
+            duration=1 / self.config.action_sending_rate,
         )
 
         # Cap actions within limits

--- a/agents/components/vla.py
+++ b/agents/components/vla.py
@@ -517,9 +517,9 @@ class VLA(ModelComponent):
             callback = self.callbacks[topic_name]
             expects_depth = self._camera_channels.get(key) == 1
             if expects_depth and isinstance(callback, RGBDCallback):
-                img_out = callback.get_output(clear_last=True, depth_only=True)
+                img_out = callback.get_output(depth_only=True)
             else:
-                img_out = callback.get_output(clear_last=True)
+                img_out = callback.get_output()
             if img_out is None:
                 self.get_logger().warning(
                     f"Did not receive an image for topic: {topic_name}, not sending input for inference"

--- a/agents/components/vla.py
+++ b/agents/components/vla.py
@@ -715,6 +715,11 @@ class VLA(ModelComponent):
         # Clear the action queue
         self._actions_received.queue.clear()
 
+        # Reset per-goal state at goal START
+        with self._last_executed_timestep_lock:
+            self._last_executed_timestep = -1
+        self._task_completed = False
+
         # Get request
         task: str = goal_handle.request.task
 
@@ -828,6 +833,12 @@ class VLA(ModelComponent):
             with self._main_goal_lock:
                 self._action_cleanup()
                 goal_handle.succeed()
+        else:
+            # Loop exited without success (e.g. timestep cap exceeded in
+            # event/keyboard mode). Clean up and abort explicitly.
+            with self._main_goal_lock:
+                self._action_cleanup()
+                goal_handle.abort()
 
         return task_result
 

--- a/agents/components/vla.py
+++ b/agents/components/vla.py
@@ -31,8 +31,10 @@ from ..callbacks import RGBDCallback
 from ..utils import validate_func_args, find_missing_values
 from ..utils.actions import (
     AGGREGATE_FUNCTIONS,
+    OBSERVATION_PREFIX,
     JointsData,
     _as_depth_frame,
+    resolve_feature_channels,
     parse_urdf_joints,
     convert_joint_limits_units,
     check_joint_limits,
@@ -203,13 +205,22 @@ class VLA(ModelComponent):
             )
 
         # Record expected channels per camera from the dataset features.
-        # Single channel features (H, W, 1) are treated as depth cameras
+        # Single channel features are treated as depth cameras
         features = self.model_client.model_init_params.get("features") or {}
         self._camera_channels: Dict[str, int] = {}
         for cam_key in self.config.camera_inputs_map:
-            feature = features.get(f"observation.images.{cam_key}") or {}
-            shape = feature.get("shape") or ()
-            self._camera_channels[cam_key] = int(shape[-1]) if len(shape) == 3 else 3
+            feature = features.get(f"{OBSERVATION_PREFIX}.images.{cam_key}") or {}
+            channels = resolve_feature_channels(feature)
+            if channels not in (1, 3, 4):
+                self.get_logger().warning(
+                    f"Could not identify the channel dimension of camera "
+                    f"'{cam_key}' from its dataset feature (shape "
+                    f"{feature.get('shape')}, names {feature.get('names')}) — "
+                    "treating it as a 3-channel RGB camera. If it is a depth "
+                    "camera, fix its feature entry in the dataset's info.json."
+                )
+                channels = 3
+            self._camera_channels[cam_key] = channels
 
         # Resolve the aggregation preset from config
         self._aggregator_function = AGGREGATE_FUNCTIONS[self.config.aggregate_fn_name]
@@ -315,7 +326,7 @@ class VLA(ModelComponent):
             self.model_client._model._features = create_observation_spec(
                 self.config.joint_names_map,
                 self.config.camera_inputs_map,
-                prefix="observation",
+                prefix=OBSERVATION_PREFIX,
                 image_shape=(480, 640, 3),
             )
             # Refresh the init params captured at client construction, so the
@@ -367,7 +378,7 @@ class VLA(ModelComponent):
         # TODO:: Handle partially available image keys with error logging
         # Remove LeRobot specific prefix in case it has been added by the user
         self.config.camera_inputs_map = {
-            k.removeprefix("observation.images."): v
+            k.removeprefix(f"{OBSERVATION_PREFIX}.images."): v
             for k, v in self.config.camera_inputs_map.items()
         }
 

--- a/agents/components/vla.py
+++ b/agents/components/vla.py
@@ -208,9 +208,7 @@ class VLA(ModelComponent):
         for cam_key in self.config.camera_inputs_map:
             feature = features.get(f"observation.images.{cam_key}") or {}
             shape = feature.get("shape") or ()
-            self._camera_channels[cam_key] = (
-                int(shape[-1]) if len(shape) == 3 else 3
-            )
+            self._camera_channels[cam_key] = int(shape[-1]) if len(shape) == 3 else 3
 
         # Resolve the aggregation preset from config
         self._aggregator_function = AGGREGATE_FUNCTIONS[self.config.aggregate_fn_name]
@@ -283,7 +281,7 @@ class VLA(ModelComponent):
                     "A stop_event must be provided when setting the termination mode to `event`"
                 )
             get_logger(self.node_name).info(
-                f"Action will terminate on {stop_event.name} event or after {max_timesteps}"
+                f"Action will terminate on {stop_event} or after {max_timesteps} timesteps"
             )
             self.config._termination_timesteps = max_timesteps
             self._add_event_action_pair(stop_event, Action(self.signal_done))

--- a/agents/components/vla.py
+++ b/agents/components/vla.py
@@ -828,3 +828,7 @@ class VLA(ModelComponent):
         """Warm up and stat check"""
         # TODO: implement warmup
         pass
+
+    def _handle_websocket_streaming(self):
+        """Not used -- VLA streams actions through the LeRobot client."""
+        pass

--- a/agents/config.py
+++ b/agents/config.py
@@ -659,14 +659,16 @@ class SpeechToTextConfig(ModelComponentConfig):
     --
     Local Model
     --
-    :param enable_local_model: Whether to enable a local STT model via ``sherpa-onnx`` (Whisper tiny.en by default), allowing the component to run without a remote model client. Requires the ``sherpa-onnx`` pip package. Default is False.
+    :param enable_local_model: Whether to enable a local STT model via ``sherpa-onnx`` (NVIDIA Parakeet TDT 0.6B by default), allowing the component to run without a remote model client. Requires the ``sherpa-onnx`` pip package. Default is False.
     :type enable_local_model: bool
     :param device_local_model: Device to run the local model on, either "cpu" or "cuda" (default: "cuda"). This parameter is only effective when ``enable_local_model`` is True.
     :type device_local_model: str
     :param ncpu_local_model: Number of CPU cores to allocate to the local model when using CPU (default: 1). This parameter is only effective when ``enable_local_model`` is True.
     :type ncpu_local_model: int
-    :param local_model_path: HuggingFace repository ID for a sherpa-onnx compatible Whisper STT model (default: ``csukuangfj/sherpa-onnx-whisper-tiny.en``), or a path to a local directory containing an already downloaded model. For available models see https://k2-fsa.github.io/sherpa/onnx/pretrained_models/index.html. This parameter is only effective when ``enable_local_model`` is True.
+    :param local_model_path: HuggingFace repository ID for a sherpa-onnx compatible STT model (default: ``csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v2-int8``, NVIDIA Parakeet TDT), or a path to a local directory containing an already downloaded model. For available models see https://k2-fsa.github.io/sherpa/onnx/pretrained_models/index.html. This parameter is only effective when ``enable_local_model`` is True.
     :type local_model_path: Optional[str]
+    :param local_model_options: Additional options for the local model, validated at load time against the detected sherpa-onnx model family's loader signature (e.g. ``decoding_method``, ``hotwords_file``, ``hotwords_score`` for transducers; ``task`` for whisper; ``use_itn`` for sense_voice). An unknown key raises an error listing the valid keys for the detected family. The reserved key ``model_type`` forces the model family instead of detecting it from the bundle contents. Only effective when ``enable_local_model`` is True. Default is ``{}``.
+    :type local_model_options: Dict
 
     --
     Transcription
@@ -807,8 +809,9 @@ class SpeechToTextConfig(ModelComponentConfig):
     device_local_model: Literal["cpu", "cuda"] = field(default="cuda")
     ncpu_local_model: int = field(default=1)
     local_model_path: Optional[str] = field(
-        default="csukuangfj/sherpa-onnx-whisper-tiny.en"
+        default="csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v2-int8"
     )
+    local_model_options: Dict = field(default=Factory(dict))
     initial_prompt: Optional[str] = field(default=None)
     language: Optional[str] = field(
         default="en",

--- a/agents/config.py
+++ b/agents/config.py
@@ -95,6 +95,8 @@ class LLMConfig(ModelComponentConfig):
     :type ncpu_local_model: int
     :param local_model_path: HuggingFace repository ID for a GGUF model (default: ``Qwen/Qwen3-0.6B-GGUF``), or a local path to a ``.gguf`` file. This parameter is only effective when ``enable_local_model`` is True.
     :type local_model_path: Optional[str]
+    :param local_model_options: Additional options for the local model, validated at load time against the ``llama_cpp.Llama`` signature (e.g. ``n_ctx``, ``n_batch``, ``flash_attn``, ``chat_format``). Reserved keys: ``filename`` selects the GGUF file when a repository ships several quantizations (e.g. ``"*q4_k_m*.gguf"``); for VLM components ``model_type`` additionally forces the VLM family (moondream, qwen_vl, minicpm, llava, llava16, nanollava) instead of detecting it from the model name. An unknown key raises an error listing the valid keys. Only effective when ``enable_local_model`` is True. Default is ``{}``.
+    :type local_model_options: Dict
 
     Example of usage:
     ```python
@@ -127,6 +129,7 @@ class LLMConfig(ModelComponentConfig):
     device_local_model: Literal["cpu", "cuda"] = field(default="cuda")
     ncpu_local_model: int = field(default=1)
     local_model_path: Optional[str] = field(default="Qwen/Qwen3-0.6B-GGUF")
+    local_model_options: Dict = field(default=Factory(dict))
     _system_prompt: Optional[str] = field(default=None, alias="_system_prompt")
     _component_prompt: Optional[Union[str, Path]] = field(
         default=None, alias="_component_prompt"
@@ -309,7 +312,7 @@ class MLLMConfig(LLMConfig):
     :type device_local_model: str
     :param ncpu_local_model: Number of CPU cores to allocate to the local model when using CPU (default: 1). This parameter is only effective when ``enable_local_model`` is True.
     :type ncpu_local_model: int
-    :param local_model_path: HuggingFace repository ID for a GGUF VLM model (default: ``ggml-org/moondream2-20250414-GGUF``). This parameter is only effective when ``enable_local_model`` is True.
+    :param local_model_path: HuggingFace repository ID for a GGUF VLM model (default: ``ggml-org/Qwen3-VL-2B-Instruct-GGUF``), a local directory with the GGUF and mmproj files, or a local path to a ``.gguf`` file. The VLM family (qwen_vl, gemma, moondream, minicpm, llava, llava16, nanollava) is detected from the model name. This parameter is only effective when ``enable_local_model`` is True.
     :type local_model_path: Optional[str]
 
     Example of usage:
@@ -326,7 +329,9 @@ class MLLMConfig(LLMConfig):
     task: Optional[
         Literal["general", "pointing", "affordance", "trajectory", "grounding"]
     ] = field(default=None)
-    local_model_path: Optional[str] = field(default="ggml-org/moondream2-20250414-GGUF")
+    local_model_path: Optional[str] = field(
+        default="ggml-org/Qwen3-VL-2B-Instruct-GGUF"
+    )
 
     @task.validator
     def _check_task(self, _, value):

--- a/agents/config.py
+++ b/agents/config.py
@@ -300,7 +300,7 @@ class MLLMConfig(LLMConfig):
     :param response_terminator: A string token marking that the end of a single response from the model. This token is only used in case of a persistent clients, such as a websocket client and when stream is set to True. It is not published. This value cannot be an empty string.
         Default is '<<Response Ended>>'
     :type response_terminator: str
-    :param strip_think_tokens: Whether to strip ``<think>...</think>`` blocks from model output. Reasoning models (e.g. Qwen3, DeepSeek-R1) emit these blocks which are useful for debugging but should typically not be forwarded to downstream components such as TTS or UI. Applies to both streaming and non-streaming output. Default is True.
+    :param strip_think_tokens: Whether to strip ``<think>...</think>`` blocks from model output. Reasoning models emit these blocks which are useful for debugging but should typically not be forwarded to downstream components such as TTS or UI. Applies to both streaming and non-streaming output. Default is True.
     :type strip_think_tokens: bool
      :param task: The specific task the VLM should perform. This can help tailor model behavior and is useful when the VLM being used with the component has been trained on specific tasks. For an example of such a model check out RoboBrain2 in models.
         Supported values are: "general", "pointing", "affordance", "trajectory", and "grounding".

--- a/agents/config.py
+++ b/agents/config.py
@@ -85,7 +85,7 @@ class LLMConfig(ModelComponentConfig):
     :param response_terminator: A string token marking that the end of a single response from the model. This token is only used in case of a persistent clients, such as a websocket client and when stream is set to True. It is not published. This value cannot be an empty string.
         Default is '<<Response Ended>>'
     :type response_terminator: str
-    :param strip_think_tokens: Whether to strip ``<think>...</think>`` blocks from model output. Reasoning models (e.g. Qwen3, DeepSeek-R1) emit these blocks which are useful for debugging but should typically not be forwarded to downstream components such as TTS or UI. Applies to both streaming and non-streaming output. Default is True.
+    :param strip_think_tokens: Whether to strip ``<think>...</think>`` blocks from model output. Reasoning models emit these blocks which are useful for debugging but should typically not be forwarded to downstream components such as TTS or UI. Applies to both streaming and non-streaming output. Default is True.
     :type strip_think_tokens: bool
     :param enable_local_model: Whether to enable a local LLM model via llama.cpp, allowing the component to run without a remote model client. Requires the ``llama-cpp-python`` package. Default is False.
     :type enable_local_model: bool

--- a/agents/config.py
+++ b/agents/config.py
@@ -729,14 +729,22 @@ class SpeechToTextConfig(ModelComponentConfig):
     --
     Wakeword Detection
     --
-    :param enable_wakeword: Enable detection of a wakeword phrase (e.g. 'Hey Jarvis').
-                            Requires `enable_vad` to be True.
+    :param enable_wakeword: Enable detection of a wake phrase before transcription.
+                            Requires `enable_vad` to be True and the
+                            ``sentencepiece`` package for encoding the phrase.
                             Defaults to False.
     :type enable_wakeword: bool
 
-    :param wakeword_threshold: Minimum confidence score to trigger wakeword detection.
-                               Only used if `enable_wakeword` is True.
-                               Defaults to 0.6.
+    :param wakeword_phrase: The wake phrase (or list of phrases) to detect,
+                            as plain text (e.g. 'hey jarvis', 'ok robot').
+                            Only used if `enable_wakeword` is True.
+                            Defaults to 'ok robot'.
+    :type wakeword_phrase: Union[str, List[str]]
+
+    :param wakeword_threshold: Keyword spotting trigger threshold (sherpa-onnx
+                               `keywords_threshold`). Lower values trigger more
+                               easily. Only used if `enable_wakeword` is True.
+                               Defaults to 0.25.
     :type wakeword_threshold: float
 
     :param device_wakeword: Device for Wakeword Detection ('cpu' or 'gpu').
@@ -769,18 +777,12 @@ class SpeechToTextConfig(ModelComponentConfig):
                            Defaults to the Silero VAD model URL.
     :type vad_model_path: str
 
-    :param melspectrogram_model_path: Path or URL to melspectrogram model used in wakeword detection.
-                                      Defaults to openWakeWord model URL.
-    :type melspectrogram_model_path: str
-
-    :param embedding_model_path: Path or URL to audio embedding model for wakeword detection.
-                                 Defaults to openWakeWord model URL.
-    :type embedding_model_path: str
-
-    :param wakeword_model_path: Path or URL to wakeword ONNX model (e.g. 'Hey Jarvis').
-                                Defaults to a pretrained openWakeWord model.
-                                For custom models, see:
-                                https://github.com/dscripka/openWakeWord/blob/main/notebooks/automatic_model_training.ipynb
+    :param wakeword_model_path: Source of the sherpa-onnx keyword spotting bundle:
+                                a model archive URL (.tar.bz2/.tar.gz), a HuggingFace
+                                repository ID, or a local directory. Defaults to the
+                                official English zipformer KWS bundle (3.3M params)
+                                from the sherpa-onnx releases. For other languages
+                                see https://github.com/k2-fsa/sherpa-onnx/releases/tag/kws-models
     :type wakeword_model_path: str
 
     --
@@ -825,8 +827,9 @@ class SpeechToTextConfig(ModelComponentConfig):
         default=0.5, validator=base_validators.in_range(min_value=0.0, max_value=1.0)
     )
     wakeword_threshold: float = field(
-        default=0.6, validator=base_validators.in_range(min_value=0.0, max_value=1.0)
+        default=0.25, validator=base_validators.in_range(min_value=0.0, max_value=1.0)
     )
+    wakeword_phrase: Union[str, List[str]] = field(default="ok robot")
     min_silence_duration_ms: int = field(default=500)
     speech_pad_ms: int = field(default=30)
     speech_buffer_max_len: int = field(default=30000)
@@ -839,14 +842,8 @@ class SpeechToTextConfig(ModelComponentConfig):
     vad_model_path: str = field(
         default="https://raw.githubusercontent.com/snakers4/silero-vad/refs/heads/master/src/silero_vad/data/silero_vad.onnx"
     )
-    melspectrogram_model_path: str = field(
-        default="https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/melspectrogram.onnx"
-    )
-    embedding_model_path: str = field(
-        default="https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/embedding_model.onnx"
-    )
     wakeword_model_path: str = field(
-        default="https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/hey_jarvis_v0.1.onnx"
+        default="https://github.com/k2-fsa/sherpa-onnx/releases/download/kws-models/sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01.tar.bz2"
     )
     _sample_rate: int = field(default=16000, alias="_sample_rate")
     _block_size: int = field(default=1280, alias="_block_size")

--- a/agents/config.py
+++ b/agents/config.py
@@ -554,14 +554,18 @@ class TextToSpeechConfig(ModelComponentConfig):
 
     This class defines the configuration options for a Text-To-Speech component.
 
-    :param enable_local_model: Whether to enable a local TTS model via ``sherpa-onnx`` (Kokoro English by default), allowing the component to run without a remote model client. Requires the ``sherpa-onnx`` pip package. Default is False.
+    :param enable_local_model: Whether to enable a local TTS model via ``sherpa-onnx`` (Kyutai's Pocket TTS by default), allowing the component to run without a remote model client. Requires the ``sherpa-onnx`` pip package. Default is False.
     :type enable_local_model: bool
     :param device_local_model: Device to run the local model on, either "cpu" or "cuda" (default: "cuda"). This parameter is only effective when ``enable_local_model`` is True.
     :type device_local_model: str
     :param ncpu_local_model: Number of CPU cores to allocate to the local model when using CPU (default: 1). This parameter is only effective when ``enable_local_model`` is True.
     :type ncpu_local_model: int
-    :param local_model_path: HuggingFace repository ID for a sherpa-onnx compatible TTS model (default: ``csukuangfj/kokoro-en-v0_19``). For available models see https://k2-fsa.github.io/sherpa/onnx/pretrained_models/index.html. This parameter is only effective when ``enable_local_model`` is True.
+    :param local_model_path: HuggingFace repository ID for a sherpa-onnx compatible TTS model (default: ``csukuangfj2/sherpa-onnx-pocket-tts-int8-2026-01-26``, Kyutai's Pocket TTS), or a path to a local directory containing an already-downloaded bundle. For available models see https://k2-fsa.github.io/sherpa/onnx/pretrained_models/index.html. This parameter is only effective when ``enable_local_model`` is True.
     :type local_model_path: Optional[str]
+    :param speaker_id: Voice index used by multi-voice local models (e.g. Kokoro ships several voices; single-voice models ignore it). Only effective when ``enable_local_model`` is True. Default is 0.
+    :type speaker_id: int
+    :param local_model_options: Additional options for the local model, validated at load time against the fields of the detected sherpa-onnx model family (e.g. ``length_scale``, ``noise_scale`` (vits/matcha), ``lang`` (kokoro), ``voice_style`` (supertonic), ``guidance_scale`` (zipvoice)) and the top-level sherpa-onnx TTS options (``silence_scale``, ``max_num_sentences``, ``rule_fsts``, ``rule_fars``). Voice-prompted families (pocket, zipvoice) also accept generation options: ``voice`` (a wav file path for voice cloning, or a voice name shipped in the bundle — Pocket TTS bundles include several; defaults to the bundle's first voice), ``num_steps``, ``reference_text`` and ``max_reference_audio_len``. An unknown key raises an error listing the valid keys for the detected family. The reserved key ``model_type`` forces the model family instead of detecting it from the bundle contents. Only effective when ``enable_local_model`` is True. Default is ``{}``.
+    :type local_model_options: Dict
     :param play_on_device: Whether to play the audio on available audio device (default: False).
     :type play_on_device: bool
     :param device: Optional device id (int) for playing the audio. Only effective if play_on_device is True (default: None).
@@ -576,7 +580,7 @@ class TextToSpeechConfig(ModelComponentConfig):
     :type block_size: int
     :param thread_shutdown_timeout: Timeout to shutdown a playback thread, if data is not received for more than a certain number of seconds. Only effective if play_on_device is True (default: 5 seconds).
     :type thread_shutdown_timeout: int
-    :param stream: Stram output when used with WebSocketClient. Useful when model output is large and broken into chunks by the server. (default: True).
+    :param stream: Stream output audio in chunks. With a WebSocketClient, chunks are streamed by the server; with a local model, audio chunks are yielded as the model synthesizes them (all sherpa-onnx families support this). Useful for playing audio while long text is still being synthesized. (default: True).
     :type stream: bool
 
     Example of usage for local playback:
@@ -598,7 +602,11 @@ class TextToSpeechConfig(ModelComponentConfig):
     enable_local_model: bool = field(default=False)
     device_local_model: Literal["cpu", "cuda"] = field(default="cuda")
     ncpu_local_model: int = field(default=1)
-    local_model_path: Optional[str] = field(default="csukuangfj/kokoro-en-v0_19")
+    local_model_path: Optional[str] = field(
+        default="csukuangfj2/sherpa-onnx-pocket-tts-int8-2026-01-26"
+    )
+    speaker_id: int = field(default=0, validator=base_validators.gt(-1))
+    local_model_options: Dict = field(default=Factory(dict))
     play_on_device: bool = field(default=False)
     device: Optional[int] = field(default=None)
     stream_to_ip: Optional[str] = field(default=None)
@@ -657,7 +665,7 @@ class SpeechToTextConfig(ModelComponentConfig):
     :type device_local_model: str
     :param ncpu_local_model: Number of CPU cores to allocate to the local model when using CPU (default: 1). This parameter is only effective when ``enable_local_model`` is True.
     :type ncpu_local_model: int
-    :param local_model_path: HuggingFace repository ID for a sherpa-onnx compatible Whisper STT model (default: ``csukuangfj/sherpa-onnx-whisper-tiny.en``). For available models see https://k2-fsa.github.io/sherpa/onnx/pretrained_models/index.html. This parameter is only effective when ``enable_local_model`` is True.
+    :param local_model_path: HuggingFace repository ID for a sherpa-onnx compatible Whisper STT model (default: ``csukuangfj/sherpa-onnx-whisper-tiny.en``), or a path to a local directory containing an already downloaded model. For available models see https://k2-fsa.github.io/sherpa/onnx/pretrained_models/index.html. This parameter is only effective when ``enable_local_model`` is True.
     :type local_model_path: Optional[str]
 
     --

--- a/agents/config.py
+++ b/agents/config.py
@@ -400,6 +400,14 @@ class VLAConfig(ModelComponentConfig):
     :param joint_limits: A manual dictionary of joint limits to be used if a URDF file
         is not provided. Format should match parsed URDF limits.
     :type joint_limits: Optional[Dict]
+    :param aggregate_fn_name: The strategy used to merge actions when newly received
+        action chunks overlap timesteps already in the queue (chunks from consecutive
+        inferences overlap). Presets mirror the LeRobot client:
+        "latest_only" (new action wins), "weighted_average" (0.3 * old + 0.7 * new),
+        "average" (0.5 * old + 0.5 * new) and "conservative" (0.7 * old + 0.3 * new).
+        A custom callable set with `set_aggregation_function` on the component takes
+        precedence over this preset. Default is "latest_only".
+    :type aggregate_fn_name: Literal["latest_only", "weighted_average", "average", "conservative"]
 
     Example of usage:
     ```python
@@ -438,6 +446,9 @@ class VLAConfig(ModelComponentConfig):
     )  # seconds
     robot_urdf_file: Optional[str] = field(default=None)
     joint_limits: Optional[Dict] = field(default=None)
+    aggregate_fn_name: Literal[
+        "latest_only", "weighted_average", "average", "conservative"
+    ] = field(default="latest_only")
     _termination_mode: Literal["timesteps", "keyboard", "event"] = field(
         default="timesteps", alias="_termination_mode"
     )

--- a/agents/config.py
+++ b/agents/config.py
@@ -74,7 +74,7 @@ class LLMConfig(ModelComponentConfig):
         Default is 0.8 and must be greater than 0.0.
     :type temperature: float
     :param max_new_tokens: The maximum number of new tokens to generate.
-        Default is 100 and must be greater than 0.
+        Default is 512 and must be greater than 0.
     :type max_new_tokens: int
     :param stream: Publish the llm output as a stream of tokens, useful when sending llm output to a user facing client or to a TTS component. Cannot be used in conjunction with tool calling.
         Default is false
@@ -118,7 +118,7 @@ class LLMConfig(ModelComponentConfig):
         default=10, validator=base_validators.gt(4)
     )  # number of user messages
     temperature: float = field(default=0.8, validator=base_validators.gt(0.0))
-    max_new_tokens: int = field(default=1000, validator=base_validators.gt(0))
+    max_new_tokens: int = field(default=512, validator=base_validators.gt(0))
     stream: bool = field(default=False)
     break_character: str = field(default=".")
     response_terminator: str = field(default="<<Response Ended>>")

--- a/agents/config.py
+++ b/agents/config.py
@@ -306,7 +306,7 @@ class MLLMConfig(LLMConfig):
         Supported values are: "general", "pointing", "affordance", "trajectory", and "grounding".
         Default is None.
     :type task: Optional[Literal["general", "pointing", "affordance", "trajectory", "grounding"]]
-    :param enable_local_model: Whether to enable a local VLM via llama.cpp (Moondream2), allowing the component to run without a remote model client. Requires the ``llama-cpp-python`` package. Default is False.
+    :param enable_local_model: Whether to enable a local VLM via llama.cpp (Qwen3-VL by default), allowing the component to run without a remote model client. Requires the ``llama-cpp-python`` package. Default is False.
     :type enable_local_model: bool
     :param device_local_model: Device to run the local model on, either "cpu" or "cuda" (default: "cuda"). This parameter is only effective when ``enable_local_model`` is True.
     :type device_local_model: str
@@ -344,13 +344,6 @@ class MLLMConfig(LLMConfig):
             raise ValueError(
                 f"Local VLM model only supports general VQA. "
                 f"Task '{value}' requires a remote model client."
-            )
-
-    def __attrs_post_init__(self):
-        """Validate cross-field constraints for local model"""
-        if self.enable_local_model and self.stream:
-            raise ValueError(
-                "stream cannot be set to True when enable_local_model is True in VLMConfig. Local VLM model does not support streaming."
             )
 
     def _get_inference_params(self) -> Dict:

--- a/agents/config.py
+++ b/agents/config.py
@@ -398,8 +398,24 @@ class VLAConfig(ModelComponentConfig):
         actions within safe bounds.
     :type robot_urdf_file: Optional[str]
     :param joint_limits: A manual dictionary of joint limits to be used if a URDF file
-        is not provided. Format should match parsed URDF limits.
+        is not provided. Format should match parsed URDF limits. When a URDF file is
+        also provided, entries in this dictionary override the URDF-derived limits for
+        those joints.
     :type joint_limits: Optional[Dict]
+    :param policy_action_units: The unit space of the policy's actions, used to
+        convert URDF-derived joint limits before capping. URDF `<limit>` values are
+        always radians (per the URDF spec); this option converts them into the unit
+        space of the policy's actions:
+        - `"radians"` (default) — use URDF values as-is. Correct only when the policy
+          outputs radians.
+        - `"degrees"` — convert lower/upper (and velocity) to degrees.
+        - `"normalized"` — the LeRobot SO-10x motor-unit convention: each joint's
+          [lower, upper] range is mapped to [-100, 100]; joints whose name contains
+          "gripper" or "jaw" are mapped to [0, 100]. Use this for policies trained on
+          LeRobot datasets with normalized motor positions.
+        Only applies to URDF-derived limits; the manual `joint_limits` dict is always
+        used verbatim.
+    :type policy_action_units: Literal["radians", "degrees", "normalized"]
     :param aggregate_fn_name: The strategy used to merge actions when newly received
         action chunks overlap timesteps already in the queue (chunks from consecutive
         inferences overlap). Presets mirror the LeRobot client:
@@ -446,6 +462,9 @@ class VLAConfig(ModelComponentConfig):
     )  # seconds
     robot_urdf_file: Optional[str] = field(default=None)
     joint_limits: Optional[Dict] = field(default=None)
+    policy_action_units: Literal["radians", "degrees", "normalized"] = field(
+        default="radians"
+    )
     aggregate_fn_name: Literal[
         "latest_only", "weighted_average", "average", "conservative"
     ] = field(default="latest_only")

--- a/agents/config.py
+++ b/agents/config.py
@@ -371,7 +371,11 @@ class VLAConfig(ModelComponentConfig):
         (keys) to the actual joint names in the robot's URDF/ROS system (values).
     :type joint_names_map: Dict[str, str]
     :param camera_inputs_map: A mapping of camera names expected by the model (keys)
-        to the corresponding ROS topics (values).
+        to the corresponding ROS topics (values). A camera whose dataset feature is
+        single channel is treated as a depth camera and fetches depth frames from its
+        topic (a depth Image topic or the depth part of an RGBD topic). Depth cameras
+        require ``dataset_info_file`` to be set on the LeRobotPolicy, as the
+        auto-generated feature spec assumes 3-channel RGB for every camera.
     :type camera_inputs_map: Mapping[str, Union[Topic, Dict]]
     :param state_input_type: The type of state data to extract from the joint state inputs.
         Supported values are "positions", "velocities", "accelerations", and "efforts".

--- a/agents/models.py
+++ b/agents/models.py
@@ -555,19 +555,22 @@ class LeRobotPolicy(Model):
     :type checkpoint: str
     :param policy_type:
     The type of LeRobot policy to load.
-    Supported values are:
+    Supported values (all policy types servable through the LeRobot Async Policy Server as of LeRobot 0.6.0) are:
+    - `"smolvla"` — General VLA from HuggingFace
     - `"diffusion"` — Diffusion-based action generation policy
     - `"act"` — Action Chunk Transformer policy
-    - `"smolvla"` — General VLA from HuggingFace
     - `"pi0"` — General VLA from Physical Intelligence
     - `"pi05"` — General VLA from Physical Intelligence
+    - `"groot"` — NVIDIA Isaac GR00T N1.7 cross-embodiment VLA (e.g. checkpoint `"nvidia/GR00T-N1.7-3B"`, requires LeRobot >= 0.6.0 on the server)
+    - `"tdmpc"` — Temporal Difference MPC policy
+    - `"vqbet"` — Vector-Quantized Behavior Transformer policy
     This field determines how the checkpoint is interpreted and which policy architecture is instantiated.
     Default: `"smolvla"`.
     :param dataset_info_file:
         URL or local path to the dataset metadata file (`info.json`).
         This file defines the input features and action structure that the policy must follow. Empty by default. If not provided, an attempt will be made by the VLA component to auto-generate it from the component config.
     :type dataset_info_file: str, optional
-    :param policy_type:
+    :param policy_device:
     The device on which the server should initialize the policy.
     Supported values are:
     - `"cuda"` — NVIDIA GPU available on server
@@ -577,6 +580,10 @@ class LeRobotPolicy(Model):
         The number of predicted actions produced per inference chunk. This is only applicable for certain policy types that implement Real Time Chunking (RTC) such as Pi0, and SmolVLA
         Default: `50`.
     :type actions_per_chunk: int
+    :param rename_map:
+        Advanced option, you normally do NOT need this — leave empty. Only needed when the checkpoint was trained with feature names different from those in your dataset metadata (e.g. a fine-tune of a generalist policy that expects `"observation.images.top"` while your dataset calls the same camera `"observation.images.front"`). This is unrelated to `joint_names_map`/`camera_inputs_map` in VLAConfig, which map your robot's joint names and topics to the dataset feature names and are always required.
+        Default: `{}`.
+    :type rename_map: Dict[str, str]
     :param init_timeout:
         Optional timeout (in seconds) for initialization.
         Default: `None`.
@@ -600,12 +607,13 @@ class LeRobotPolicy(Model):
     """
 
     checkpoint: str = field(default="lerobot/smolvla_base")
-    policy_type: Literal["smolvla", "diffusion", "act", "pi0", "pi05"] = field(
-        default="smolvla"
-    )
+    policy_type: Literal[
+        "smolvla", "diffusion", "act", "pi0", "pi05", "groot", "tdmpc", "vqbet"
+    ] = field(default="smolvla")
     actions_per_chunk: int = field(default=50)
     policy_device: Literal["cpu", "cuda"] = field(default="cuda")
     dataset_info_file: Optional[str] = field(default=None)
+    rename_map: Dict[str, str] = field(default={})
     _features: Dict = field(default={})  # Created in the component if missing
     _actions: Optional[Dict] = field(default=None)
     _image_keys: Optional[List] = field(default=None)
@@ -628,4 +636,5 @@ class LeRobotPolicy(Model):
             "features": self._features,
             "actions_per_chunk": self.actions_per_chunk,
             "device": self.policy_device,
+            "rename_map": self.rename_map,
         }

--- a/agents/models.py
+++ b/agents/models.py
@@ -3,7 +3,7 @@ The following model specification classes are meant to define a comman interface
 """
 
 from typing import Optional, Dict, Any, Literal, List
-from attrs import define, field, validators
+from attrs import Factory, define, field, validators
 from .ros import BaseAttrs, base_validators
 from .utils import build_lerobot_features_from_dataset_info, _LANGUAGE_CODES
 
@@ -613,8 +613,10 @@ class LeRobotPolicy(Model):
     actions_per_chunk: int = field(default=50)
     policy_device: Literal["cpu", "cuda"] = field(default="cuda")
     dataset_info_file: Optional[str] = field(default=None)
-    rename_map: Dict[str, str] = field(default={})
-    _features: Dict = field(default={})  # Created in the component if missing
+    rename_map: Dict[str, str] = field(default=Factory(dict))
+    _features: Dict = field(
+        default=Factory(dict)
+    )  # Created in the component if missing
     _actions: Optional[Dict] = field(default=None)
     _image_keys: Optional[List] = field(default=None)
     _joint_keys: Optional[List] = field(default=None)

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -570,6 +570,14 @@ class JointTrajectoryPoint(SupportedType):
         return JointTrajectoryPointROS
 
     @classmethod
+    def _to_ros_duration(cls, seconds: float) -> Any:
+        """Convert seconds as float to a builtin_interfaces Duration message"""
+        from builtin_interfaces.msg import Duration
+
+        sec = int(seconds)
+        return Duration(sec=sec, nanosec=int((seconds - sec) * 1e9))
+
+    @classmethod
     def convert(cls, output: JointsData, index: Optional[int] = None, **_) -> Any:
         """
         Takes joint state data and converts it into a ROS message
@@ -578,12 +586,17 @@ class JointTrajectoryPoint(SupportedType):
         :return: JointTrajectory
         """
         msg = cls.get_ros_type()()
-        msg.time_from_start = output.delay
+        # Point idx is reached after the initial delay plus the per point
+        # duration of all points up to and including this one
+        point_number = 1 if index is None else index + 1
+        msg.time_from_start = cls._to_ros_duration(
+            output.delay + output.duration * point_number
+        )
 
         if index is None:
             msg.positions = output.positions.tolist()
             msg.velocities = output.velocities.tolist()
-            msg.accelerations = output.velocities.tolist()
+            msg.accelerations = output.accelerations.tolist()
             msg.effort = output.efforts.tolist()
             return msg
 
@@ -686,7 +699,7 @@ class JointJog(SupportedType):
 
         msg.displacements = output.positions.tolist()
         msg.velocities = output.velocities.tolist()
-        msg.duration = output.duration.tolist()
+        msg.duration = float(output.duration)
 
         return msg
 

--- a/agents/utils/__init__.py
+++ b/agents/utils/__init__.py
@@ -10,8 +10,8 @@ from .utils import (
     strip_think_tokens,
     execute_method_response_to_str,
     VADStatus,
-    WakeWordStatus,
     load_model,
+    load_model_archive,
     load_model_repo,
     flatten,
     build_url,
@@ -37,7 +37,7 @@ __all__ = [
     "strip_think_tokens",
     "execute_method_response_to_str",
     "VADStatus",
-    "WakeWordStatus",
     "load_model",
+    "load_model_archive",
     "load_model_repo",
 ]

--- a/agents/utils/actions.py
+++ b/agents/utils/actions.py
@@ -9,7 +9,7 @@ from .utils import _read_spec_file, find_missing_values
 # Chunk-overlap aggregation presets, mirroring the LeRobot client's
 # AGGREGATE_FUNCTIONS.
 AGGREGATE_FUNCTIONS: Dict[str, Callable] = {
-    "latest_only": lambda old, new: new,
+    "latest_only": lambda _, new: new,
     "weighted_average": lambda old, new: 0.3 * old + 0.7 * new,
     "average": lambda old, new: 0.5 * old + 0.5 * new,
     "conservative": lambda old, new: 0.7 * old + 0.3 * new,
@@ -292,9 +292,7 @@ def cap_actions_with_limits(
         )
         return target_actions
 
-    for idx, (jname, target) in enumerate(
-        zip(joint_names, target_actions)
-    ):
+    for idx, (jname, target) in enumerate(zip(joint_names, target_actions)):
         # If limit missing in dict
         joint_limits = limits_dict.get(jname)
         if joint_limits is None:
@@ -462,3 +460,60 @@ def parse_urdf_joints(path_or_url: str) -> Dict:
         joints_limits[name] = limits
 
     return joints_limits
+
+
+_GRIPPER_NAME_HINTS = ("gripper", "jaw")
+
+
+def convert_joint_limits_units(
+    joints_limits: Dict[str, Optional[Dict[str, float]]],
+    units: Literal["radians", "degrees", "normalized"],
+) -> Dict[str, Optional[Dict[str, float]]]:
+    """
+    Convert URDF-derived joint limits (always radians per the URDF spec) into
+    the unit space of the policy's actions.
+
+    :param joints_limits: Output of parse_urdf_joints() (values in radians).
+    :type joints_limits: Dict[str, Optional[Dict[str, float]]]
+    :param units: Target unit space:
+        - "radians": no conversion (URDF values used as-is).
+        - "degrees": lower/upper and velocity converted rad -> deg.
+        - "normalized": LeRobot motor-unit convention — each joint's
+          [lower, upper] mechanical range maps linearly to [-100, 100];
+          joints whose name contains "gripper" or "jaw" map to [0, 100].
+          Velocity limits are scaled by the same per-joint factor.
+    :type units: Literal["radians", "degrees", "normalized"]
+    :return: A new dict in the requested units. Joints without limits stay None.
+    :rtype: Dict[str, Optional[Dict[str, float]]]
+    """
+    if units == "radians":
+        return joints_limits
+
+    converted: Dict[str, Optional[Dict[str, float]]] = {}
+    for name, limits in joints_limits.items():
+        if limits is None:
+            converted[name] = None
+            continue
+        new_limits = dict(limits)
+        lower, upper = limits.get("lower"), limits.get("upper")
+        if units == "degrees":
+            for key in ("lower", "upper", "velocity"):
+                if limits.get(key) is not None:
+                    new_limits[key] = float(np.degrees(limits[key]))
+        elif units == "normalized":
+            if lower is None or upper is None or upper <= lower:
+                get_logger("joint_limits").warning(
+                    f"Joint '{name}' has no usable lower/upper limits in the URDF — "
+                    "cannot normalize; leaving limits unset for this joint."
+                )
+                converted[name] = None
+                continue
+            is_gripper = any(h in name.lower() for h in _GRIPPER_NAME_HINTS)
+            norm_lower, norm_upper = (0.0, 100.0) if is_gripper else (-100.0, 100.0)
+            new_limits["lower"] = norm_lower
+            new_limits["upper"] = norm_upper
+            if limits.get("velocity") is not None:
+                scale = (norm_upper - norm_lower) / (upper - lower)
+                new_limits["velocity"] = float(limits["velocity"] * scale)
+        converted[name] = new_limits
+    return converted

--- a/agents/utils/actions.py
+++ b/agents/utils/actions.py
@@ -16,6 +16,10 @@ AGGREGATE_FUNCTIONS: Dict[str, Callable] = {
 }
 
 
+# Feature key prefix used by LeRobot dataset specs
+OBSERVATION_PREFIX = "observation"
+
+
 def _as_depth_frame(img: np.ndarray) -> np.ndarray:
     """Shape a depth output as (H, W, 1) as expected for single channel
     dataset features. uint16 depth (e.g. mono16/16UC1 encodings) is cast to
@@ -104,8 +108,32 @@ class JointsData:
         return mapped
 
 
+def resolve_feature_channels(feature: Dict) -> int:
+    """Resolve the channel count of an image feature from its dataset entry.
+
+    Prefers the dimension labeled in ``names`` (lerobot writes both
+    channel-last and channel-first layouts), falls back to treating a 2-D shape
+    as single channel and a 3-D shape as channel-last.
+    Defaults to 3 (RGB) when the entry carries no usable shape.
+
+    :param feature: Normalized feature entry with optional ``shape`` and ``names``
+    :return: Number of channels declared for the feature
+    """
+    shape = feature.get("shape") or ()
+    names = feature.get("names") or ()
+    if len(names) == len(shape):
+        for label in ("channels", "channel"):
+            if label in names:
+                return int(shape[names.index(label)])
+    # Case (H, W)
+    if len(shape) == 2:
+        return 1
+    # Default channel-last or 3
+    return int(shape[-1]) if len(shape) == 3 else 3
+
+
 def create_observation_spec(
-    joints_map, camera_map, prefix="observation", image_shape=(480, 640, 3)
+    joints_map, camera_map, prefix=OBSERVATION_PREFIX, image_shape=(480, 640, 3)
 ):
     """Create a specification dictionary for observation data structure.
 

--- a/agents/utils/actions.py
+++ b/agents/utils/actions.py
@@ -1,10 +1,30 @@
-from typing import List, Dict, Literal, Optional, Iterable, Tuple
+from typing import Callable, List, Dict, Literal, Optional, Iterable, Tuple
 from attr import define, field
 import numpy as np
 
 from rclpy.logging import get_logger
 
 from .utils import _read_spec_file, find_missing_values
+
+# Chunk-overlap aggregation presets, mirroring the LeRobot client's
+# AGGREGATE_FUNCTIONS.
+AGGREGATE_FUNCTIONS: Dict[str, Callable] = {
+    "latest_only": lambda old, new: new,
+    "weighted_average": lambda old, new: 0.3 * old + 0.7 * new,
+    "average": lambda old, new: 0.5 * old + 0.5 * new,
+    "conservative": lambda old, new: 0.7 * old + 0.3 * new,
+}
+
+
+def _as_depth_frame(img: np.ndarray) -> np.ndarray:
+    """Shape a depth output as (H, W, 1) as expected for single channel
+    dataset features. uint16 depth (e.g. mono16/16UC1 encodings) is cast to
+    float32 since torch cannot convert uint16 arrays on the server side"""
+    if img.ndim == 2:
+        img = np.expand_dims(img, axis=-1)
+    if img.dtype == np.uint16:
+        img = img.astype(np.float32)
+    return img
 
 
 def _size_validator(instance, attribute, value):

--- a/agents/utils/local_llm.py
+++ b/agents/utils/local_llm.py
@@ -1,5 +1,9 @@
+import inspect
 import json
-from typing import Dict, Generator, Union
+from typing import Dict, Generator, Optional, Union
+
+# Reserved keys in model_options that are not llama_cpp.Llama parameters
+_FILENAME_KEY = "filename"
 
 
 class LocalLLM:
@@ -9,9 +13,20 @@ class LocalLLM:
         (e.g. ``Qwen/Qwen3-0.6B-GGUF``) or a local path to a ``.gguf`` file.
     :param device: Device to run on ('cpu' or 'cuda')
     :param ncpu: Number of CPU threads
+    :param model_options: Additional keyword options for ``llama_cpp.Llama``,
+        validated against its signature (e.g. ``n_ctx``, ``n_batch``,
+        ``flash_attn``, ``chat_format``). The reserved key ``filename``
+        selects the GGUF file when a repository ships several quantizations
+        (e.g. ``"*q4_k_m*.gguf"``).
     """
 
-    def __init__(self, model_path: str, device: str = "cuda", ncpu: int = 1):
+    def __init__(
+        self,
+        model_path: str,
+        device: str = "cuda",
+        ncpu: int = 1,
+        model_options: Optional[Dict] = None,
+    ):
         try:
             from llama_cpp import Llama
         except ImportError as e:
@@ -25,22 +40,37 @@ class LocalLLM:
         self.device = device
         self.ncpu = ncpu
 
-        n_gpu_layers = -1 if device == "cuda" else 0
+        options = dict(model_options or {})
+        filename = options.pop(_FILENAME_KEY, "*.gguf")
+
+        # Validate user options against the Llama signature
+        llama_params = inspect.signature(Llama.__init__).parameters
+        for key in options:
+            if key not in llama_params:
+                valid = sorted(
+                    p for p in llama_params if p not in ("self", "kwargs")
+                )
+                raise ValueError(
+                    f"Unknown local_model_options key '{key}' for llama-cpp. "
+                    f"Valid options: {valid}. Reserved: '{_FILENAME_KEY}'."
+                )
+
+        kwargs = {
+            "n_gpu_layers": -1 if device == "cuda" else 0,
+            "n_threads": ncpu,
+            # NOTE: 0 = use the model's trained context length. llama-cpp's own
+            # default (512) overflows immediately with chat history, system
+            # prompts and tool descriptions
+            "n_ctx": 0,
+            "verbose": False,
+            **options,
+        }
 
         if model_path.endswith(".gguf"):
-            self.llm = Llama(
-                model_path=model_path,
-                n_gpu_layers=n_gpu_layers,
-                n_threads=ncpu,
-                verbose=False,
-            )
+            self.llm = Llama(model_path=model_path, **kwargs)
         else:
             self.llm = Llama.from_pretrained(
-                repo_id=model_path,
-                filename="*.gguf",
-                n_gpu_layers=n_gpu_layers,
-                n_threads=ncpu,
-                verbose=False,
+                repo_id=model_path, filename=filename, **kwargs
             )
 
     def __call__(

--- a/agents/utils/local_llm.py
+++ b/agents/utils/local_llm.py
@@ -1,9 +1,14 @@
 import inspect
 import json
-from typing import Dict, Generator, Optional, Union
+import re
+import threading
+from typing import Dict, Generator, List, Optional, Tuple, Union
 
 # Reserved keys in model_options that are not llama_cpp.Llama parameters
 _FILENAME_KEY = "filename"
+
+# Qwen/Hermes-style inline tool call emitted as text
+_TOOL_CALL_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 
 
 class LocalLLM:
@@ -73,6 +78,11 @@ class LocalLLM:
                 repo_id=model_path, filename=filename, **kwargs
             )
 
+        # NOTE: llama-cpp contexts are stateful and not thread-safe. Concurrent
+        # calls corrupt the shared batch/KV cache and abort the process. We will
+        # use thread locks for each call.
+        self._lock = threading.Lock()
+
     def __call__(
         self, inference_input: Dict, stream=False
     ) -> Union[Dict, Generator[str, None, None]]:
@@ -95,17 +105,24 @@ class LocalLLM:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
 
-        response = self.llm.create_chat_completion(**kwargs)
-
         if stream:
-            return {"output": self._stream_tokens(response)}
+            return {"output": self._stream_tokens(kwargs)}
+
+        with self._lock:
+            response = self.llm.create_chat_completion(**kwargs)
 
         choice = response["choices"][0]
         message = choice["message"]
+        content = message.get("content") or ""
+        tool_calls = message.get("tool_calls")
 
-        result = {"output": message.get("content") or ""}
+        # parse tool calls (Qwen/Hermes style)
+        if tools and not tool_calls:
+            content, tool_calls = self._extract_inline_tool_calls(content)
 
-        if message.get("tool_calls"):
+        result = {"output": content}
+
+        if tool_calls:
             result["tool_calls"] = [
                 {
                     "function": {
@@ -115,18 +132,50 @@ class LocalLLM:
                         else tc["function"]["arguments"],
                     }
                 }
-                for tc in message["tool_calls"]
+                for tc in tool_calls
             ]
 
         return result
 
-    def _stream_tokens(self, response) -> Generator[str, None, None]:
+    @staticmethod
+    def _extract_inline_tool_calls(
+        content: str,
+    ) -> Tuple[str, Optional[List[Dict]]]:
+        """Extract Qwen/Hermes-style ``<tool_call>{...}</tool_call>`` tags.
+
+        :param content: Model output text
+        :returns: Tuple of (text without tool call tags, tool calls or None)
+        """
+        calls = []
+        for block in _TOOL_CALL_RE.findall(content):
+            try:
+                parsed = json.loads(block)
+            except json.JSONDecodeError:
+                continue
+            if name := parsed.get("name"):
+                calls.append(
+                    {
+                        "function": {
+                            "name": name,
+                            "arguments": parsed.get("arguments") or {},
+                        }
+                    }
+                )
+        if calls:
+            content = _TOOL_CALL_RE.sub("", content).strip()
+        return content, calls or None
+
+    def _stream_tokens(self, kwargs: Dict) -> Generator[str, None, None]:
         """Yield decoded text tokens from a streaming response.
 
-        :param response: Streaming iterator from create_chat_completion
+        The model lock is held for the whole generation, from inside the
+        generator so it is acquired and released by the consuming thread.
+
+        :param kwargs: Keyword arguments for create_chat_completion
         :yields: Decoded text strings, one per chunk
         """
-        for chunk in response:
-            delta = chunk["choices"][0]["delta"]
-            if "content" in delta and delta["content"]:
-                yield delta["content"]
+        with self._lock:
+            for chunk in self.llm.create_chat_completion(**kwargs):
+                delta = chunk["choices"][0]["delta"]
+                if "content" in delta and delta["content"]:
+                    yield delta["content"]

--- a/agents/utils/local_llm.py
+++ b/agents/utils/local_llm.py
@@ -169,7 +169,8 @@ class LocalLLM:
         """Yield decoded text tokens from a streaming response.
 
         The model lock is held for the whole generation, from inside the
-        generator so it is acquired and released by the consuming thread.
+        generator so it is acquired and released by the consuming thread
+        The component should guarantee closure of abandoned streams.
 
         :param kwargs: Keyword arguments for create_chat_completion
         :yields: Decoded text strings, one per chunk

--- a/agents/utils/local_stt.py
+++ b/agents/utils/local_stt.py
@@ -1,21 +1,165 @@
 """Local STT wrapper using sherpa-onnx."""
 
-from glob import glob
-from typing import Dict
+import inspect
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
+
+# Model families supported by sherpa-onnx and the bundle files that identify
+# them. (first match wins)
+_MODEL_FAMILIES: Dict[str, Dict] = {
+    "moonshine": {
+        "factory": "from_moonshine",
+        "required": {
+            "preprocessor": ["preprocess*.onnx"],
+            "encoder": ["encode*.onnx"],
+            "uncached_decoder": ["uncached_decode*.onnx"],
+            "cached_decoder": ["cached_decode*.onnx"],
+            "tokens": ["tokens.txt"],
+        },
+    },
+    "moonshine_v2": {
+        "factory": "from_moonshine_v2",
+        "required": {
+            "encoder": ["encoder_model*.ort", "encoder_model*.onnx"],
+            "decoder": ["decoder_model*.ort", "decoder_model*.onnx"],
+            "tokens": ["tokens.txt"],
+        },
+    },
+    "qwen3_asr": {
+        "factory": "from_qwen3_asr",
+        "required": {
+            "conv_frontend": ["conv_frontend*.onnx"],
+            "encoder": ["encoder*.onnx"],
+            "decoder": ["decoder*.onnx"],
+            "tokenizer": ["tokenizer"],
+        },
+    },
+    "transducer": {
+        "factory": "from_transducer",
+        "required": {
+            "encoder": ["*encoder*.onnx"],
+            "decoder": ["*decoder*.onnx"],
+            "joiner": ["*joiner*.onnx"],
+            "tokens": ["tokens.txt"],
+        },
+    },
+    "sense_voice": {
+        "factory": "from_sense_voice",
+        "name_hints": ("sense-voice", "sense_voice"),
+        "required": {"model": ["model*.onnx"], "tokens": ["tokens.txt"]},
+    },
+    "paraformer": {
+        "factory": "from_paraformer",
+        "name_hints": ("paraformer",),
+        "required": {
+            "paraformer": ["model*.onnx", "*paraformer*.onnx"],
+            "tokens": ["tokens.txt"],
+        },
+    },
+    "omnilingual_asr_ctc": {
+        "factory": "from_omnilingual_asr_ctc",
+        "name_hints": ("omnilingual",),
+        "required": {"model": ["model*.onnx"], "tokens": ["tokens.txt"]},
+    },
+    "nemo_ctc": {
+        "factory": "from_nemo_ctc",
+        "name_hints": ("ctc",),
+        "required": {"model": ["model*.onnx"], "tokens": ["tokens.txt"]},
+    },
+    # Fallback family matched at the end, so any bundle with a plain
+    # encoder/decoder/tokens layout keeps loading as whisper
+    "whisper": {
+        "factory": "from_whisper",
+        "required": {
+            "encoder": ["*encoder*.onnx"],
+            "decoder": ["*decoder*.onnx"],
+            "tokens": ["*tokens*.txt"],
+        },
+    },
+}
+
+# NeMo-style transducers need model_type='nemo_transducer'
+_NEMO_TRANSDUCER_HINTS = ("nemo", "parakeet")
+
+# Reserved key in local_model_options that forces the model family instead of
+# detecting it from the bundle contents
+_MODEL_TYPE_KEY = "model_type"
+
+
+def _resolve_file(model_dir: Path, patterns: List[str]) -> Optional[str]:
+    """Return the first file (or directory) in model_dir matching patterns."""
+    for pattern in patterns:
+        for match in sorted(model_dir.glob(pattern)):
+            return str(match)
+    return None
+
+
+def detect_model_family(
+    model_path: str, model_type: Optional[str] = None
+) -> Tuple[str, Dict[str, str]]:
+    """Detect the sherpa-onnx STT model family from a bundle's contents.
+
+    :param model_path: Path to the downloaded model directory.
+    :param model_type: Optional family name to force (skips detection).
+    :return: Tuple of (family name, resolved file fields for the factory).
+    :raises ValueError: If the family cannot be determined.
+    """
+    model_dir = Path(model_path)
+
+    candidates = list(_MODEL_FAMILIES.keys())
+    if model_type is not None:
+        if model_type not in _MODEL_FAMILIES:
+            raise ValueError(
+                f"Unknown model_type '{model_type}'. Available families: "
+                f"{sorted(_MODEL_FAMILIES)}"
+            )
+        candidates = [model_type]
+
+    dir_hint = model_dir.name.lower()
+    for family in candidates:
+        spec = _MODEL_FAMILIES[family]
+        hints = spec.get("name_hints")
+        if hints and model_type is None and not any(h in dir_hint for h in hints):
+            continue
+        resolved = {}
+        for field, patterns in spec["required"].items():
+            found = _resolve_file(model_dir, patterns)
+            if found is None:
+                break
+            resolved[field] = found
+        else:
+            return family, resolved
+
+    raise ValueError(
+        f"Could not detect a sherpa-onnx STT model family from the contents of "
+        f"'{model_path}'. Supported families: {sorted(_MODEL_FAMILIES)}. If the "
+        f"bundle belongs to one of these families, force it by setting "
+        f"local_model_options={{'{_MODEL_TYPE_KEY}': '<family>'}} in the config."
+    )
 
 
 class LocalSTT:
     """Local Speech-to-Text inference using sherpa-onnx.
 
-    Uses Whisper models by default. The model directory should contain
-    encoder, decoder, and tokens files (auto-detected via glob).
-    Int8 quantized variants are preferred when available.
+    The model family (transducer incl. NeMo/parakeet, whisper, qwen3_asr,
+    moonshine, sense_voice, paraformer, nemo_ctc, omnilingual) is detected
+    automatically from the contents of the model directory, so any
+    sherpa-onnx compatible offline STT bundle can be loaded by pointing
+    ``local_model_path`` at its HuggingFace repository or a local directory.
 
-    :param model_path: Path to the model directory containing ONNX files
+    :param model_path: Path to the model directory containing the bundle files
     :param device: Device to run on ('cpu' or 'cuda')
     :param ncpu: Number of CPU threads
+    :param sample_rate: Sample rate of the incoming audio
+    :param language: Language code passed to factories that accept one
+        (whisper, sense_voice); ignored by language-agnostic families
+    :param tail_paddings: Tail padding frames for whisper models
+    :param model_options: Additional keyword options for the detected
+        family's sherpa-onnx factory, validated against its signature (e.g.
+        ``decoding_method``, ``hotwords_file`` for transducers, ``task`` for
+        whisper). The reserved key 'model_type' forces the model family.
     """
 
     def __init__(
@@ -26,6 +170,7 @@ class LocalSTT:
         sample_rate: int = 16000,
         language: str = "en",
         tail_paddings: int = 1500,
+        model_options: Optional[Dict] = None,
     ):
         try:
             import sherpa_onnx
@@ -39,31 +184,55 @@ class LocalSTT:
         self.ncpu = ncpu
         self._sample_rate = sample_rate
 
-        # Auto-detect model files — prefer int8 variants for edge
-        encoders = sorted(glob(f"{model_path}/*encoder*.onnx"))
-        decoders = sorted(glob(f"{model_path}/*decoder*.onnx"))
-        tokens_files = glob(f"{model_path}/*tokens*.txt")
+        options = dict(model_options or {})
+        model_type = options.pop(_MODEL_TYPE_KEY, None)
+        # transducer family (normally auto-detected from the model path)
+        transducer_variant = None
+        if model_type == "nemo_transducer":
+            transducer_variant = model_type
+            model_type = "transducer"
+        family, file_fields = detect_model_family(model_path, model_type)
+        self.model_family = family
 
-        if not encoders or not decoders or not tokens_files:
-            raise FileNotFoundError(
-                f"Could not find required model files in {model_path}. "
-                "Expected *encoder*.onnx, *decoder*.onnx, and *tokens*.txt"
-            )
-
-        encoder = next((f for f in encoders if "int8" in f), encoders[0])
-        decoder = next((f for f in decoders if "int8" in f), decoders[0])
-        tokens = tokens_files[0]
-
-        self._recognizer = sherpa_onnx.OfflineRecognizer.from_whisper(
-            encoder=encoder,
-            decoder=decoder,
-            tokens=tokens,
-            language=language,
-            task="transcribe",
-            tail_paddings=tail_paddings,
-            num_threads=ncpu,
-            provider="cuda" if device == "cuda" else "cpu",
+        factory = getattr(
+            sherpa_onnx.OfflineRecognizer, _MODEL_FAMILIES[family]["factory"]
         )
+        factory_params = inspect.signature(factory).parameters
+
+        kwargs = dict(file_fields)
+        if "num_threads" in factory_params:
+            kwargs["num_threads"] = ncpu
+        if "provider" in factory_params:
+            kwargs["provider"] = "cuda" if device == "cuda" else "cpu"
+        if "language" in factory_params and language:
+            kwargs["language"] = language
+        if "tail_paddings" in factory_params:
+            kwargs["tail_paddings"] = tail_paddings
+        if family == "transducer":
+            # NOTE: Check the whole path. HF cache paths carry the repo name in a
+            # parent component while the leaf is a commit hash
+            if transducer_variant is None and any(
+                hint in str(Path(model_path).resolve()).lower()
+                for hint in _NEMO_TRANSDUCER_HINTS
+            ):
+                transducer_variant = "nemo_transducer"
+            if transducer_variant:
+                kwargs["model_type"] = transducer_variant
+
+        # Validate user options against the factory signature
+        for key, value in options.items():
+            if key not in factory_params or key in file_fields:
+                valid = sorted(
+                    p for p in factory_params if p not in file_fields and p != "cls"
+                )
+                raise ValueError(
+                    f"Unknown local_model_options key '{key}' for the "
+                    f"'{family}' model family. Valid options: {valid}. "
+                    f"Reserved: '{_MODEL_TYPE_KEY}'."
+                )
+            kwargs[key] = value
+
+        self._recognizer = factory(**kwargs)
 
     def __call__(self, inference_input: Dict) -> Dict:
         """Run STT inference.

--- a/agents/utils/local_tts.py
+++ b/agents/utils/local_tts.py
@@ -1,24 +1,288 @@
 """Local TTS wrapper using sherpa-onnx."""
 
 import io
+import queue
+import threading
 import wave
-from typing import Dict
+from pathlib import Path
+from typing import Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
+
+# Model families supported by sherpa-onnx and the bundle files that identify
+# them (first match wins).
+_MODEL_FAMILIES: Dict[str, Dict[str, Dict[str, List[str]]]] = {
+    "supertonic": {
+        "required": {
+            "tts_json": ["tts.json"],
+            "duration_predictor": ["duration_predictor*.onnx"],
+            "text_encoder": ["text_encoder*.onnx"],
+            "unicode_indexer": ["unicode_indexer*.onnx"],
+            "vector_estimator": ["vector_estimator*.onnx"],
+            "vocoder": ["vocoder*.onnx"],
+        },
+        "optional": {"voice_style": ["voice_style*.bin", "voice_style*.json"]},
+    },
+    "pocket": {
+        "required": {
+            "lm_main": ["lm_main.onnx", "lm_main.int8.onnx"],
+            "lm_flow": ["lm_flow.onnx", "lm_flow.int8.onnx"],
+            "encoder": ["encoder.onnx", "encoder.int8.onnx"],
+            "decoder": ["decoder.onnx", "decoder.int8.onnx"],
+            "text_conditioner": [
+                "text_conditioner.onnx",
+                "text_conditioner.int8.onnx",
+            ],
+            "vocab_json": ["vocab.json"],
+            "token_scores_json": ["token_scores.json"],
+        },
+        "optional": {},
+    },
+    "matcha": {
+        "required": {
+            "acoustic_model": [
+                "matcha*.onnx",
+                "model-steps*.onnx",
+                "acoustic*.onnx",
+            ],
+            "vocoder": ["*vocos*.onnx", "*hifigan*.onnx", "vocoder*.onnx"],
+            "tokens": ["tokens.txt"],
+        },
+        "optional": {
+            "lexicon": ["lexicon*.txt"],
+            "data_dir": ["espeak-ng-data"],
+            "dict_dir": ["dict"],
+        },
+    },
+    "zipvoice": {
+        "required": {
+            "encoder": ["encoder*.onnx"],
+            "decoder": ["decoder*.onnx"],
+            "vocoder": ["vocoder*.onnx", "*vocos*.onnx"],
+            "tokens": ["tokens.txt"],
+        },
+        "optional": {
+            "lexicon": ["lexicon*.txt"],
+            "data_dir": ["espeak-ng-data"],
+        },
+    },
+    "kitten": {
+        "required": {
+            "model": ["model.onnx", "model.int8.onnx"],
+            "voices": ["voices.bin"],
+            "tokens": ["tokens.txt"],
+        },
+        "optional": {"data_dir": ["espeak-ng-data"]},
+    },
+    "kokoro": {
+        "required": {
+            "model": ["model.onnx", "model.int8.onnx", "kokoro*.onnx"],
+            "voices": ["voices.bin"],
+            "tokens": ["tokens.txt"],
+        },
+        "optional": {
+            "data_dir": ["espeak-ng-data"],
+            "dict_dir": ["dict"],
+            "lexicon": ["lexicon*.txt"],
+        },
+    },
+    "vits": {
+        "required": {
+            "model": ["model.onnx", "model.int8.onnx", "*.onnx"],
+            "tokens": ["tokens.txt"],
+        },
+        "optional": {
+            "lexicon": ["lexicon*.txt"],
+            "data_dir": ["espeak-ng-data"],
+            "dict_dir": ["dict"],
+        },
+    },
+}
+
+# Options that apply to sherpa-onnx's top-level OfflineTtsConfig
+_TOP_LEVEL_OPTIONS = ("rule_fsts", "rule_fars", "max_num_sentences", "silence_scale")
+
+# Options that apply to sherpa-onnx's per-call GenerationConfig (used by
+# e.g. pocket/zipvoice). 'voice' is a wav path or a name resolved in the bundle
+_GENERATION_OPTIONS = (
+    "voice",
+    "num_steps",
+    "reference_text",
+    "max_reference_audio_len",
+)
+
+# Families that require a reference voice wav for generation
+_REFERENCE_VOICE_FAMILIES = ("pocket", "zipvoice")
+
+# Reserved key in local_model_options that forces the model family instead of
+# detecting it from the bundle contents
+_MODEL_TYPE_KEY = "model_type"
+
+
+def _resolve_file(model_dir: Path, patterns: List[str]) -> Optional[str]:
+    """Return the first file (or directory) in model_dir matching patterns."""
+    for pattern in patterns:
+        for match in sorted(model_dir.glob(pattern)):
+            return str(match)
+    return None
+
+
+def detect_model_family(
+    model_path: str, model_type: Optional[str] = None
+) -> Tuple[str, Dict[str, str]]:
+    """Detect the sherpa-onnx TTS model family from a bundle's contents.
+
+    :param model_path: Path to the downloaded model directory.
+    :param model_type: Optional family name to force (skips detection).
+    :return: Tuple of (family name, resolved file fields for the sub-config).
+    :raises ValueError: If the family cannot be determined or forced files
+        are missing.
+    """
+    model_dir = Path(model_path)
+
+    candidates = list(_MODEL_FAMILIES.keys())
+    if model_type is not None:
+        if model_type not in _MODEL_FAMILIES:
+            raise ValueError(
+                f"Unknown model_type '{model_type}'. Available families: "
+                f"{sorted(_MODEL_FAMILIES)}"
+            )
+        candidates = [model_type]
+
+    dir_hint = model_dir.name.lower()
+    for family in candidates:
+        # NOTE: kokoro and kitten bundles share the same file layout. Without an
+        # explicit model_type, kitten is only selected on a name hint
+        if family == "kitten" and model_type is None and "kitten" not in dir_hint:
+            continue
+        spec = _MODEL_FAMILIES[family]
+        resolved = {}
+        for field, patterns in spec["required"].items():
+            found = _resolve_file(model_dir, patterns)
+            if found is None:
+                break
+            resolved[field] = found
+        else:
+            for field, patterns in spec["optional"].items():
+                found = _resolve_file(model_dir, patterns)
+                if found is not None:
+                    resolved[field] = found
+            return family, resolved
+
+    raise ValueError(
+        f"Could not detect a sherpa-onnx TTS model family from the contents of "
+        f"'{model_path}'. Supported families: {sorted(_MODEL_FAMILIES)}. If the "
+        f"bundle belongs to one of these families, force it by setting "
+        f"local_model_options={{'{_MODEL_TYPE_KEY}': '<family>'}} in the config."
+    )
+
+
+def split_model_options(sub_config_cls, options: Dict) -> Tuple[Dict, Dict, Dict]:
+    """Validate user options against the detected family's config fields.
+    Unrecognized key raises with the valid keys for the family.
+
+    :param sub_config_cls: The sherpa-onnx OfflineTts*ModelConfig class.
+    :param options: User-provided local_model_options (model_type excluded).
+    :return: Tuple of (sub-config, top-level, generation options).
+    """
+    probe = sub_config_cls()
+    valid_sub = [
+        attr
+        for attr in dir(probe)
+        if not attr.startswith("_") and not callable(getattr(probe, attr))
+    ]
+    sub_options, top_options, generation_options = {}, {}, {}
+    for key, value in options.items():
+        if key in valid_sub:
+            sub_options[key] = value
+        elif key in _TOP_LEVEL_OPTIONS:
+            top_options[key] = value
+        elif key in _GENERATION_OPTIONS:
+            generation_options[key] = value
+        else:
+            raise ValueError(
+                f"Unknown local_model_options key '{key}' for this model family. "
+                f"Valid family options: {sorted(valid_sub)}. "
+                f"Valid top-level options: {sorted(_TOP_LEVEL_OPTIONS)}. "
+                f"Valid generation options: {sorted(_GENERATION_OPTIONS)}. "
+                f"Reserved: '{_MODEL_TYPE_KEY}'."
+            )
+    return sub_options, top_options, generation_options
+
+
+def resolve_voice_wav(
+    model_dir: Union[str, Path], voice: Optional[str]
+) -> Optional[str]:
+    """Resolve a reference-voice wav for voice-prompted families.
+
+    :param model_dir: The model bundle directory.
+    :param voice: A wav path, or a name resolved inside the bundle (e.g.
+        'loona' matches 'test_wavs/loona.wav'). When None, the first wav
+        shipped in the bundle is used.
+    :return: Path to the wav, or None if nothing was found.
+    """
+    model_dir = Path(model_dir)
+    if voice:
+        candidate = Path(voice)
+        if candidate.is_file():
+            return str(candidate)
+        for match in sorted(model_dir.rglob(f"{voice}*.wav")):
+            return str(match)
+        raise ValueError(
+            f"Voice '{voice}' is neither a wav file nor a name found in the "
+            f"model bundle at '{model_dir}'. Available bundle voices: "
+            f"{[p.stem for p in sorted(model_dir.rglob('*.wav'))]}"
+        )
+    for pattern in ("test_wavs/*.wav", "*.wav"):
+        for match in sorted(model_dir.glob(pattern)):
+            return str(match)
+    return None
+
+
+def _load_voice_wav(path: str) -> Tuple[np.ndarray, int]:
+    """Load a reference wav as float32 samples in [-1, 1] plus sample rate."""
+    with wave.open(path, "rb") as wf:
+        if wf.getsampwidth() != 2:
+            raise ValueError(
+                f"Reference voice wav '{path}' must be 16-bit PCM "
+                f"(got sample width {wf.getsampwidth()} bytes)"
+            )
+        frames = wf.readframes(wf.getnframes())
+        samples = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+        channels = wf.getnchannels()
+        if channels > 1:
+            samples = samples.reshape(-1, channels)[:, 0].copy()
+        return samples, wf.getframerate()
 
 
 class LocalTTS:
     """Local Text-to-Speech inference using sherpa-onnx.
 
-    Uses Kokoro models by default. The model directory should contain
-    model.onnx, voices.bin, tokens.txt, and espeak-ng-data/.
+    The model family (pocket, kokoro, kitten, vits, matcha, supertonic,
+    zipvoice) is detected automatically from the contents of the model
+    directory.
 
-    :param model_path: Path to the model directory containing ONNX and data files
+    :param model_path: Path to the model directory containing the bundle files
     :param device: Device to run on ('cpu' or 'cuda')
     :param ncpu: Number of CPU threads
+    :param speaker_id: Voice index passed to generation (multi-voice models)
+    :param stream: Yield audio chunks as they are synthesized instead of a
+        single WAV (uses sherpa-onnx's generation callback). Default True,
+        matching the component's stream default
+    :param model_options: Options applied to the detected family's sub-config
+        or the top-level OfflineTtsConfig, validated against the available
+        fields. The reserved key 'model_type' forces the model family.
     """
 
-    def __init__(self, model_path: str, device: str = "cuda", ncpu: int = 1):
+    def __init__(
+        self,
+        model_path: str,
+        device: str = "cuda",
+        ncpu: int = 1,
+        speaker_id: int = 0,
+        stream: bool = True,
+        model_options: Optional[Dict] = None,
+    ):
         try:
             import sherpa_onnx
         except ImportError as e:
@@ -29,38 +293,147 @@ class LocalTTS:
 
         self.device = device
         self.ncpu = ncpu
+        self.speaker_id = speaker_id
+        self.stream = stream
+
+        options = dict(model_options or {})
+        model_type = options.pop(_MODEL_TYPE_KEY, None)
+        # detect family
+        family, file_fields = detect_model_family(model_path, model_type)
+
+        sub_config_cls = getattr(
+            sherpa_onnx, f"OfflineTts{family.capitalize()}ModelConfig"
+        )
+        sub_options, top_options, generation_options = split_model_options(
+            sub_config_cls, options
+        )
 
         tts_config = sherpa_onnx.OfflineTtsConfig(
             model=sherpa_onnx.OfflineTtsModelConfig(
-                kokoro=sherpa_onnx.OfflineTtsKokoroModelConfig(
-                    model=f"{model_path}/model.onnx",
-                    voices=f"{model_path}/voices.bin",
-                    tokens=f"{model_path}/tokens.txt",
-                    data_dir=f"{model_path}/espeak-ng-data",
-                ),
+                **{family: sub_config_cls(**{**file_fields, **sub_options})},
                 num_threads=ncpu,
                 provider="cuda" if device == "cuda" else "cpu",
             ),
+            **top_options,
         )
         self._tts = sherpa_onnx.OfflineTts(tts_config)
+        self.model_family = family
+        self._generation_config = self._build_generation_config(
+            sherpa_onnx, model_path, family, generation_options, top_options
+        )
 
-    def __call__(self, inference_input: Dict) -> Dict:
+    def _build_generation_config(
+        self, sherpa_onnx, model_path, family, generation_options, top_options
+    ):
+        """Build a per-call GenerationConfig for voice-prompted families.
+
+        Families like pocket and zipvoice synthesize against a reference
+        voice wav; other families return None here and use the plain
+        (sid, speed) generation path.
+        """
+        needs_voice = family in _REFERENCE_VOICE_FAMILIES
+        if not needs_voice and not generation_options:
+            return None
+
+        voice_wav = resolve_voice_wav(model_path, generation_options.pop("voice", None))
+        if needs_voice and voice_wav is None:
+            raise ValueError(
+                f"The '{family}' model family needs a reference voice wav and "
+                f"the bundle at '{model_path}' does not ship one. Provide one "
+                "with local_model_options={'voice': '/path/to/voice.wav'}."
+            )
+
+        generation_config = sherpa_onnx.GenerationConfig()
+        generation_config.sid = self.speaker_id
+        if voice_wav is not None:
+            samples, sample_rate = _load_voice_wav(voice_wav)
+            generation_config.reference_audio = samples.tolist()
+            generation_config.reference_sample_rate = sample_rate
+        if "silence_scale" in top_options:
+            generation_config.silence_scale = top_options["silence_scale"]
+        if "num_steps" in generation_options:
+            generation_config.num_steps = generation_options["num_steps"]
+        if "reference_text" in generation_options:
+            generation_config.reference_text = generation_options["reference_text"]
+        if "max_reference_audio_len" in generation_options:
+            generation_config.extra["max_reference_audio_len"] = str(
+                generation_options["max_reference_audio_len"]
+            )
+        return generation_config
+
+    def __call__(self, inference_input: Dict, stream: bool = False) -> Dict:
         """Run TTS inference.
 
         :param inference_input: Dict with 'query' (text string)
-        :returns: Dict with 'output' (WAV bytes)
+        :param stream: Stream audio chunks (passed by the component from
+            config.stream when truthy; the constructor value is the fallback)
+        :returns: Dict with 'output' (WAV bytes, or a generator of WAV-chunk
+            bytes when streaming is enabled)
         """
         text = inference_input["query"]
+        text = text.strip() if text else ""
         if not text:
             return {"output": b""}
 
-        audio = self._tts.generate(text, sid=0, speed=1.0)
+        # NOTE: autoregressive models (e.g. pocket) predict when to stop speaking;
+        # unpunctuated text destabilizes that prediction. Ensure the
+        # text ends with terminal punctuation
+        if text[-1] not in ".!?…":
+            text += "."
+
+        if stream or self.stream:
+            return {"output": self._generate_stream(text)}
+
+        audio = self._generate(text)
         wav_bytes = self._samples_to_wav(audio.samples, audio.sample_rate)
 
         return {"output": wav_bytes}
 
+    def _generate(self, text: str, callback=None):
+        """Generate audio, using the reference-voice path when configured."""
+        if self._generation_config is not None:
+            if callback is not None:
+                return self._tts.generate(text, self._generation_config, callback)
+            return self._tts.generate(text, self._generation_config)
+        if callback is not None:
+            return self._tts.generate(
+                text, sid=self.speaker_id, speed=1.0, callback=callback
+            )
+        return self._tts.generate(text, sid=self.speaker_id, speed=1.0)
+
+    def _generate_stream(self, text: str) -> Generator[bytes, None, None]:
+        """Yield WAV-encoded audio chunks as the model synthesizes them.
+
+        sherpa-onnx invokes the generation callback synchronously, so
+        generation runs on a worker thread feeding a queue that this
+        generator drains.
+        """
+        chunk_queue: queue.Queue = queue.Queue()
+        sample_rate = self._tts.sample_rate
+
+        def _on_chunk(samples, progress) -> int:
+            # the callback buffer is reused by sherpa-onnx, copy it
+            chunk_queue.put(np.array(samples, dtype=np.float32, copy=True))
+            return 1
+
+        def _worker():
+            try:
+                self._generate(text, callback=_on_chunk)
+            finally:
+                chunk_queue.put(None)
+
+        # Start thread
+        threading.Thread(target=_worker, name="LocalTTS-Generate", daemon=True).start()
+
+        while True:
+            chunk = chunk_queue.get()
+            if chunk is None:
+                break
+            if chunk.size:
+                yield self._samples_to_wav(chunk, sample_rate)
+
     @staticmethod
-    def _samples_to_wav(samples: np.ndarray, sample_rate: int) -> bytes:
+    def _samples_to_wav(samples: Union[np.ndarray, List], sample_rate: int) -> bytes:
         """Convert float32 samples to WAV bytes using stdlib only.
 
         :param samples: Float32 audio samples in [-1, 1]

--- a/agents/utils/local_vlm.py
+++ b/agents/utils/local_vlm.py
@@ -1,24 +1,111 @@
-from typing import Dict, List
+import inspect
+from pathlib import Path
+from typing import Dict, List, Optional
 
 import numpy as np
 from .utils import encode_img_base64
 
+# VLM families supported through llama-cpp-python chat handlers.
+_VLM_FAMILIES: Dict[str, Dict] = {
+    "moondream": {
+        "hints": ("moondream",),
+        "handlers": ["MoondreamChatHandler"],
+        "filename": "*text-model*.gguf",
+    },
+    # NOTE: MTMD is llama-cpp's generic multimodal handler for newer model families.
+    # TODO: When most new models switch to MTMD, we can simplify things here
+    "qwen_vl": {
+        "hints": ("qwen2-vl", "qwen2.5-vl", "qwen2_5-vl", "qwen25-vl", "qwen3-vl", "qwen3vl"),
+        "handlers": ["MTMDChatHandler", "Qwen25VLChatHandler"],
+        "filename": "Qwen*.gguf",
+    },
+    "gemma": {
+        "hints": ("gemma",),
+        "handlers": ["MTMDChatHandler", "Gemma4ChatHandler"],
+        "filename": "gemma*.gguf",
+    },
+    "minicpm": {
+        "hints": ("minicpm",),
+        "handlers": ["MiniCPMv26ChatHandler"],
+        "filename": "*.gguf",
+    },
+    "llava16": {
+        "hints": ("llava-v1.6", "llava-1.6", "llava16"),
+        "handlers": ["Llava16ChatHandler"],
+        "filename": "*.gguf",
+    },
+    "llava": {
+        "hints": ("llava", "bakllava"),
+        "handlers": ["Llava15ChatHandler"],
+        "filename": "*.gguf",
+    },
+    "nanollava": {
+        "hints": ("nanollava",),
+        "handlers": ["NanoLlavaChatHandler"],
+        "filename": "*.gguf",
+    },
+}
+
+# Reserved keys in model_options that are not llama_cpp.Llama parameters
+_MODEL_TYPE_KEY = "model_type"
+_FILENAME_KEY = "filename"
+
+
+def detect_vlm_family(model_path: str, model_type: Optional[str] = None) -> str:
+    """Detect the VLM family from the model path/repository name.
+
+    :param model_path: HuggingFace repo ID or local path.
+    :param model_type: Optional family name to force (skips detection).
+    :raises ValueError: If no family matches.
+    """
+    if model_type is not None:
+        if model_type not in _VLM_FAMILIES:
+            raise ValueError(
+                f"Unknown model_type '{model_type}'. Available families: "
+                f"{sorted(_VLM_FAMILIES)}"
+            )
+        return model_type
+
+    name = model_path.lower()
+    for family, spec in _VLM_FAMILIES.items():
+        if any(hint in name for hint in spec["hints"]):
+            return family
+
+    raise ValueError(
+        f"Could not detect a VLM family from '{model_path}'. Supported "
+        f"families: {sorted(_VLM_FAMILIES)}. Force one by setting "
+        f"local_model_options={{'{_MODEL_TYPE_KEY}': '<family>'}} in the config."
+    )
+
 
 class LocalVLM:
-    """Local VLM inference using llama-cpp-python with Moondream2.
+    """Local VLM inference using llama-cpp-python multimodal chat handlers.
+
+    The VLM family (moondream, qwen_vl, minicpm, llava/llava16, nanollava) is
+    detected from the model name.
 
     :param model_path: HuggingFace repository ID for a GGUF VLM model
-        (e.g. ``ggml-org/moondream2-20250414-GGUF``) or a local path to a
-        ``.gguf`` file. When using a HuggingFace repo, the mmproj file is
-        downloaded automatically.
+        (e.g. ``ggml-org/Qwen3-VL-2B-Instruct-GGUF``), a local directory
+        containing the GGUF and mmproj files, or a local path to a ``.gguf``
+        file (with the mmproj file next to it).
     :param device: Device to run on ('cpu' or 'cuda')
     :param ncpu: Number of CPU threads
+    :param model_options: Additional keyword options for ``llama_cpp.Llama``,
+        validated against its signature (e.g. ``n_ctx``, ``n_batch``,
+        ``flash_attn``). Reserved keys: ``filename`` selects the GGUF file
+        in multi-file repositories, ``model_type`` forces the VLM family.
     """
 
-    def __init__(self, model_path: str, device: str = "cuda", ncpu: int = 1):
+    def __init__(
+        self,
+        model_path: str,
+        device: str = "cuda",
+        ncpu: int = 1,
+        model_options: Optional[Dict] = None,
+    ):
         try:
             from llama_cpp import Llama
-            from llama_cpp.llama_chat_format import MoondreamChatHandler
+            from llama_cpp import llama_chat_format
         except ImportError as e:
             raise ImportError(
                 "Local VLM model deployment requires llama-cpp-python. "
@@ -30,22 +117,87 @@ class LocalVLM:
         self.device = device
         self.ncpu = ncpu
 
-        n_gpu_layers = -1 if device == "cuda" else 0
+        options = dict(model_options or {})
+        model_type = options.pop(_MODEL_TYPE_KEY, None)
+        family = detect_vlm_family(model_path, model_type)
+        self.model_family = family
+        spec = _VLM_FAMILIES[family]
+        filename = options.pop(_FILENAME_KEY, spec["filename"])
 
-        chat_handler = MoondreamChatHandler.from_pretrained(
-            repo_id=model_path,
-            filename="*mmproj*",
-        )
+        # Resolve a chat handler class available in this llama-cpp version
+        handler_cls = None
+        for handler_name in spec["handlers"]:
+            handler_cls = getattr(llama_chat_format, handler_name, None)
+            if handler_cls is not None:
+                break
+        if handler_cls is None:
+            raise ValueError(
+                f"This llama-cpp-python version provides no chat handler for "
+                f"the '{family}' family (tried: {spec['handlers']}). "
+                "Upgrade with: pip install -U llama-cpp-python"
+            )
 
-        self.llm = Llama.from_pretrained(
-            repo_id=model_path,
-            filename="*text-model*.gguf",
-            chat_handler=chat_handler,
-            n_gpu_layers=n_gpu_layers,
-            n_threads=ncpu,
-            n_ctx=4096,
-            verbose=False,
-        )
+        # Validate user options against the Llama signature
+        llama_params = inspect.signature(Llama.__init__).parameters
+        for key in options:
+            if key not in llama_params:
+                valid = sorted(
+                    p for p in llama_params if p not in ("self", "kwargs")
+                )
+                raise ValueError(
+                    f"Unknown local_model_options key '{key}' for llama-cpp. "
+                    f"Valid options: {valid}. "
+                    f"Reserved: ['{_FILENAME_KEY}', '{_MODEL_TYPE_KEY}']."
+                )
+
+        kwargs = {
+            "n_gpu_layers": -1 if device == "cuda" else 0,
+            "n_threads": ncpu,
+            "n_ctx": 4096,
+            "verbose": False,
+            **options,
+        }
+
+        local_path = Path(model_path)
+        if local_path.is_dir() or model_path.endswith(".gguf"):
+            model_dir = local_path if local_path.is_dir() else local_path.parent
+            mmproj = next(iter(sorted(model_dir.glob("*mmproj*"))), None)
+            if mmproj is None:
+                raise FileNotFoundError(
+                    f"No multimodal projector (*mmproj*) found in '{model_dir}' "
+                    "— required for VLM inference."
+                )
+            if local_path.is_dir():
+                gguf = next(
+                    (
+                        f
+                        for f in sorted(model_dir.glob(filename))
+                        if "mmproj" not in f.name
+                    ),
+                    None,
+                )
+                if gguf is None:
+                    raise FileNotFoundError(
+                        f"No GGUF model matching '{filename}' found in '{model_dir}'."
+                    )
+            else:
+                gguf = local_path
+            self.llm = Llama(
+                model_path=str(gguf),
+                chat_handler=handler_cls(clip_model_path=str(mmproj)),
+                **kwargs,
+            )
+        else:
+            chat_handler = handler_cls.from_pretrained(
+                repo_id=model_path,
+                filename="*mmproj*",
+            )
+            self.llm = Llama.from_pretrained(
+                repo_id=model_path,
+                filename=filename,
+                chat_handler=chat_handler,
+                **kwargs,
+            )
 
     def __call__(self, inference_input: Dict) -> Dict:
         """Run VLM inference.
@@ -54,32 +206,30 @@ class LocalVLM:
             'images' (list of RGB numpy arrays)
         :returns: Dict with 'output' (str)
         """
-        # Extract the text query from messages
-        messages = inference_input["query"]
-        query = ""
-        for msg in reversed(messages):
-            if msg["role"] == "user":
-                query = msg["content"]
-                break
-
-        # Get images
         images: List[np.ndarray] = inference_input.get("images", [])
         if not images:
             return {"output": "No image provided."}
 
-        # Convert first RGB numpy image to base64 data URI
-        data_uri = f"data:image/png;base64,{encode_img_base64(images[0])}"
-
-        # Build multimodal message in OpenAI vision format
-        multimodal_messages = [
+        image_parts = [
             {
-                "role": "user",
-                "content": [
-                    {"type": "image_url", "image_url": {"url": data_uri}},
-                    {"type": "text", "text": query},
-                ],
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/png;base64,{encode_img_base64(image)}"
+                },
             }
+            for image in images
         ]
 
-        response = self.llm.create_chat_completion(messages=multimodal_messages)
+        # Keep the full conversation; attach the images to the last user
+        # message
+        messages = [dict(message) for message in inference_input["query"]]
+        for message in reversed(messages):
+            if message["role"] == "user":
+                text = message["content"]
+                message["content"] = image_parts + [{"type": "text", "text": text}]
+                break
+        else:
+            messages.append({"role": "user", "content": image_parts})
+
+        response = self.llm.create_chat_completion(messages=messages)
         return {"output": response["choices"][0]["message"]["content"]}

--- a/agents/utils/local_vlm.py
+++ b/agents/utils/local_vlm.py
@@ -258,7 +258,8 @@ class LocalVLM:
         """Yield decoded text tokens from a streaming response.
 
         The model lock is held for the whole generation, from inside the
-        generator so it is acquired and released by the consuming thread.
+        generator so it is acquired and released by the consuming thread
+        The component should guarantee closure of abandoned streams.
 
         :param kwargs: Keyword arguments for create_chat_completion
         :yields: Decoded text strings, one per chunk

--- a/agents/utils/local_vlm.py
+++ b/agents/utils/local_vlm.py
@@ -1,6 +1,7 @@
 import inspect
+import threading
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, Generator, List, Optional, Union
 
 import numpy as np
 from .utils import encode_img_base64
@@ -199,12 +200,21 @@ class LocalVLM:
                 **kwargs,
             )
 
-    def __call__(self, inference_input: Dict) -> Dict:
+        # NOTE: llama-cpp contexts are stateful and not thread-safe. Concurrent
+        # calls corrupt the shared batch/KV cache and abort the process. We will
+        # use thread locking per call
+        self._lock = threading.Lock()
+
+    def __call__(
+        self, inference_input: Dict, stream: bool = False
+    ) -> Union[Dict, Generator[str, None, None]]:
         """Run VLM inference.
 
         :param inference_input: Dict with 'query' (messages list) and
-            'images' (list of RGB numpy arrays)
-        :returns: Dict with 'output' (str)
+            'images' (list of RGB numpy arrays), and optional 'temperature',
+            'max_new_tokens'
+        :param stream: Yield the response as a generator of text chunks
+        :returns: Dict with 'output' (str, or a generator when streaming)
         """
         images: List[np.ndarray] = inference_input.get("images", [])
         if not images:
@@ -231,5 +241,30 @@ class LocalVLM:
         else:
             messages.append({"role": "user", "content": image_parts})
 
-        response = self.llm.create_chat_completion(messages=messages)
+        kwargs = {"messages": messages, "stream": stream}
+        if temperature := inference_input.get("temperature"):
+            kwargs["temperature"] = temperature
+        if max_new_tokens := inference_input.get("max_new_tokens"):
+            kwargs["max_tokens"] = max_new_tokens
+
+        if stream:
+            return {"output": self._stream_tokens(kwargs)}
+
+        with self._lock:
+            response = self.llm.create_chat_completion(**kwargs)
         return {"output": response["choices"][0]["message"]["content"]}
+
+    def _stream_tokens(self, kwargs: Dict) -> Generator[str, None, None]:
+        """Yield decoded text tokens from a streaming response.
+
+        The model lock is held for the whole generation, from inside the
+        generator so it is acquired and released by the consuming thread.
+
+        :param kwargs: Keyword arguments for create_chat_completion
+        :yields: Decoded text strings, one per chunk
+        """
+        with self._lock:
+            for chunk in self.llm.create_chat_completion(**kwargs):
+                delta = chunk["choices"][0]["delta"]
+                if "content" in delta and delta["content"]:
+                    yield delta["content"]

--- a/agents/utils/utils.py
+++ b/agents/utils/utils.py
@@ -418,7 +418,9 @@ def load_model_repo(
 
     :param model_name: Local cache name for the model
     :type model_name: str
-    :param repo_id: HuggingFace repository ID (e.g. 'onnx-community/Qwen3-0.6B-ONNX')
+    :param repo_id: HuggingFace repository ID (e.g. 'onnx-community/Qwen3-0.6B-ONNX'),
+        or a path to an existing local model directory, which is returned as-is
+        without downloading anything
     :type repo_id: str
     :param allow_patterns: Optional glob pattern to filter which files to download
         (e.g. 'cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/*'). When set,
@@ -431,6 +433,10 @@ def load_model_repo(
     import shutil
     from pathlib import Path
     from platformdirs import user_cache_dir
+
+    # A local model directory is used directly, no download involved
+    if Path(repo_id).is_dir():
+        return str(Path(repo_id))
 
     cachedir = user_cache_dir("ros_agents")
     # Use repo_id to create a unique subdirectory

--- a/agents/utils/utils.py
+++ b/agents/utils/utils.py
@@ -24,6 +24,7 @@ import cv2
 import httpx
 import numpy as np
 from attrs import Attribute
+from rclpy.logging import get_logger
 from jinja2 import Environment, FileSystemLoader
 from jinja2.environment import Template
 from .pluralize import pluralize
@@ -610,6 +611,11 @@ def _normalize_entry(spec: Dict) -> Dict:
     if not feature_type:
         return {}
 
+    # NOTE: The policy server builds state features only when dtype is exactly
+    # float32 (values get rebuilt as float32 there anyway)
+    if dtype == "float64":
+        dtype = "float32"
+
     names = _normalize_names(spec.get("names"))
 
     entry = {
@@ -647,6 +653,11 @@ def build_lerobot_features_from_dataset_info(
         # NOTE: Only checking for state, images and action for now
         if key == "observation.state":
             features[key] = _normalize_entry(spec)
+            # NOTE: This should be removed when feature checking is fixed in LeRobot
+            if spec.get("dtype", "").lower() == "float64":
+                get_logger("lerobot_dataset_features").warning(
+                    f"Dataset declares '{key}' as float64. Sending it as float32 for policy server compatibility, since the server would silently drop non float32 state features and rebuilds the values as float32 anyway."
+                )
         elif key.startswith("observation.images."):
             features[key] = _normalize_entry(spec)
             image_keys.append(key.removeprefix("observation.images."))

--- a/agents/utils/utils.py
+++ b/agents/utils/utils.py
@@ -307,15 +307,17 @@ def encode_img_base64(img: np.ndarray) -> str:
 def strip_think_tokens(text: str) -> str:
     """Strip ``<think>...</think>`` blocks from model output.
 
-    Reasoning models (Qwen3, DeepSeek-R1, etc.) emit these blocks which are
-    useful for debugging but should not be forwarded to downstream components.
+    Reasoning models emit these blocks which are useful for debugging but should
+    not be forwarded to downstream components. A block left unterminated
+    (generation truncated by the token limit before ``</think>`` was emitted)
+    is stripped to the end of the text.
 
     :param text: Raw model output text
     :type text: str
     :returns: Text with think blocks removed
     :rtype: str
     """
-    return re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+    return re.sub(r"<think>.*?(?:</think>|\Z)", "", text, flags=re.DOTALL).strip()
 
 
 def execute_method_response_to_str(tool_name: str, response) -> str:

--- a/agents/utils/utils.py
+++ b/agents/utils/utils.py
@@ -354,14 +354,6 @@ class VADStatus(Enum):
     END = 2
 
 
-class WakeWordStatus(Enum):
-    """WakeWord Status for start and end of detected wake word"""
-
-    START = 0
-    ONGOING = 1
-    END = 2
-
-
 def load_model(model_name: str, model_path: str) -> str:
     """Model download utility function"""
     from tqdm import tqdm
@@ -407,6 +399,73 @@ def load_model(model_name: str, model_path: str) -> str:
 
     progress_bar.close()
     return str(model_full_path)
+
+
+def load_model_archive(model_name: str, url: str) -> str:
+    """Download and extract a model archive (.tar.bz2/.tar.gz) from a URL.
+
+    Cached under the same directory scheme as `load_model_repo`. When
+    the archive contains a single top-level directory (the sherpa-onnx
+    convention), that directory is returned.
+
+    :param model_name: Local cache name for the model
+    :type model_name: str
+    :param url: Archive URL, or a path to an existing local model directory,
+        which is returned as-is
+    :type url: str
+    :returns: Path to the extracted model directory
+    :rtype: str
+    """
+    import shutil
+    import tarfile
+    from platformdirs import user_cache_dir
+
+    # A local model directory is used directly, no download involved
+    if Path(url).is_dir():
+        return str(Path(url))
+
+    archive_name = url.rstrip("/").rsplit("/", 1)[-1]
+    stem = archive_name
+    for suffix in (".tar.bz2", ".tar.gz", ".tgz", ".tar"):
+        if stem.endswith(suffix):
+            stem = stem[: -len(suffix)]
+            break
+
+    base_dir = Path(user_cache_dir("ros_agents")) / "models" / model_name
+    model_dir = base_dir / stem
+    if model_dir.exists() and any(model_dir.iterdir()):
+        return str(model_dir)
+
+    # Download and extract in a staging directory, move into place on success
+    staging_dir = base_dir / f".{stem}_staging"
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = staging_dir / archive_name
+    try:
+        with httpx.stream("GET", url, timeout=60, follow_redirects=True) as r:
+            r.raise_for_status()
+            with open(archive_path, "wb") as f:
+                for chunk in r.iter_bytes(chunk_size=65536):
+                    f.write(chunk)
+        with tarfile.open(archive_path) as tar:
+            try:
+                tar.extractall(staging_dir, filter="data")
+            except TypeError:
+                # python < 3.12 without the filter argument
+                tar.extractall(staging_dir)  # nosec
+        archive_path.unlink()
+
+        entries = list(staging_dir.iterdir())
+        extracted = (
+            entries[0] if len(entries) == 1 and entries[0].is_dir() else staging_dir
+        )
+        shutil.move(str(extracted), str(model_dir))
+    finally:
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir)
+
+    return str(model_dir)
 
 
 def load_model_repo(

--- a/agents/utils/voice.py
+++ b/agents/utils/voice.py
@@ -1,9 +1,10 @@
-from typing import Optional, List
+from typing import Optional, List, Union
 from typing import Callable
 import logging
+from pathlib import Path
 
 import numpy as np
-from .utils import VADStatus, WakeWordStatus
+from .utils import VADStatus
 
 try:
     import onnxruntime as ort
@@ -137,157 +138,148 @@ class VADIterator:
         return None
 
 
-class AudioFeatures:
+class WakeWordSpotter:
     """
-     Adapted streaming implementation of AudioFeatures class from the wonderful [openWakeWord project](https://github.com/dscripka/openWakeWord/). This class converts raw audio to audio embeddings. It uses the following two ONNX models.
+    Open-vocabulary wake word detection using sherpa-onnx's streaming
+    KeywordSpotter (default, a small zipformer transducer).
 
-    - An ONNX implementation of Torch's melspectrogram function with fixed parameters.
-
-    - A shared feature extraction backbone model that converts melspectrogram inputs into general-purpose speech audio embeddings. This model is provided by Google as a TFHub module under an Apache-2.0 license and manually reimplemented in openWakeWord.
-    """
-
-    def __init__(
-        self,
-        melspectogram_model_path: str,
-        embedding_model_path: str,
-        ncpu: int = 1,
-        device: str = "cpu",
-    ):
-        # Initialize ONNX options
-        sessionOptions = ort.SessionOptions()
-        sessionOptions.inter_op_num_threads = ncpu
-        sessionOptions.intra_op_num_threads = ncpu
-
-        providers = _get_onnx_providers(device, "WakeWord")
-        # Initialize melspectrogram model
-        self.melspec_model = ort.InferenceSession(
-            melspectogram_model_path, sess_options=sessionOptions, providers=providers
-        )
-
-        self.melspec_model_predict = lambda x: self.melspec_model.run(
-            None, {"input": x}
-        )
-
-        # Initialize audio embedding model
-        self.embedding_model = ort.InferenceSession(
-            embedding_model_path, sess_options=sessionOptions, providers=providers
-        )
-
-        self.embedding_model_predict = lambda x: self.embedding_model.run(
-            None, {"input_1": x}
-        )[0].squeeze()
-
-        # Buffers for storing melspectrograms and embeddings
-        self.melspectrogram_buffer = np.ones((76, 32))  # n_frames x num_features
-        self.embeddings_buffer = self._initialize_random_embeddings(
-            np.random.randint(-1000, 1000, 16000 * 4).astype(np.float32)
-        )
-
-    def _get_melspectrogram(
-        self,
-        x: np.ndarray,
-        melspec_transform: Callable = lambda x: x / 10 + 2,
-    ):
-        """
-        Function to compute the mel-spectrogram of the provided audio samples.
-        melspec_transform: A function to transform the computed melspectrogram.
-        Defaults to a transform that makes the ONNX melspectrogram model closer to the native Tensorflow implementation from Google (https://tfhub.dev/google/speech_embedding/1).
-        """
-        x = x[None,] if len(x.shape) < 2 else x
-
-        # compute melspectrogram
-        outputs = self.melspec_model_predict(x)
-        spec = np.squeeze(outputs[0])
-
-        # transform melspectrogram
-        spec = melspec_transform(spec)
-
-        return spec
-
-    def _initialize_random_embeddings(
-        self, x: np.ndarray, window_size: int = 76, step_size: int = 8, **kwargs
-    ):
-        """Initialize random embeddings"""
-        spec = self._get_melspectrogram(x, **kwargs)
-        windows = []
-        for i in range(0, spec.shape[0], step_size):
-            window = spec[i : i + window_size]
-            if window.shape[0] == window_size:  # truncate short windows
-                windows.append(window)
-        batch = np.expand_dims(np.array(windows), axis=-1).astype(np.float32)
-        embedding = self.embedding_model_predict(batch)
-        return embedding
-
-    def get_embeddings(self, n_feature_frames: int = 16) -> np.ndarray:
-        """Get computed embeddings from the buffer"""
-        return self.embeddings_buffer[int(-1 * n_feature_frames) :, :][None,].astype(
-            np.float32
-        )
-
-    def __call__(self, x):
-        """Calclate melspetrogram and audio embeddings"""
-        # calculate melspectogram
-        mels = self._get_melspectrogram(x)
-        self.melspectrogram_buffer = np.roll(
-            self.melspectrogram_buffer, -mels.shape[0], axis=0
-        )
-        self.melspectrogram_buffer[-mels.shape[0] :] = mels
-
-        # calculate audio embeddings
-        x = self.melspectrogram_buffer.astype(np.float32)[None, :, :, None]
-
-        self.embeddings_buffer = np.roll(self.embeddings_buffer, -1, axis=0)
-        self.embeddings_buffer[-1:] = self.embedding_model_predict(x)
-
-
-class WakeWord:
-    """
-    A wakeword model classification class that uses pre-trained wakeword models adapted for models presented in [openWakeWord project](https://github.com/dscripka/openWakeWord/).
-    This class consumed audio embeddings and gives out the probability of detecting a wakeword.
-    Simple models like 2 layer RNNs work fairly well as wakeword classification models. Pre-trained models from openWakeWord are available [here](https://github.com/dscripka/openWakeWord/tree/main?tab=readme-ov-file#pre-trained-models).
-    To train a custom model, follow this simple [tutorial](https://github.com/dscripka/openWakeWord/blob/main/notebooks/automatic_model_training.ipynb) provided by openWakeWord. Please check [licensing information](https://github.com/dscripka/openWakeWord/tree/main?tab=readme-ov-file#license) for pre-trained models, before utilizing them.
+    The wake phrase is plain text, encoded into the bundle's BPE tokens at
+    load time, so it can be changed in the config without training a
+    per-phrase classifier. Audio is fed block by block (same int16-scale
+    float convention as VADIterator) and a detection returns the phrase.
     """
 
     def __init__(
         self,
         model_path: str,
-        threshold: float = 0.6,
-        ncpu=1,
-        device="cpu",
+        phrase: Union[str, List[str]] = "ok robot",
+        threshold: float = 0.25,
+        score: float = 2.0,
+        sample_rate: int = 16000,
+        ncpu: int = 1,
+        device: str = "cpu",
     ):
-        sessionOptions = ort.SessionOptions()
-        sessionOptions.inter_op_num_threads = ncpu
-        sessionOptions.intra_op_num_threads = ncpu
+        try:
+            import sherpa_onnx
+            import sentencepiece  # noqa: F401 — used when encoding the phrase
+        except ImportError as e:
+            raise ImportError(
+                "Wake word detection requires sherpa-onnx and sentencepiece. "
+                "Install them with: pip install sherpa-onnx sentencepiece"
+            ) from e
 
-        providers = _get_onnx_providers(device, "WakeWord")
-        # Create inference session
-        self.model = ort.InferenceSession(
-            model_path, sess_options=sessionOptions, providers=providers
+        model_dir = Path(model_path)
+
+        def find(patterns: List[str]) -> Optional[str]:
+            for pattern in patterns:
+                for match in sorted(model_dir.glob(pattern)):
+                    return str(match)
+            return None
+
+        encoder = find(["encoder*.onnx", "*encoder*.onnx"])
+        decoder = find(["decoder*.onnx", "*decoder*.onnx"])
+        joiner = find(["joiner*.onnx", "*joiner*.onnx"])
+        tokens = find(["tokens.txt"])
+        if not all([encoder, decoder, joiner, tokens]):
+            raise FileNotFoundError(
+                f"Could not find a sherpa-onnx keyword spotting bundle in "
+                f"'{model_path}'. Expected encoder/decoder/joiner onnx files "
+                "and tokens.txt (e.g. sherpa-onnx-kws-zipformer-gigaspeech-3.3M)."
+            )
+
+        phrases = [phrase] if isinstance(phrase, str) else list(phrase)
+        keywords_file = self._build_keywords_file(model_dir, phrases)
+
+        self._sample_rate = sample_rate
+        self._spotter = sherpa_onnx.KeywordSpotter(
+            tokens=tokens,
+            encoder=encoder,
+            decoder=decoder,
+            joiner=joiner,
+            keywords_file=keywords_file,
+            keywords_threshold=threshold,
+            keywords_score=score,
+            num_threads=ncpu,
+            provider="cuda" if device == "cuda" else "cpu",
         )
-        self.model_input = self.model.get_inputs()[0].shape[1]
-        self.model_output = self.model.get_outputs()[0].shape[1]
-        self.threshold = threshold
-        self.prob: float = 0.0
+        self._stream = self._spotter.create_stream()
 
-    def _predict(self, x) -> Optional[WakeWordStatus]:
-        self.prob = self.model.run(None, {self.model.get_inputs()[0].name: x})[
-            0
-        ].squeeze()
+    @staticmethod
+    def _build_keywords_file(model_dir: Path, phrases: List[str]) -> str:
+        """Encode wake phrases into the bundle's BPE tokens and write the
+        keywords file sherpa expects (one line per phrase: tokens @phrase)."""
+        bpe_model = None
+        for match in sorted(model_dir.glob("*.model")):
+            bpe_model = str(match)
+            break
+        if bpe_model is None:
+            raise FileNotFoundError(
+                f"No BPE model (bpe.model) found in '{model_dir}' — required "
+                "to encode custom wake phrases for this bundle."
+            )
+        try:
+            import sentencepiece as spm
+        except ImportError as e:
+            raise ImportError(
+                "Encoding wake phrases requires sentencepiece. "
+                "Install it with: pip install sentencepiece"
+            ) from e
 
-    def __call__(self, x: np.ndarray):
-        """Check wakeword probability in audio embeddings"""
-        if self.prob < self.threshold:
-            self._predict(x)
-            if self.prob > self.threshold:
-                return WakeWordStatus.START
-            else:
-                return
-        elif self.prob >= self.threshold:
-            self._predict(x)
-            if self.prob < self.threshold:
-                return WakeWordStatus.END
-            else:
-                return WakeWordStatus.ONGOING
+        sp = spm.SentencePieceProcessor()
+        sp.load(bpe_model)
+
+        # read the token vocabulary to verify the casing convention
+        vocab = set()
+        with open(model_dir / "tokens.txt", encoding="utf-8") as f:
+            for line in f:
+                parts = line.split()
+                if parts:
+                    vocab.add(parts[0])
+
+        lines = []
+        for phrase in phrases:
+            pieces = None
+            for candidate in (phrase.upper(), phrase, phrase.lower()):
+                encoded = sp.encode_as_pieces(candidate)
+                if encoded and all(p in vocab for p in encoded):
+                    pieces = encoded
+                    break
+            if pieces is None:
+                raise ValueError(
+                    f"The wake phrase '{phrase}' cannot be encoded with this "
+                    "bundle's tokens — check that the phrase language matches "
+                    "the keyword spotting model."
+                )
+            # NOTE: sherpa's keywords parser splits on whitespace. The display
+            # label after @ must not contain spaces
+            label = phrase.replace(" ", "_")
+            lines.append(f"{' '.join(pieces)} @{label}")
+
+        keywords_file = model_dir / "agents_keywords.txt"
+        keywords_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return str(keywords_file)
+
+    def process(self, x_np_32: np.ndarray) -> Optional[str]:
+        """Feed an audio block and return the detected wake phrase, if any.
+
+        :param x_np_32: int16-scale float32 samples (same convention as
+            VADIterator)
+        """
+        self._stream.accept_waveform(self._sample_rate, x_np_32 / 32768.0)
+        detected = None
+        while self._spotter.is_ready(self._stream):
+            self._spotter.decode_stream(self._stream)
+            result = self._spotter.get_result(self._stream)
+            if result:
+                detected = result
+                # reset so the same stream can detect again later
+                self._spotter.reset_stream(self._stream)
+        return detected
+
+    def reset(self):
+        """Start a fresh detection stream (e.g. at the end of a speech
+        segment) so stale audio does not linger in the decoder state."""
+        self._stream = self._spotter.create_stream()
 
 
 class HypothesisBuffer:

--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 86.6%</title>
+    <title>interrogate: 87.1%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">86.6%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">86.6%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">87.1%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">87.1%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -7,6 +7,7 @@ from agents.config import (
     LLMConfig,
     MLLMConfig,
     MotionDetectorConfig,
+    VLAConfig,
     SpeechToTextConfig,
     TextToSpeechConfig,
     SemanticRouterConfig,
@@ -212,3 +213,33 @@ class TestMotionDetectorConfig:
         rebuilt = MotionDetectorConfig(**json.loads(config.to_json()))
         assert rebuilt.voxel_size == pytest.approx(0.2)
         assert rebuilt.base_frame == "base_footprint"
+
+
+class TestVLAConfig:
+    _MAPS = {
+        "joint_names_map": {"shoulder_pan.pos": "joint1"},
+        "camera_inputs_map": {"front": {"name": "camera", "msg_type": "Image"}},
+    }
+
+    def test_construction_defaults(self):
+        c = VLAConfig(**self._MAPS)
+        assert c.aggregate_fn_name == "latest_only"
+        # main action loop runs at the observation sending rate
+        assert c.loop_rate == c.observation_sending_rate
+
+    def test_aggregate_preset_selectable(self):
+        c = VLAConfig(**self._MAPS, aggregate_fn_name="weighted_average")
+        assert c.aggregate_fn_name == "weighted_average"
+
+    def test_rates_must_be_positive(self):
+        with pytest.raises(ValueError):
+            VLAConfig(**self._MAPS, observation_sending_rate=0.0)
+        with pytest.raises(ValueError):
+            VLAConfig(**self._MAPS, action_sending_rate=0.0)
+
+    def test_serialization_round_trip(self):
+        """Multiprocess launch path: config survives a JSON round trip."""
+        config = VLAConfig(**self._MAPS, aggregate_fn_name="conservative")
+        rebuilt = VLAConfig(**json.loads(config.to_json()))
+        assert rebuilt.aggregate_fn_name == "conservative"
+        assert rebuilt.joint_names_map == {"shoulder_pan.pos": "joint1"}

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -128,16 +128,38 @@ class TestTTSConfig:
         TextToSpeechConfig()
 
     def test_stream_with_local_ok(self):
-        """Local model + stream is accepted at config time; stream is
-        disabled at runtime by _deploy_local_model."""
+        """Local model + stream is a supported combination (chunks are
+        yielded by the local model as they are synthesized)."""
         c = TextToSpeechConfig(enable_local_model=True)
         assert c.enable_local_model is True
-        assert c.stream is True  # will be overridden at deploy time
+        assert c.stream is True
 
     def test_local_no_stream_ok(self):
         c = TextToSpeechConfig(enable_local_model=True, stream=False)
         assert c.enable_local_model is True
         assert c.stream is False
+
+    def test_local_model_defaults(self):
+        c = TextToSpeechConfig()
+        assert "pocket-tts" in c.local_model_path
+        assert c.speaker_id == 0
+        assert c.local_model_options == {}
+
+    def test_speaker_id_non_negative(self):
+        with pytest.raises(ValueError):
+            TextToSpeechConfig(speaker_id=-1)
+        c = TextToSpeechConfig(speaker_id=3)
+        assert c.speaker_id == 3
+
+    def test_local_model_options_round_trip(self):
+        config = TextToSpeechConfig(
+            local_model_options={"model_type": "kokoro", "length_scale": 1.2}
+        )
+        rebuilt = TextToSpeechConfig(**json.loads(config.to_json()))
+        assert rebuilt.local_model_options == {
+            "model_type": "kokoro",
+            "length_scale": 1.2,
+        }
 
     def test_stream_to_ip_without_play_raises(self):
         with pytest.raises(ValueError):

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -237,9 +237,18 @@ class TestVLAConfig:
         with pytest.raises(ValueError):
             VLAConfig(**self._MAPS, action_sending_rate=0.0)
 
+    def test_policy_action_units_default(self):
+        c = VLAConfig(**self._MAPS)
+        assert c.policy_action_units == "radians"
+
     def test_serialization_round_trip(self):
         """Multiprocess launch path: config survives a JSON round trip."""
-        config = VLAConfig(**self._MAPS, aggregate_fn_name="conservative")
+        config = VLAConfig(
+            **self._MAPS,
+            aggregate_fn_name="conservative",
+            policy_action_units="normalized",
+        )
         rebuilt = VLAConfig(**json.loads(config.to_json()))
         assert rebuilt.aggregate_fn_name == "conservative"
+        assert rebuilt.policy_action_units == "normalized"
         assert rebuilt.joint_names_map == {"shoulder_pan.pos": "joint1"}

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -88,6 +88,15 @@ class TestSTTConfig:
         """SpeechToTextConfig can be constructed with defaults."""
         SpeechToTextConfig()
 
+    def test_wakeword_defaults(self):
+        c = SpeechToTextConfig(enable_vad=True, enable_wakeword=True)
+        assert c.wakeword_phrase == "ok robot"
+        assert c.wakeword_threshold == 0.25
+        assert c.wakeword_model_path.endswith(".tar.bz2")
+        # the openWakeWord-era model fields are gone
+        assert not hasattr(c, "melspectrogram_model_path")
+        assert not hasattr(c, "embedding_model_path")
+
     def test_wakeword_requires_vad(self):
         with pytest.raises(ValueError):
             SpeechToTextConfig(enable_wakeword=True)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -67,9 +67,9 @@ class TestMLLMConfig:
         assert c.task == "general"
         assert c.enable_local_model is True
 
-    def test_stream_with_local_raises(self):
-        with pytest.raises(ValueError):
-            MLLMConfig(enable_local_model=True, stream=True)
+    def test_stream_with_local_ok(self):
+        c = MLLMConfig(enable_local_model=True, stream=True)
+        assert c.stream is True
 
     def test_inference_params_with_task(self):
         c = MLLMConfig(task="general")

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -283,3 +283,12 @@ class TestVLAConfig:
         assert rebuilt.aggregate_fn_name == "conservative"
         assert rebuilt.policy_action_units == "normalized"
         assert rebuilt.joint_names_map == {"shoulder_pan.pos": "joint1"}
+
+
+class TestVLMLocalModelDefaults:
+    def test_default_is_qwen3_vl(self):
+        from agents.config import MLLMConfig
+
+        c = MLLMConfig()
+        assert c.local_model_path == "ggml-org/Qwen3-VL-2B-Instruct-GGUF"
+        assert c.local_model_options == {}

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -212,6 +212,22 @@ class TestLLMThinkTokens:
         publish.assert_called_once()
         assert publish.call_args[0][0] == "Paris."
 
+    def test_stream_unterminated_think_warns(self, llm):
+        """A stream that ends inside a think block must warn, same as the
+        non-streaming path."""
+        llm.config.break_character = ""
+        llm._in_think_block = False
+        llm._swallow_stream_ws = False
+        llm.result_partial = []
+        llm.result_complete = []
+
+        for token in ["<think>", "reasoning cut off by the token limit"]:
+            llm._LLM__process_stream_token(token)
+        llm._LLM__finalize_stream()
+
+        llm.get_logger.return_value.warning.assert_called_once()
+        llm.publishers_dict["out"].publish.assert_not_called()
+
 
 class TestLLMWarmup:
     def test_with_model_client(self, llm, mock_model_client):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -229,6 +229,36 @@ class TestLLMThinkTokens:
         llm.publishers_dict["out"].publish.assert_not_called()
 
 
+class TestLLMStreamCleanup:
+    def test_generator_closed_when_publish_raises(self, llm):
+        """An abandoned stream must be finalized immediately so it releases
+        held resources (e.g. the local model lock) instead of waiting for
+        garbage collection."""
+        closed = []
+
+        def stream():
+            try:
+                yield "one. "
+                yield "two. "
+            finally:
+                closed.append(True)
+
+        llm.config.break_character = ""
+        llm._in_think_block = False
+        llm._swallow_stream_ws = False
+        llm.result_partial = []
+        llm.result_complete = []
+        llm.publishers_dict["out"].publish.side_effect = RuntimeError(
+            "publisher destroyed"
+        )
+
+        # keep a reference so finalization cannot come from refcounting
+        result = {"output": stream()}
+        llm._LLM__handle_streaming_generator(result)
+
+        assert closed == [True]
+
+
 class TestLLMWarmup:
     def test_with_model_client(self, llm, mock_model_client):
         llm._warmup()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -168,6 +168,51 @@ class TestLLMExecutionStep:
         mock_tool.assert_called_once()
 
 
+class TestLLMThinkTokens:
+    THINKING = "<think>\nreasoning here\n</think>\n\nParis."
+
+    def _run_step(self, llm, mock_model_client, text=None):
+        mock_model_client.inference.return_value = {"output": text or self.THINKING}
+        mock_cb = MagicMock()
+        mock_cb.get_output.return_value = "capital of France?"
+        llm.trig_callbacks = {"in": mock_cb}
+        llm.callbacks = {}
+        llm._execution_step(topic=Topic(name="in", msg_type="String"))
+        return llm.publishers_dict["out"].publish.call_args[0][0]
+
+    def test_stripped_by_default(self, llm, mock_model_client):
+        assert self._run_step(llm, mock_model_client) == "Paris."
+
+    def test_kept_when_disabled(self, llm, mock_model_client):
+        llm.config.strip_think_tokens = False
+        assert self._run_step(llm, mock_model_client) == self.THINKING
+
+    def test_unterminated_think_block_stripped_with_warning(
+        self, llm, mock_model_client
+    ):
+        """A block truncated by max_new_tokens has no closing tag but must
+        still be stripped, and the component should warn about it."""
+        truncated = "<think>\nreasoning cut off by the token limit"
+        assert self._run_step(llm, mock_model_client, text=truncated) == ""
+        llm.get_logger.return_value.warning.assert_called_once()
+
+    def test_stream_tokens_filtered(self, llm):
+        """Think tokens are dropped, including the whitespace models emit
+        after the closing tag — the answer must not start with blank lines."""
+        llm.config.break_character = ""
+        llm._in_think_block = False
+        llm._swallow_stream_ws = False
+        llm.result_partial = []
+        llm.result_complete = []
+
+        for token in ["<think>", "\n", "reasoning", "</think>", "\n\n", "\nParis."]:
+            llm._LLM__process_stream_token(token)
+
+        publish = llm.publishers_dict["out"].publish
+        publish.assert_called_once()
+        assert publish.call_args[0][0] == "Paris."
+
+
 class TestLLMWarmup:
     def test_with_model_client(self, llm, mock_model_client):
         llm._warmup()

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -129,3 +129,80 @@ class TestCallWithTools:
         call_kwargs = local_llm.llm.create_chat_completion.call_args[1]
         assert call_kwargs["tools"] == tools
         assert call_kwargs["tool_choice"] == "auto"
+
+
+class TestLocalLLMModelOptions:
+    @staticmethod
+    def _fake_llama(mock_llama_cpp):
+        """Install a fake Llama class with a realistic signature, recording
+        constructor and from_pretrained calls."""
+        calls = {}
+
+        class FakeLlama:
+            def __init__(
+                self,
+                model_path=None,
+                n_ctx=512,
+                n_gpu_layers=0,
+                n_threads=1,
+                n_batch=512,
+                flash_attn=False,
+                chat_format=None,
+                verbose=True,
+            ):
+                calls["init"] = {
+                    "model_path": model_path,
+                    "n_ctx": n_ctx,
+                    "n_gpu_layers": n_gpu_layers,
+                    "n_threads": n_threads,
+                    "n_batch": n_batch,
+                    "flash_attn": flash_attn,
+                    "chat_format": chat_format,
+                    "verbose": verbose,
+                }
+
+            @classmethod
+            def from_pretrained(cls, repo_id=None, filename=None, **kwargs):
+                calls["from_pretrained"] = {
+                    "repo_id": repo_id,
+                    "filename": filename,
+                    **kwargs,
+                }
+                return MagicMock()
+
+        mock_llama_cpp.Llama = FakeLlama
+        return calls
+
+    def test_options_passed_and_defaults_set(self, mock_llama_cpp, tmp_path):
+        calls = self._fake_llama(mock_llama_cpp)
+        from agents.utils.local_llm import LocalLLM
+
+        gguf = tmp_path / "model.gguf"
+        gguf.touch()
+        LocalLLM(
+            str(gguf), device="cpu", ncpu=2, model_options={"n_batch": 1024}
+        )
+        assert calls["init"]["n_batch"] == 1024
+        # context defaults to the model's trained length, not llama-cpp's 512
+        assert calls["init"]["n_ctx"] == 0
+        assert calls["init"]["n_threads"] == 2
+
+    def test_filename_selects_quant_from_repo(self, mock_llama_cpp):
+        calls = self._fake_llama(mock_llama_cpp)
+        from agents.utils.local_llm import LocalLLM
+
+        LocalLLM(
+            "some/repo-GGUF",
+            device="cpu",
+            model_options={"filename": "*q4_k_m*.gguf"},
+        )
+        assert calls["from_pretrained"]["filename"] == "*q4_k_m*.gguf"
+
+    def test_unknown_option_raises(self, mock_llama_cpp, tmp_path):
+        self._fake_llama(mock_llama_cpp)
+        from agents.utils.local_llm import LocalLLM
+
+        gguf = tmp_path / "model.gguf"
+        gguf.touch()
+        with pytest.raises(ValueError, match="Valid options"):
+            LocalLLM(str(gguf), model_options={"not_an_option": 1})

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -2,6 +2,8 @@
 
 import sys
 import json
+import threading
+import time
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +24,7 @@ def local_llm(mock_llama_cpp):
     llm.llm = MagicMock()
     llm.device = "cpu"
     llm.ncpu = 1
+    llm._lock = threading.Lock()
     return llm
 
 
@@ -118,6 +121,41 @@ class TestCallWithTools:
         assert result["tool_calls"][0]["function"]["name"] == "route_to_nav"
         assert result["tool_calls"][0]["function"]["arguments"] == {"x": 1}
 
+    def test_inline_tool_calls_extracted_from_text(self, local_llm):
+        """llama-cpp's GGUF-template handler leaves Qwen/Hermes tool calls as
+        text — LocalLLM must parse them into the structured field."""
+        content = (
+            "<think>\nThe user asks a visual question.\n</think>\n\n"
+            '<tool_call>\n{"name": "route_to_vision", "arguments": {}}\n</tool_call>'
+        )
+        local_llm.llm.create_chat_completion.return_value = _mock_response(content)
+
+        tools = [{"type": "function", "function": {"name": "route_to_vision"}}]
+        result = local_llm(
+            {"query": [{"role": "user", "content": "what do you see"}], "tools": tools}
+        )
+        assert "<tool_call>" not in result["output"]
+        assert result["tool_calls"][0]["function"]["name"] == "route_to_vision"
+        assert result["tool_calls"][0]["function"]["arguments"] == {}
+
+    def test_inline_tool_calls_ignored_without_tools(self, local_llm):
+        content = '<tool_call>\n{"name": "fn", "arguments": {}}\n</tool_call>'
+        local_llm.llm.create_chat_completion.return_value = _mock_response(content)
+
+        result = local_llm({"query": [{"role": "user", "content": "Hi"}]})
+        assert "tool_calls" not in result
+        assert "<tool_call>" in result["output"]
+
+    def test_malformed_inline_tool_call_kept_as_text(self, local_llm):
+        content = "<tool_call>\n{not valid json}\n</tool_call>"
+        local_llm.llm.create_chat_completion.return_value = _mock_response(content)
+
+        tools = [{"type": "function", "function": {"name": "fn"}}]
+        result = local_llm(
+            {"query": [{"role": "user", "content": "Hi"}], "tools": tools}
+        )
+        assert "tool_calls" not in result
+
     def test_passes_tools_to_api(self, local_llm):
         local_llm.llm.create_chat_completion.return_value = _mock_response("ok")
 
@@ -129,6 +167,35 @@ class TestCallWithTools:
         call_kwargs = local_llm.llm.create_chat_completion.call_args[1]
         assert call_kwargs["tools"] == tools
         assert call_kwargs["tool_choice"] == "auto"
+
+
+class TestThreadSafety:
+    def test_concurrent_calls_serialized(self, local_llm):
+        """llama-cpp contexts are not thread-safe — concurrent component
+        callbacks must never overlap inside create_chat_completion."""
+        active, max_active = 0, 0
+
+        def fake_create(**kwargs):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            time.sleep(0.01)
+            active -= 1
+            return _mock_response("ok")
+
+        local_llm.llm.create_chat_completion.side_effect = fake_create
+
+        threads = [
+            threading.Thread(
+                target=local_llm, args=({"query": [{"role": "user", "content": "x"}]},)
+            )
+            for _ in range(4)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert max_active == 1
 
 
 class TestLocalLLMModelOptions:

--- a/tests/test_local_stt.py
+++ b/tests/test_local_stt.py
@@ -66,3 +66,165 @@ class TestLocalSTTCall:
     def test_unsupported_type(self, local_stt):
         result = local_stt({"query": 12345})
         assert result["output"] == ""
+
+
+class TestLocalSTTModelDetection:
+    """Family detection from bundle contents — pure filesystem, no sherpa."""
+
+    @staticmethod
+    def _make_bundle(tmp_path, files, dirname="bundle"):
+        bundle = tmp_path / dirname
+        bundle.mkdir()
+        for name in files:
+            if name.endswith("/"):
+                (bundle / name.rstrip("/")).mkdir()
+            else:
+                (bundle / name).touch()
+        return str(bundle)
+
+    def test_parakeet_transducer_detected(self, tmp_path):
+        from agents.utils.local_stt import detect_model_family
+
+        bundle = self._make_bundle(
+            tmp_path,
+            ["encoder.int8.onnx", "decoder.int8.onnx", "joiner.int8.onnx", "tokens.txt"],
+            dirname="sherpa-onnx-nemo-parakeet-tdt-0.6b-v2-int8",
+        )
+        family, files = detect_model_family(bundle)
+        assert family == "transducer"
+        assert files["joiner"].endswith("joiner.int8.onnx")
+
+    def test_whisper_fallback(self, tmp_path):
+        from agents.utils.local_stt import detect_model_family
+
+        bundle = self._make_bundle(
+            tmp_path,
+            [
+                "tiny.en-encoder.int8.onnx",
+                "tiny.en-decoder.int8.onnx",
+                "tiny.en-tokens.txt",
+            ],
+        )
+        family, files = detect_model_family(bundle)
+        assert family == "whisper"
+        assert "encoder" in files and "decoder" in files
+
+    def test_qwen3_detected(self, tmp_path):
+        from agents.utils.local_stt import detect_model_family
+
+        bundle = self._make_bundle(
+            tmp_path,
+            ["conv_frontend.onnx", "encoder.int8.onnx", "decoder.int8.onnx", "tokenizer/"],
+        )
+        family, files = detect_model_family(bundle)
+        assert family == "qwen3_asr"
+        assert files["tokenizer"].endswith("tokenizer")
+
+    def test_moonshine_v1_and_v2(self, tmp_path):
+        from agents.utils.local_stt import detect_model_family
+
+        v1 = self._make_bundle(
+            tmp_path,
+            [
+                "preprocess.onnx",
+                "encode.int8.onnx",
+                "uncached_decode.int8.onnx",
+                "cached_decode.int8.onnx",
+                "tokens.txt",
+            ],
+            dirname="moonshine-v1",
+        )
+        assert detect_model_family(v1)[0] == "moonshine"
+
+        v2 = self._make_bundle(
+            tmp_path,
+            ["encoder_model.ort", "decoder_model_merged.ort", "tokens.txt"],
+            dirname="moonshine-v2",
+        )
+        assert detect_model_family(v2)[0] == "moonshine_v2"
+
+    def test_sense_voice_needs_name_hint(self, tmp_path):
+        from agents.utils.local_stt import detect_model_family
+
+        bundle = self._make_bundle(
+            tmp_path,
+            ["model.int8.onnx", "tokens.txt"],
+            dirname="sherpa-onnx-sense-voice-zh-en-int8",
+        )
+        assert detect_model_family(bundle)[0] == "sense_voice"
+
+    def test_model_type_override(self, tmp_path):
+        from agents.utils.local_stt import detect_model_family
+
+        bundle = self._make_bundle(
+            tmp_path, ["model.onnx", "tokens.txt"], dirname="anon"
+        )
+        family, _ = detect_model_family(bundle, model_type="nemo_ctc")
+        assert family == "nemo_ctc"
+
+    def test_undetectable_raises_with_hint(self, tmp_path):
+        from agents.utils.local_stt import detect_model_family
+
+        bundle = self._make_bundle(tmp_path, ["README.md"])
+        with pytest.raises(ValueError, match="model_type"):
+            detect_model_family(bundle)
+
+
+class TestLocalSTTModelOptions:
+    """Options validation against real sherpa factory signatures."""
+
+    @staticmethod
+    def _mocked_sherpa_with_real_signature():
+        """A mock sherpa module whose from_transducer has the real signature."""
+        import inspect
+
+        real_sherpa = pytest.importorskip("sherpa_onnx")
+        mock = MagicMock()
+        factory_mock = MagicMock()
+        factory_mock.__signature__ = inspect.signature(
+            real_sherpa.OfflineRecognizer.from_transducer
+        )
+        mock.OfflineRecognizer.from_transducer = factory_mock
+        return mock
+
+    def test_transducer_options_and_nemo_model_type(self, tmp_path):
+        mock = self._mocked_sherpa_with_real_signature()
+        bundle = tmp_path / "sherpa-onnx-nemo-parakeet-tdt-0.6b-v2-int8"
+        bundle.mkdir()
+        for f in [
+            "encoder.int8.onnx",
+            "decoder.int8.onnx",
+            "joiner.int8.onnx",
+            "tokens.txt",
+        ]:
+            (bundle / f).touch()
+
+        from agents.utils.local_stt import LocalSTT
+
+        with patch.dict(sys.modules, {"sherpa_onnx": mock}):
+            stt = LocalSTT(
+                str(bundle),
+                device="cpu",
+                ncpu=2,
+                model_options={"decoding_method": "greedy_search"},
+            )
+        assert stt.model_family == "transducer"
+        _, kwargs = mock.OfflineRecognizer.from_transducer.call_args
+        assert kwargs["model_type"] == "nemo_transducer"
+        assert kwargs["decoding_method"] == "greedy_search"
+        assert kwargs["num_threads"] == 2
+        # language is not a transducer factory param and must not be passed
+        assert "language" not in kwargs
+
+    def test_unknown_option_raises(self, tmp_path):
+        mock = self._mocked_sherpa_with_real_signature()
+        bundle = tmp_path / "parakeet"
+        bundle.mkdir()
+        for f in ["encoder.onnx", "decoder.onnx", "joiner.onnx", "tokens.txt"]:
+            (bundle / f).touch()
+
+        from agents.utils.local_stt import LocalSTT
+
+        with patch.dict(sys.modules, {"sherpa_onnx": mock}):
+            with pytest.raises(ValueError, match="Valid options"):
+                LocalSTT(str(bundle), model_options={"not_an_option": 1})

--- a/tests/test_local_tts.py
+++ b/tests/test_local_tts.py
@@ -22,6 +22,9 @@ def local_tts(mock_sherpa):
     tts._tts = MagicMock()
     tts.device = "cpu"
     tts.ncpu = 1
+    tts.speaker_id = 0
+    tts.stream = False
+    tts._generation_config = None
     return tts
 
 
@@ -38,10 +41,68 @@ class TestLocalTTSCall:
         assert len(result["output"]) > 0
         # Verify WAV header
         assert result["output"][:4] == b"RIFF"
+        # terminal punctuation is appended before synthesis
         local_tts._tts.generate.assert_called_once_with(
-            "Hello world", sid=0, speed=1.0
+            "Hello world.", sid=0, speed=1.0
         )
 
     def test_empty_text(self, local_tts):
         result = local_tts({"query": ""})
         assert result["output"] == b""
+
+    def test_terminal_punctuation_added(self, local_tts):
+        """Unpunctuated text destabilizes LM stop prediction (runaway
+        babbling) — a terminal period must be appended before synthesis."""
+        mock_audio = MagicMock()
+        mock_audio.samples = np.zeros(100, dtype=np.float32)
+        mock_audio.sample_rate = 24000
+        local_tts._tts.generate.return_value = mock_audio
+
+        local_tts({"query": "who are you"})
+        local_tts._tts.generate.assert_called_once_with(
+            "who are you.", sid=0, speed=1.0
+        )
+        local_tts._tts.generate.reset_mock()
+
+        local_tts({"query": "who are you?  "})
+        local_tts._tts.generate.assert_called_once_with(
+            "who are you?", sid=0, speed=1.0
+        )
+
+    def test_speaker_id_passed_to_generate(self, local_tts):
+        mock_audio = MagicMock()
+        mock_audio.samples = np.zeros(100, dtype=np.float32)
+        mock_audio.sample_rate = 24000
+        local_tts._tts.generate.return_value = mock_audio
+        local_tts.speaker_id = 3
+
+        local_tts({"query": "Hello"})
+        local_tts._tts.generate.assert_called_once_with("Hello.", sid=3, speed=1.0)
+
+
+class TestLoadModelRepoLocalPath:
+    def test_local_directory_returned_as_is(self, tmp_path):
+        from agents.utils.utils import load_model_repo
+
+        bundle = tmp_path / "my_bundle"
+        bundle.mkdir()
+        assert load_model_repo("local_tts", str(bundle)) == str(bundle)
+
+
+class TestLocalTTSStreaming:
+    def test_stream_yields_wav_chunks(self, local_tts):
+        local_tts.stream = True
+        local_tts._tts.sample_rate = 24000
+
+        def fake_generate(text, sid=0, speed=1.0, callback=None):
+            # emulate sherpa-onnx invoking the callback per synthesized chunk
+            callback(np.zeros(1000, dtype=np.float32), 0.5)
+            callback(np.full(500, 0.1, dtype=np.float32), 1.0)
+            return MagicMock()
+
+        local_tts._tts.generate.side_effect = fake_generate
+
+        result = local_tts({"query": "Hello"})
+        chunks = list(result["output"])
+        assert len(chunks) == 2
+        assert all(chunk[:4] == b"RIFF" for chunk in chunks)

--- a/tests/test_local_vlm.py
+++ b/tests/test_local_vlm.py
@@ -1,6 +1,7 @@
 """Tests for LocalVLM wrapper — no ROS needed."""
 
 import sys
+import threading
 import pytest
 import numpy as np
 from unittest.mock import MagicMock, patch
@@ -31,6 +32,7 @@ def local_vlm(mock_deps):
     vlm.llm = MagicMock()
     vlm.device = "cpu"
     vlm.ncpu = 1
+    vlm._lock = threading.Lock()
     return vlm
 
 
@@ -65,6 +67,37 @@ class TestLocalVLMCall:
         content = messages[0]["content"]
         assert any(item["type"] == "image_url" for item in content)
         assert any(item["type"] == "text" for item in content)
+
+    def test_streaming_returns_generator(self, local_vlm):
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        chunks = [
+            {"choices": [{"delta": {"role": "assistant"}, "finish_reason": None}]},
+            {"choices": [{"delta": {"content": "A red"}, "finish_reason": None}]},
+            {"choices": [{"delta": {"content": " box"}, "finish_reason": None}]},
+            {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+        ]
+        local_vlm.llm.create_chat_completion.return_value = iter(chunks)
+
+        result = local_vlm(
+            {"query": [{"role": "user", "content": "What is this?"}], "images": [img]},
+            stream=True,
+        )
+        assert list(result["output"]) == ["A red", " box"]
+        assert local_vlm.llm.create_chat_completion.call_args[1]["stream"] is True
+
+    def test_generation_params_forwarded(self, local_vlm):
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        local_vlm.llm.create_chat_completion.return_value = _mock_vlm_response("ok")
+
+        local_vlm({
+            "query": [{"role": "user", "content": "What is this?"}],
+            "images": [img],
+            "temperature": 0.5,
+            "max_new_tokens": 100,
+        })
+        call_kwargs = local_vlm.llm.create_chat_completion.call_args[1]
+        assert call_kwargs["temperature"] == 0.5
+        assert call_kwargs["max_tokens"] == 100
 
     def test_no_images(self, local_vlm):
         result = local_vlm({

--- a/tests/test_local_vlm.py
+++ b/tests/test_local_vlm.py
@@ -88,9 +88,13 @@ class TestLocalVLMCall:
 
         call_kwargs = local_vlm.llm.create_chat_completion.call_args[1]
         messages = call_kwargs["messages"]
-        # The text part should be the last user message
+        # The full conversation is preserved and the images are attached to
+        # the LAST user message
+        assert len(messages) == 3
+        assert messages[0] == {"role": "user", "content": "First question"}
+        assert messages[1] == {"role": "assistant", "content": "Answer"}
         text_items = [
-            item for item in messages[0]["content"] if item["type"] == "text"
+            item for item in messages[2]["content"] if item["type"] == "text"
         ]
         assert text_items[0]["text"] == "Second question"
 
@@ -108,3 +112,51 @@ class TestLocalVLMCall:
         image_item = next(item for item in content if item["type"] == "image_url")
         url = image_item["image_url"]["url"]
         assert url.startswith("data:image/png;base64,")
+
+
+class TestVLMFamilyDetection:
+    def test_families_detected_from_name(self):
+        from agents.utils.local_vlm import detect_vlm_family
+
+        assert detect_vlm_family("ggml-org/moondream2-20250414-GGUF") == "moondream"
+        assert detect_vlm_family("unsloth/Qwen3-VL-2B-Instruct-GGUF") == "qwen_vl"
+        assert detect_vlm_family("openbmb/MiniCPM-V-2_6-gguf") == "minicpm"
+        assert detect_vlm_family("cjpais/llava-v1.6-mistral-7b-gguf") == "llava16"
+        assert detect_vlm_family("mys/ggml_llava-v1.5-7b") == "llava"
+
+    def test_model_type_override_and_unknown(self):
+        from agents.utils.local_vlm import detect_vlm_family
+
+        assert detect_vlm_family("some/opaque-model", model_type="llava") == "llava"
+        with pytest.raises(ValueError, match="model_type"):
+            detect_vlm_family("some/opaque-model")
+        with pytest.raises(ValueError, match="Unknown model_type"):
+            detect_vlm_family("x", model_type="not_a_family")
+
+
+class TestVLMMessageBuilding:
+    def test_context_preserved_and_multi_image(self, local_vlm):
+        local_vlm.llm.create_chat_completion.return_value = _mock_vlm_response(
+            "Two oranges"
+        )
+        images = [
+            np.zeros((4, 4, 3), dtype=np.uint8),
+            np.ones((4, 4, 3), dtype=np.uint8),
+        ]
+        result = local_vlm(
+            {
+                "query": [
+                    {"role": "system", "content": "You are a robot."},
+                    {"role": "user", "content": "What do you see?"},
+                ],
+                "images": images,
+            }
+        )
+        assert result["output"] == "Two oranges"
+        messages = local_vlm.llm.create_chat_completion.call_args[1]["messages"]
+        # system prompt preserved
+        assert messages[0] == {"role": "system", "content": "You are a robot."}
+        # both images attached to the user message, text kept
+        user_content = messages[1]["content"]
+        assert sum(1 for part in user_content if part["type"] == "image_url") == 2
+        assert user_content[-1] == {"type": "text", "text": "What do you see?"}

--- a/tests/test_semantic_router.py
+++ b/tests/test_semantic_router.py
@@ -1,12 +1,14 @@
 """Tests for SemanticRouter component — requires rclpy."""
 
 import pytest
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from agents.config import SemanticRouterConfig, LLMConfig
 from agents.ros import Topic, Route
+from agents.components.llm import LLM
 from agents.components.semantic_router import SemanticRouter, RouterMode
 from agents.clients.model_base import ModelClient
+from tests.conftest import mock_component_internals
 
 
 @pytest.fixture
@@ -68,6 +70,37 @@ class TestRouterConstruction:
                 routes=routes,
                 component_name="test_fail_router",
             )
+
+    def test_agentic_local_mode_deploys_local_model(self, rclpy_init, routes):
+        """Regression: agentic routing on the local LLM must deploy the model
+        on configure (LLM.custom_on_configure only deploys for type(self) is
+        LLM, so the router has to trigger its own deploy)."""
+        router = SemanticRouter(
+            inputs=[Topic(name="in", msg_type="String")],
+            routes=routes,
+            config=LLMConfig(enable_local_model=True),
+            component_name="test_local_deploy_router",
+        )
+        mock_component_internals(router)
+        router._deploy_local_model = MagicMock()
+        with patch.object(LLM, "custom_on_configure"):
+            router.custom_on_configure()
+        router._deploy_local_model.assert_called_once()
+
+    def test_agentic_client_mode_does_not_deploy_local_model(
+        self, rclpy_init, routes, mock_model_client
+    ):
+        router = SemanticRouter(
+            inputs=[Topic(name="in", msg_type="String")],
+            routes=routes,
+            model_client=mock_model_client,
+            component_name="test_client_no_deploy_router",
+        )
+        mock_component_internals(router)
+        router._deploy_local_model = MagicMock()
+        with patch.object(LLM, "custom_on_configure"):
+            router.custom_on_configure()
+        router._deploy_local_model.assert_not_called()
 
     def test_no_tool_support_raises(self, rclpy_init, routes):
         client = MagicMock(spec=ModelClient)

--- a/tests/test_speechtotext.py
+++ b/tests/test_speechtotext.py
@@ -1,7 +1,9 @@
 """Tests for SpeechToText component — requires rclpy."""
 
+import sys
+
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from agents.config import SpeechToTextConfig
 from agents.ros import Topic
@@ -114,3 +116,66 @@ class TestSTTCreateInput:
 
         result = stt._create_input(topic=trigger)
         assert result is None
+
+
+class TestWakeWordSpotter:
+    """Keyword-file building for the sherpa keyword spotter."""
+
+    @staticmethod
+    def _bundle_with_tokens(tmp_path, tokens):
+        bundle = tmp_path / "kws-bundle"
+        bundle.mkdir()
+        (bundle / "bpe.model").touch()
+        (bundle / "tokens.txt").write_text(
+            "".join(f"{token} {i}\n" for i, token in enumerate(tokens))
+        )
+        return bundle
+
+    @staticmethod
+    def _mock_sentencepiece(pieces_map):
+        """Mock sentencepiece whose encode_as_pieces uses a lookup table."""
+        spm = MagicMock()
+        sp = spm.SentencePieceProcessor.return_value
+        sp.encode_as_pieces.side_effect = lambda text: pieces_map.get(text, ["<unk>"])
+        return spm
+
+    def test_keywords_file_built_with_casing_fallback(self, tmp_path):
+        from agents.utils.voice import WakeWordSpotter
+
+        bundle = self._bundle_with_tokens(tmp_path, ["▁HEY", "▁JARVIS"])
+        spm = self._mock_sentencepiece({"HEY JARVIS": ["▁HEY", "▁JARVIS"]})
+        with patch.dict(sys.modules, {"sentencepiece": spm}):
+            keywords_file = WakeWordSpotter._build_keywords_file(
+                bundle, ["hey jarvis"]
+            )
+        content = (bundle / "agents_keywords.txt").read_text()
+        assert keywords_file.endswith("agents_keywords.txt")
+        # uppercase encoding matched the vocab; label must be space-free
+        assert content == "▁HEY ▁JARVIS @hey_jarvis\n"
+
+    def test_unencodable_phrase_raises(self, tmp_path):
+        from agents.utils.voice import WakeWordSpotter
+
+        bundle = self._bundle_with_tokens(tmp_path, ["▁HEY", "▁JARVIS"])
+        spm = self._mock_sentencepiece({})  # nothing encodes into the vocab
+        with patch.dict(sys.modules, {"sentencepiece": spm}):
+            with pytest.raises(ValueError, match="cannot be encoded"):
+                WakeWordSpotter._build_keywords_file(bundle, ["bonjour robot"])
+
+    def test_missing_bpe_model_raises(self, tmp_path):
+        from agents.utils.voice import WakeWordSpotter
+
+        bundle = tmp_path / "no-bpe"
+        bundle.mkdir()
+        (bundle / "tokens.txt").touch()
+        with pytest.raises(FileNotFoundError, match="BPE"):
+            WakeWordSpotter._build_keywords_file(bundle, ["hey jarvis"])
+
+
+class TestLoadModelArchive:
+    def test_local_directory_returned_as_is(self, tmp_path):
+        from agents.utils.utils import load_model_archive
+
+        bundle = tmp_path / "kws"
+        bundle.mkdir()
+        assert load_model_archive("wakeword_kws", str(bundle)) == str(bundle)

--- a/tests/test_speechtotext.py
+++ b/tests/test_speechtotext.py
@@ -121,6 +121,11 @@ class TestSTTCreateInput:
 class TestWakeWordSpotter:
     """Keyword-file building for the sherpa keyword spotter."""
 
+    @pytest.fixture(autouse=True)
+    def _needs_onnxruntime(self):
+        # importing agents.utils.voice pulls in onnxruntime (VAD) at module level
+        pytest.importorskip("onnxruntime")
+
     @staticmethod
     def _bundle_with_tokens(tmp_path, tokens):
         bundle = tmp_path / "kws-bundle"

--- a/tests/test_texttospeech.py
+++ b/tests/test_texttospeech.py
@@ -74,3 +74,134 @@ class TestTTSCreateInput:
         result = tts._create_input(text="Direct text")
         assert result is not None
         assert result["query"] == "Direct text"
+
+
+class TestLocalTTSModelDetection:
+    """Family detection from bundle contents — pure filesystem, no sherpa."""
+
+    @staticmethod
+    def _make_bundle(tmp_path, files, dirname="bundle"):
+        bundle = tmp_path / dirname
+        bundle.mkdir()
+        for name in files:
+            if name.endswith("/"):
+                (bundle / name.rstrip("/")).mkdir()
+            else:
+                (bundle / name).touch()
+        return str(bundle)
+
+    def test_pocket_detected(self, tmp_path):
+        from agents.utils.local_tts import detect_model_family
+
+        bundle = self._make_bundle(
+            tmp_path,
+            [
+                "lm_main.int8.onnx",
+                "lm_flow.int8.onnx",
+                "encoder.onnx",
+                "decoder.int8.onnx",
+                "text_conditioner.onnx",
+                "vocab.json",
+                "token_scores.json",
+            ],
+        )
+        family, files = detect_model_family(bundle)
+        assert family == "pocket"
+        assert files["lm_main"].endswith("lm_main.int8.onnx")
+        assert files["vocab_json"].endswith("vocab.json")
+
+    def test_kokoro_detected(self, tmp_path):
+        from agents.utils.local_tts import detect_model_family
+
+        bundle = self._make_bundle(
+            tmp_path,
+            ["model.onnx", "voices.bin", "tokens.txt", "espeak-ng-data/"],
+        )
+        family, files = detect_model_family(bundle)
+        assert family == "kokoro"
+        assert files["data_dir"].endswith("espeak-ng-data")
+
+    def test_kitten_needs_name_hint(self, tmp_path):
+        from agents.utils.local_tts import detect_model_family
+
+        files = ["model.onnx", "voices.bin", "tokens.txt", "espeak-ng-data/"]
+        # same layout as kokoro: kitten only wins on a name hint
+        bundle = self._make_bundle(tmp_path, files, dirname="kitten-nano-en")
+        family, _ = detect_model_family(bundle)
+        assert family == "kitten"
+
+    def test_model_type_override(self, tmp_path):
+        from agents.utils.local_tts import detect_model_family
+
+        bundle = self._make_bundle(
+            tmp_path, ["model.onnx", "voices.bin", "tokens.txt"]
+        )
+        family, _ = detect_model_family(bundle, model_type="kitten")
+        assert family == "kitten"
+
+    def test_vits_detected_without_voices(self, tmp_path):
+        from agents.utils.local_tts import detect_model_family
+
+        bundle = self._make_bundle(tmp_path, ["en_US-amy.onnx", "tokens.txt"])
+        family, _ = detect_model_family(bundle)
+        assert family == "vits"
+
+    def test_undetectable_raises_with_hint(self, tmp_path):
+        from agents.utils.local_tts import detect_model_family
+
+        bundle = self._make_bundle(tmp_path, ["README.md"])
+        with pytest.raises(ValueError, match="model_type"):
+            detect_model_family(bundle)
+
+    def test_unknown_model_type_raises(self, tmp_path):
+        from agents.utils.local_tts import detect_model_family
+
+        bundle = self._make_bundle(tmp_path, ["model.onnx", "tokens.txt"])
+        with pytest.raises(ValueError, match="Unknown model_type"):
+            detect_model_family(bundle, model_type="not_a_family")
+
+
+class TestLocalTTSModelOptions:
+    """Option splitting/validation against sherpa-onnx config fields."""
+
+    def test_options_split_and_unknown_key(self):
+        sherpa_onnx = pytest.importorskip("sherpa_onnx")
+        from agents.utils.local_tts import split_model_options
+
+        sub, top, generation = split_model_options(
+            sherpa_onnx.OfflineTtsVitsModelConfig,
+            {
+                "noise_scale": 0.5,
+                "length_scale": 1.2,
+                "silence_scale": 0.1,
+                "voice": "loona",
+            },
+        )
+        assert sub == {"noise_scale": 0.5, "length_scale": 1.2}
+        assert top == {"silence_scale": 0.1}
+        assert generation == {"voice": "loona"}
+
+        with pytest.raises(ValueError, match="Valid family options"):
+            split_model_options(
+                sherpa_onnx.OfflineTtsVitsModelConfig, {"not_a_real_option": 1}
+            )
+
+    def test_voice_resolution(self, tmp_path):
+        from agents.utils.local_tts import resolve_voice_wav
+
+        bundle = tmp_path / "bundle"
+        (bundle / "test_wavs").mkdir(parents=True)
+        (bundle / "test_wavs" / "bria.wav").touch()
+        (bundle / "test_wavs" / "loona.wav").touch()
+
+        # default: first bundle voice
+        assert resolve_voice_wav(bundle, None).endswith("bria.wav")
+        # by name
+        assert resolve_voice_wav(bundle, "loona").endswith("loona.wav")
+        # unknown name lists available voices
+        with pytest.raises(ValueError, match="bria"):
+            resolve_voice_wav(bundle, "not_a_voice")
+        # no wavs in bundle
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert resolve_voice_wav(empty, None) is None

--- a/tests/test_vla.py
+++ b/tests/test_vla.py
@@ -644,3 +644,62 @@ class TestVLAComponent:
         data = published["output"]
         assert data.duration == pytest.approx(1 / comp.config.action_sending_rate)
         assert data.duration > 0
+
+    def _prepare_goal_execution(self, vla_topics, name):
+        """Build a VLA and patch the internals main_action_callback needs."""
+        model = LeRobotPolicy(name="policy")
+        client = _mock_lerobot_client(model)
+        comp = VLA(
+            inputs=[vla_topics["state"], vla_topics["camera"]],
+            outputs=[vla_topics["out"]],
+            model_client=client,
+            config=VLAConfig(
+                joint_names_map={"shoulder_pan.pos": "joint1"},
+                camera_inputs_map={"front": vla_topics["camera"]},
+            ),
+            component_name=name,
+        )
+        comp._actions_received = queue.Queue()
+        comp._last_executed_timestep_lock = threading.Lock()
+        comp._last_executed_timestep = -1
+        comp._task_completed = False
+        comp._main_goal_lock = threading.Lock()
+        comp.create_timer = MagicMock()
+        comp.get_logger = MagicMock()
+        comp.got_all_inputs = MagicMock(return_value=True)
+        comp._action_done = MagicMock(return_value=False)
+        comp._action_cleanup = MagicMock()
+        return comp
+
+    def test_cancel_requested_goal_transitions_to_canceled(
+        self, rclpy_init, vla_topics
+    ):
+        """A canceling goal must reach STATUS_CANCELED — returning without a
+        transition makes rclpy force-abort it, so clients cannot distinguish
+        a clean preempt from an execution failure."""
+        comp = self._prepare_goal_execution(vla_topics, "test_vla_cancel")
+        goal_handle = MagicMock()
+        goal_handle.request.task = "pick"
+        goal_handle.is_active = True
+        goal_handle.is_cancel_requested = True
+
+        comp.main_action_callback(goal_handle)
+
+        goal_handle.canceled.assert_called_once()
+        goal_handle.abort.assert_not_called()
+        comp._action_cleanup.assert_called_once()
+
+    def test_preempted_goal_not_transitioned_again(self, rclpy_init, vla_topics):
+        """A goal already aborted by preemption is terminal — transitioning
+        it again would be an invalid state transition."""
+        comp = self._prepare_goal_execution(vla_topics, "test_vla_preempt")
+        goal_handle = MagicMock()
+        goal_handle.request.task = "pick"
+        goal_handle.is_active = False
+        goal_handle.is_cancel_requested = False
+
+        comp.main_action_callback(goal_handle)
+
+        goal_handle.canceled.assert_not_called()
+        goal_handle.abort.assert_not_called()
+        comp._action_cleanup.assert_called_once()

--- a/tests/test_vla.py
+++ b/tests/test_vla.py
@@ -26,6 +26,7 @@ from agents.utils.actions import (
     JointsData,
     _as_depth_frame,
     convert_joint_limits_units,
+    resolve_feature_channels,
 )
 from agents.utils.utils import build_lerobot_features_from_dataset_info
 
@@ -284,6 +285,29 @@ class TestJointLimitsUnitConversion:
         out = convert_joint_limits_units(limits, "normalized")
         assert out["no_bounds"] is None
         assert out["inverted"] is None
+
+
+class TestResolveFeatureChannels:
+    def test_channel_last_with_names(self):
+        feature = {"shape": [480, 640, 1], "names": ["height", "width", "channel"]}
+        assert resolve_feature_channels(feature) == 1
+
+    def test_channel_first_with_names(self):
+        feature = {"shape": [1, 480, 640], "names": ["channels", "height", "width"]}
+        assert resolve_feature_channels(feature) == 1
+
+    def test_2d_shape_is_single_channel(self):
+        assert resolve_feature_channels({"shape": [480, 640]}) == 1
+
+    def test_3d_shape_without_names_is_channel_last(self):
+        assert resolve_feature_channels({"shape": [480, 640, 3]}) == 3
+
+    def test_missing_feature_defaults_to_rgb(self):
+        assert resolve_feature_channels({}) == 3
+
+    def test_names_not_parallel_to_shape_ignored(self):
+        feature = {"shape": [480, 640, 3], "names": ["channel"]}
+        assert resolve_feature_channels(feature) == 3
 
 
 class TestDepthFrame:

--- a/tests/test_vla.py
+++ b/tests/test_vla.py
@@ -269,6 +269,8 @@ def _ros_image(arr: np.ndarray, encoding: str):
 class TestRGBDCallbackDepthOnly:
     @pytest.fixture
     def rgbd_callback(self):
+        # RGBD is an optional msg type in agents.ros
+        pytest.importorskip("realsense2_camera_msgs")
         from agents.callbacks import RGBDCallback
 
         callback = RGBDCallback(Topic(name="cam_rgbd", msg_type="RGBD"))
@@ -343,6 +345,8 @@ class TestJointConverters:
         assert np.allclose(times, [0.1, 0.2, 0.3], atol=1e-6)
 
     def test_joint_jog_duration_is_float(self, joints_data):
+        # JointJog is an optional msg type in agents.ros
+        pytest.importorskip("control_msgs")
         msg = JointJog.convert(joints_data)
         assert msg.duration == 0.25
         assert list(msg.displacements) == [1.0, 2.0]

--- a/tests/test_vla.py
+++ b/tests/test_vla.py
@@ -21,7 +21,12 @@ from agents.components.vla import VLA
 from agents.config import VLAConfig
 from agents.models import LeRobotPolicy
 from agents.ros import JointJog, JointTrajectory, JointTrajectoryPoint, Topic
-from agents.utils.actions import AGGREGATE_FUNCTIONS, JointsData, _as_depth_frame
+from agents.utils.actions import (
+    AGGREGATE_FUNCTIONS,
+    JointsData,
+    _as_depth_frame,
+    convert_joint_limits_units,
+)
 from agents.utils.utils import build_lerobot_features_from_dataset_info
 
 SAMPLE_DATASET_INFO = {
@@ -234,6 +239,51 @@ class TestActionsQueueAggregation:
         actions = list(comp._actions_received.queue)
         # 0.7 * old + 0.3 * new
         assert np.allclose(actions[0].action, [0.7 * 1.0 + 0.3 * 9.0])
+
+
+class TestJointLimitsUnitConversion:
+    def test_radians_is_passthrough(self):
+        limits = {"joint1": {"lower": -1.0, "upper": 1.0, "velocity": 2.0}}
+        assert convert_joint_limits_units(limits, "radians") == limits
+
+    def test_degrees_conversion(self):
+        limits = {
+            "joint1": {
+                "lower": -np.pi,
+                "upper": np.pi / 2,
+                "effort": 5.0,
+                "velocity": np.pi,
+            }
+        }
+        out = convert_joint_limits_units(limits, "degrees")
+        assert out["joint1"]["lower"] == pytest.approx(-180.0)
+        assert out["joint1"]["upper"] == pytest.approx(90.0)
+        assert out["joint1"]["velocity"] == pytest.approx(180.0)
+        # effort is not an angular quantity, must stay untouched
+        assert out["joint1"]["effort"] == 5.0
+
+    def test_normalized_maps_range_and_scales_velocity(self):
+        limits = {"joint1": {"lower": -2.0, "upper": 2.0, "velocity": 1.0}}
+        out = convert_joint_limits_units(limits, "normalized")
+        assert out["joint1"]["lower"] == -100.0
+        assert out["joint1"]["upper"] == 100.0
+        # velocity scaled by the same per-joint factor: 200 / 4 rad
+        assert out["joint1"]["velocity"] == pytest.approx(50.0)
+
+    def test_normalized_gripper_maps_to_0_100(self):
+        limits = {"gripper_joint": {"lower": -0.17, "upper": 1.75, "velocity": None}}
+        out = convert_joint_limits_units(limits, "normalized")
+        assert out["gripper_joint"]["lower"] == 0.0
+        assert out["gripper_joint"]["upper"] == 100.0
+
+    def test_normalized_unusable_limits_become_none(self):
+        limits = {
+            "no_bounds": {"lower": None, "upper": 1.0},
+            "inverted": {"lower": 1.0, "upper": 1.0},
+        }
+        out = convert_joint_limits_units(limits, "normalized")
+        assert out["no_bounds"] is None
+        assert out["inverted"] is None
 
 
 class TestDepthFrame:
@@ -455,3 +505,83 @@ class TestVLAComponent:
                 ),
                 component_name="test_vla_bad_cameras",
             )
+
+    @pytest.fixture
+    def urdf_file(self, tmp_path):
+        path = tmp_path / "so101.urdf"
+        path.write_text(
+            '<robot name="so101">'
+            '<joint name="joint1" type="revolute">'
+            '<limit lower="-2.0" upper="2.0" effort="10.0" velocity="1.0"/>'
+            "</joint>"
+            '<joint name="joint2" type="revolute">'
+            '<limit lower="-1.0" upper="1.0" effort="10.0" velocity="1.0"/>'
+            "</joint>"
+            "</robot>"
+        )
+        return str(path)
+
+    def _make_vla_with_limits(self, vla_topics, dataset_info_file, config_kwargs, name):
+        model = LeRobotPolicy(name="policy", dataset_info_file=dataset_info_file)
+        client = _mock_lerobot_client(model)
+        config = VLAConfig(
+            joint_names_map={
+                "shoulder_pan.pos": "joint1",
+                "elbow_flex.pos": "joint2",
+            },
+            camera_inputs_map={
+                "front": vla_topics["camera"],
+                "depth_front": vla_topics["depth"],
+            },
+            **config_kwargs,
+        )
+        return VLA(
+            inputs=[vla_topics["state"], vla_topics["camera"], vla_topics["depth"]],
+            outputs=[vla_topics["out"]],
+            model_client=client,
+            config=config,
+            component_name=name,
+        )
+
+    def test_urdf_limits_converted_to_policy_units(
+        self, rclpy_init, vla_topics, dataset_info_file, urdf_file
+    ):
+        comp = self._make_vla_with_limits(
+            vla_topics,
+            dataset_info_file,
+            {"robot_urdf_file": urdf_file, "policy_action_units": "normalized"},
+            "test_vla_urdf_units",
+        )
+        assert comp.robot_joints_limits["joint1"]["lower"] == -100.0
+        assert comp.robot_joints_limits["joint1"]["upper"] == 100.0
+        assert comp.robot_joints_limits["joint2"]["upper"] == 100.0
+
+    def test_urdf_limits_default_stay_radians(
+        self, rclpy_init, vla_topics, dataset_info_file, urdf_file
+    ):
+        comp = self._make_vla_with_limits(
+            vla_topics,
+            dataset_info_file,
+            {"robot_urdf_file": urdf_file},
+            "test_vla_urdf_radians",
+        )
+        assert comp.robot_joints_limits["joint1"]["lower"] == -2.0
+        assert comp.robot_joints_limits["joint1"]["upper"] == 2.0
+
+    def test_manual_joint_limits_override_urdf(
+        self, rclpy_init, vla_topics, dataset_info_file, urdf_file
+    ):
+        manual = {"joint2": {"lower": -5.0, "upper": 5.0}}
+        comp = self._make_vla_with_limits(
+            vla_topics,
+            dataset_info_file,
+            {
+                "robot_urdf_file": urdf_file,
+                "policy_action_units": "normalized",
+                "joint_limits": manual,
+            },
+            "test_vla_manual_override",
+        )
+        # manual entry wins verbatim for joint2; joint1 stays URDF-derived
+        assert comp.robot_joints_limits["joint2"] == {"lower": -5.0, "upper": 5.0}
+        assert comp.robot_joints_limits["joint1"]["lower"] == -100.0

--- a/tests/test_vla.py
+++ b/tests/test_vla.py
@@ -119,6 +119,19 @@ class TestLeRobotPolicy:
             "rename_map",
         }
 
+    def test_default_dicts_not_shared_between_instances(self):
+        """Mutable defaults must be per-instance factories — a plain dict
+        default is one class-level object shared by every default-constructed
+        policy."""
+        policy_a = LeRobotPolicy(name="a")
+        policy_b = LeRobotPolicy(name="b")
+        policy_a.rename_map["observation.images.top"] = "observation.images.overhead"
+        policy_a._features["observation.state"] = {"shape": (2,)}
+        assert policy_b.rename_map == {}
+        assert policy_b._features == {}
+        # policies constructed after the mutation start clean too
+        assert LeRobotPolicy(name="c").rename_map == {}
+
     def test_rename_map_passthrough(self):
         model = LeRobotPolicy(
             name="policy",

--- a/tests/test_vla.py
+++ b/tests/test_vla.py
@@ -585,3 +585,38 @@ class TestVLAComponent:
         # manual entry wins verbatim for joint2; joint1 stays URDF-derived
         assert comp.robot_joints_limits["joint2"] == {"lower": -5.0, "upper": 5.0}
         assert comp.robot_joints_limits["joint1"]["lower"] == -100.0
+
+    def test_sent_actions_carry_one_tick_duration(self, rclpy_init, vla_topics):
+        """Published JointsData must carry a nonzero duration (one action
+        tick) — a zero time_from_start makes joint_trajectory_controller
+        reject the trajectory and gives JointJog a zero jog duration."""
+        model = LeRobotPolicy(name="policy")
+        client = _mock_lerobot_client(model)
+        comp = VLA(
+            inputs=[vla_topics["state"], vla_topics["camera"]],
+            outputs=[vla_topics["out"]],
+            model_client=client,
+            config=VLAConfig(
+                joint_names_map={"shoulder_pan.pos": "joint1"},
+                camera_inputs_map={"front": vla_topics["camera"]},
+            ),
+            component_name="test_vla_action_duration",
+        )
+        # action queue state is normally created in custom_on_activate
+        comp._actions_received = queue.Queue()
+        comp._action_queue_lock = threading.Lock()
+        comp._last_executed_timestep_lock = threading.Lock()
+        comp._last_executed_timestep = -1
+        comp._actions_received.put(
+            SimpleNamespace(
+                action=SimpleNamespace(numpy=lambda: np.array([0.1])), timestep=3
+            )
+        )
+        published = {}
+        comp._publish = lambda result: published.update(result)
+
+        comp._send_action_commands()
+
+        data = published["output"]
+        assert data.duration == pytest.approx(1 / comp.config.action_sending_rate)
+        assert data.duration > 0

--- a/tests/test_vla.py
+++ b/tests/test_vla.py
@@ -1,0 +1,453 @@
+"""Tests for the VLA component, LeRobotPolicy model, LeRobot transport shim,
+feature building from dataset info and joint data converters."""
+
+import json
+import pickle
+import queue
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from agents.clients.lerobot import LeRobotClient, SERVER_SUPPORTED_POLICIES
+from agents.clients.lerobot_transport.utils import (
+    RemotePolicyConfig,
+    TimedAction,
+    TimedObservation,
+)
+from agents.components.vla import VLA
+from agents.config import VLAConfig
+from agents.models import LeRobotPolicy
+from agents.ros import JointJog, JointTrajectory, JointTrajectoryPoint, Topic
+from agents.utils.actions import AGGREGATE_FUNCTIONS, JointsData, _as_depth_frame
+from agents.utils.utils import build_lerobot_features_from_dataset_info
+
+SAMPLE_DATASET_INFO = {
+    "features": {
+        "observation.state": {
+            "dtype": "float64",
+            "shape": [2],
+            "names": ["shoulder_pan.pos", "elbow_flex.pos"],
+        },
+        "observation.images.front": {
+            "dtype": "video",
+            "shape": [480, 640, 3],
+            "names": ["height", "width", "channels"],
+        },
+        "observation.images.depth_front": {
+            "dtype": "video",
+            "shape": [480, 640, 1],
+            "names": ["height", "width", "channels"],
+        },
+        "action": {
+            "dtype": "float32",
+            "shape": [2],
+            "names": ["shoulder_pan.pos", "elbow_flex.pos"],
+        },
+        "timestamp": {"dtype": "float32", "shape": [1], "names": None},
+    }
+}
+
+
+@pytest.fixture
+def dataset_info_file(tmp_path):
+    """Write the sample dataset info.json to a temp file."""
+    path = tmp_path / "info.json"
+    path.write_text(json.dumps(SAMPLE_DATASET_INFO))
+    return str(path)
+
+
+class TestLeRobotTransportShim:
+    """The shim dataclasses must match the LeRobot async_inference contract
+    (verified against lerobot v0.6.0) for pickling to work across the wire."""
+
+    def test_remote_policy_config_fields(self):
+        assert set(RemotePolicyConfig.__dataclass_fields__) == {
+            "policy_type",
+            "pretrained_name_or_path",
+            "lerobot_features",
+            "actions_per_chunk",
+            "device",
+            "rename_map",
+        }
+
+    def test_timed_observation_fields(self):
+        assert set(TimedObservation.__dataclass_fields__) == {
+            "timestamp",
+            "timestep",
+            "observation",
+            "must_go",
+        }
+
+    def test_timed_action_fields(self):
+        assert set(TimedAction.__dataclass_fields__) == {
+            "timestamp",
+            "timestep",
+            "action",
+        }
+
+    def test_module_spoofing_and_pickle_round_trip(self):
+        assert RemotePolicyConfig.__module__ == "lerobot.async_inference.helpers"
+        obs = TimedObservation(
+            timestamp=1.0, timestep=3, observation={"a": 1}, must_go=True
+        )
+        restored = pickle.loads(pickle.dumps(obs))
+        assert restored.timestep == 3
+        assert restored.observation == {"a": 1}
+        assert restored.must_go is True
+
+
+class TestLeRobotPolicy:
+    def test_init_params_contain_rename_map(self):
+        model = LeRobotPolicy(name="policy")
+        params = model._get_init_params()
+        assert params["rename_map"] == {}
+        assert set(params) == {
+            "checkpoint",
+            "policy_type",
+            "features",
+            "actions_per_chunk",
+            "device",
+            "rename_map",
+        }
+
+    def test_rename_map_passthrough(self):
+        model = LeRobotPolicy(
+            name="policy",
+            rename_map={"observation.images.front": "observation.images.top"},
+        )
+        assert model._get_init_params()["rename_map"] == {
+            "observation.images.front": "observation.images.top"
+        }
+
+    def test_server_supported_policies_derived_from_literal(self):
+        assert set(SERVER_SUPPORTED_POLICIES) == {
+            "act",
+            "smolvla",
+            "diffusion",
+            "tdmpc",
+            "vqbet",
+            "pi0",
+            "pi05",
+            "groot",
+        }
+
+    def test_dataset_info_parsing(self, dataset_info_file):
+        model = LeRobotPolicy(name="policy", dataset_info_file=dataset_info_file)
+        assert model._joint_keys == ["shoulder_pan.pos", "elbow_flex.pos"]
+        assert sorted(model._image_keys) == ["depth_front", "front"]
+        assert model._actions["names"] == ["shoulder_pan.pos", "elbow_flex.pos"]
+
+
+class TestFeatureBuilder:
+    def test_float64_state_coerced_to_float32(self, dataset_info_file):
+        result = build_lerobot_features_from_dataset_info(dataset_info_file)
+        # the policy server only builds state features with dtype 'float32'
+        assert result["features"]["observation.state"]["dtype"] == "float32"
+
+    def test_depth_feature_shape_preserved(self, dataset_info_file):
+        result = build_lerobot_features_from_dataset_info(dataset_info_file)
+        depth = result["features"]["observation.images.depth_front"]
+        assert depth["shape"] == (480, 640, 1)
+        assert depth["dtype"] == "video"
+
+    def test_image_keys_stripped_of_prefix(self, dataset_info_file):
+        result = build_lerobot_features_from_dataset_info(dataset_info_file)
+        assert sorted(result["image_keys"]) == ["depth_front", "front"]
+
+    def test_nested_names_flattened(self, tmp_path):
+        info = {
+            "features": {
+                "observation.state": {
+                    "dtype": "float32",
+                    "shape": [2],
+                    "names": {"motors": ["pan", "lift"]},
+                },
+                "action": {
+                    "dtype": "float32",
+                    "shape": [2],
+                    "names": {"motors": ["pan", "lift"]},
+                },
+            }
+        }
+        path = tmp_path / "info.json"
+        path.write_text(json.dumps(info))
+        result = build_lerobot_features_from_dataset_info(str(path))
+        assert result["features"]["observation.state"]["names"] == [
+            "motors.pan",
+            "motors.lift",
+        ]
+
+
+def _queue_harness(preset: str) -> VLA:
+    """Bare VLA instance with just the state used by _update_actions_queue."""
+    comp = VLA.__new__(VLA)
+    comp._actions_received = queue.Queue()
+    comp._last_executed_timestep_lock = threading.Lock()
+    comp._last_executed_timestep = -1
+    comp._aggregator_function = AGGREGATE_FUNCTIONS[preset]
+    return comp
+
+
+def _timed_action(timestep: int, value: float) -> TimedAction:
+    return TimedAction(
+        timestamp=float(timestep), timestep=timestep, action=np.array([value])
+    )
+
+
+class TestActionsQueueAggregation:
+    def test_new_actions_inserted_in_timestep_order(self):
+        comp = _queue_harness("latest_only")
+        comp._update_actions_queue([_timed_action(5, 5.0), _timed_action(2, 2.0)])
+        timesteps = [a.timestep for a in comp._actions_received.queue]
+        assert timesteps == [2, 5]
+
+    def test_stale_timesteps_dropped(self):
+        comp = _queue_harness("latest_only")
+        comp._last_executed_timestep = 3
+        comp._update_actions_queue([_timed_action(2, 2.0), _timed_action(4, 4.0)])
+        timesteps = [a.timestep for a in comp._actions_received.queue]
+        assert timesteps == [4]
+
+    def test_overlap_latest_only(self):
+        comp = _queue_harness("latest_only")
+        comp._update_actions_queue([_timed_action(1, 1.0)])
+        comp._update_actions_queue([_timed_action(1, 9.0)])
+        actions = list(comp._actions_received.queue)
+        assert len(actions) == 1
+        assert np.allclose(actions[0].action, [9.0])
+
+    def test_overlap_weighted_average(self):
+        comp = _queue_harness("weighted_average")
+        comp._update_actions_queue([_timed_action(1, 1.0)])
+        comp._update_actions_queue([_timed_action(1, 9.0)])
+        actions = list(comp._actions_received.queue)
+        # 0.3 * old + 0.7 * new
+        assert np.allclose(actions[0].action, [0.3 * 1.0 + 0.7 * 9.0])
+
+    def test_overlap_conservative(self):
+        comp = _queue_harness("conservative")
+        comp._update_actions_queue([_timed_action(1, 1.0)])
+        comp._update_actions_queue([_timed_action(1, 9.0)])
+        actions = list(comp._actions_received.queue)
+        # 0.7 * old + 0.3 * new
+        assert np.allclose(actions[0].action, [0.7 * 1.0 + 0.3 * 9.0])
+
+
+class TestDepthFrame:
+    def test_2d_expanded_to_single_channel(self):
+        out = _as_depth_frame(np.zeros((4, 5), dtype=np.float32))
+        assert out.shape == (4, 5, 1)
+
+    def test_uint16_cast_to_float32(self):
+        out = _as_depth_frame(np.zeros((4, 5), dtype=np.uint16))
+        assert out.dtype == np.float32
+
+    def test_single_channel_float_passthrough(self):
+        img = np.zeros((4, 5, 1), dtype=np.float32)
+        out = _as_depth_frame(img)
+        assert out.shape == (4, 5, 1)
+        assert out.dtype == np.float32
+
+
+def _ros_image(arr: np.ndarray, encoding: str):
+    from sensor_msgs.msg import Image as ImageROS
+
+    msg = ImageROS()
+    msg.height = arr.shape[0]
+    msg.width = arr.shape[1]
+    channels = 1 if arr.ndim == 2 else arr.shape[2]
+    msg.encoding = encoding
+    msg.step = arr.shape[1] * channels * arr.itemsize
+    msg.is_bigendian = False
+    msg.data = arr.tobytes()
+    return msg
+
+
+class TestRGBDCallbackDepthOnly:
+    @pytest.fixture
+    def rgbd_callback(self):
+        from agents.callbacks import RGBDCallback
+
+        callback = RGBDCallback(Topic(name="cam_rgbd", msg_type="RGBD"))
+        rgb = np.arange(4 * 5 * 3, dtype=np.uint8).reshape(4, 5, 3)
+        depth = np.arange(4 * 5, dtype=np.uint16).reshape(4, 5)
+        callback.msg = SimpleNamespace(
+            rgb=_ros_image(rgb, "rgb8"), depth=_ros_image(depth, "16UC1")
+        )
+        return callback
+
+    def test_default_returns_rgb(self, rgbd_callback):
+        out = rgbd_callback._get_output()
+        assert out.shape == (4, 5, 3)
+
+    def test_get_depth_returns_fused_rgbd(self, rgbd_callback):
+        out = rgbd_callback._get_output(get_depth=True)
+        assert out.shape == (4, 5, 4)
+
+    def test_depth_only_returns_single_channel(self, rgbd_callback):
+        out = rgbd_callback._get_output(depth_only=True)
+        assert out.shape == (4, 5, 1)
+        assert out.dtype == np.uint16
+
+
+class TestJointConverters:
+    @pytest.fixture
+    def joints_data(self):
+        return JointsData(
+            joints_names=["joint1", "joint2"],
+            positions=np.array([1.0, 2.0]),
+            velocities=np.array([0.1, 0.2]),
+            accelerations=np.array([0.01, 0.02]),
+            efforts=np.array([0.5, 0.6]),
+            duration=0.25,
+            delay=1.5,
+        )
+
+    def test_trajectory_point_uses_accelerations(self, joints_data):
+        msg = JointTrajectoryPoint.convert(joints_data)
+        assert list(msg.accelerations) == [0.01, 0.02]
+        assert list(msg.velocities) == [0.1, 0.2]
+
+    def test_trajectory_point_time_from_start_is_duration_msg(self, joints_data):
+        from builtin_interfaces.msg import Duration
+
+        msg = JointTrajectoryPoint.convert(joints_data)
+        assert isinstance(msg.time_from_start, Duration)
+        # delay + duration = 1.75s
+        assert msg.time_from_start.sec == 1
+        assert msg.time_from_start.nanosec == 750000000
+
+    def test_trajectory_points_monotonically_timed(self):
+        # 2D (multi point) joints data bypasses JointsData size validation,
+        # so a duck typed stub is used to exercise the indexed conversion
+        stub = SimpleNamespace(
+            joints_names=["joint1", "joint2"],
+            positions=np.array([[1.0, 2.0], [1.1, 2.1], [1.2, 2.2]]),
+            velocities=np.array([[0.1, 0.2], [0.1, 0.2], [0.1, 0.2]]),
+            accelerations=np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]),
+            efforts=np.array([[0.5, 0.6], [0.5, 0.6], [0.5, 0.6]]),
+            duration=0.1,
+            delay=0.0,
+        )
+        msg = JointTrajectory.convert(stub)
+        assert len(msg.points) == 3
+        times = [
+            p.time_from_start.sec + p.time_from_start.nanosec * 1e-9
+            for p in msg.points
+        ]
+        assert times == sorted(times)
+        assert times[0] > 0.0
+        assert np.allclose(times, [0.1, 0.2, 0.3], atol=1e-6)
+
+    def test_joint_jog_duration_is_float(self, joints_data):
+        msg = JointJog.convert(joints_data)
+        assert msg.duration == 0.25
+        assert list(msg.displacements) == [1.0, 2.0]
+
+
+def _mock_lerobot_client(model: LeRobotPolicy) -> MagicMock:
+    client = MagicMock(spec=LeRobotClient)
+    client._model = model
+    client.model_init_params = model._get_init_params()
+    return client
+
+
+class TestVLAComponent:
+    @pytest.fixture
+    def vla_topics(self):
+        return {
+            "state": Topic(name="joint_states", msg_type="JointState"),
+            "camera": Topic(name="camera_rgb", msg_type="Image"),
+            "depth": Topic(name="camera_depth", msg_type="Image"),
+            "out": Topic(name="joint_cmd", msg_type="JointState"),
+        }
+
+    def test_auto_spec_refreshes_client_init_params(self, rclpy_init, vla_topics):
+        """Auto-generated features must reach the client's init params,
+        otherwise the policy server receives an empty feature spec."""
+        model = LeRobotPolicy(name="policy")
+        client = _mock_lerobot_client(model)
+        assert not client.model_init_params["features"]
+        VLA(
+            inputs=[vla_topics["state"], vla_topics["camera"]],
+            outputs=[vla_topics["out"]],
+            model_client=client,
+            config=VLAConfig(
+                joint_names_map={"shoulder_pan.pos": "joint1"},
+                camera_inputs_map={"front": vla_topics["camera"]},
+            ),
+            component_name="test_vla_auto_spec",
+        )
+        features = client.model_init_params["features"]
+        assert "observation.state" in features
+        assert "observation.images.front" in features
+
+    def test_dataset_verification_and_camera_prefix_strip(
+        self, rclpy_init, vla_topics, dataset_info_file
+    ):
+        model = LeRobotPolicy(name="policy", dataset_info_file=dataset_info_file)
+        client = _mock_lerobot_client(model)
+        config = VLAConfig(
+            joint_names_map={
+                "shoulder_pan.pos": "joint1",
+                "elbow_flex.pos": "joint2",
+            },
+            camera_inputs_map={
+                "observation.images.front": vla_topics["camera"],
+                "depth_front": vla_topics["depth"],
+            },
+        )
+        comp = VLA(
+            inputs=[vla_topics["state"], vla_topics["camera"], vla_topics["depth"]],
+            outputs=[vla_topics["out"]],
+            model_client=client,
+            config=config,
+            component_name="test_vla_dataset",
+        )
+        # dataset action names mapped to robot joint names, in dataset order
+        assert comp._dataset_sorted_joint_names == ["joint1", "joint2"]
+        # LeRobot prefix stripped from user provided camera keys
+        assert sorted(config.camera_inputs_map.keys()) == ["depth_front", "front"]
+
+    def test_incomplete_joint_map_raises(
+        self, rclpy_init, vla_topics, dataset_info_file
+    ):
+        model = LeRobotPolicy(name="policy", dataset_info_file=dataset_info_file)
+        client = _mock_lerobot_client(model)
+        with pytest.raises(ValueError):
+            VLA(
+                inputs=[vla_topics["state"], vla_topics["camera"]],
+                outputs=[vla_topics["out"]],
+                model_client=client,
+                config=VLAConfig(
+                    joint_names_map={"shoulder_pan.pos": "joint1"},
+                    camera_inputs_map={
+                        "front": vla_topics["camera"],
+                        "depth_front": vla_topics["depth"],
+                    },
+                ),
+                component_name="test_vla_bad_joints",
+            )
+
+    def test_incomplete_camera_map_raises(
+        self, rclpy_init, vla_topics, dataset_info_file
+    ):
+        model = LeRobotPolicy(name="policy", dataset_info_file=dataset_info_file)
+        client = _mock_lerobot_client(model)
+        with pytest.raises(ValueError):
+            VLA(
+                inputs=[vla_topics["state"], vla_topics["camera"]],
+                outputs=[vla_topics["out"]],
+                model_client=client,
+                config=VLAConfig(
+                    joint_names_map={
+                        "shoulder_pan.pos": "joint1",
+                        "elbow_flex.pos": "joint2",
+                    },
+                    camera_inputs_map={"front": vla_topics["camera"]},
+                ),
+                component_name="test_vla_bad_cameras",
+            )


### PR DESCRIPTION
## Summary

Updates the VLA stack to support all policy types servable by the LeRobot Async Policy Server as of LeRobot 0.6.x, adds depth camera inputs and joint-limit unit conversion, and hardens the client/server contract and the action-server goal handling. **Validated end-to-end in an Isaac Sim SO101 pick-orange evaluation** driving a GR00T N1.7 LoRA fine-tune through this component (10-episode protocol; failures observed were policy-quality, not pipeline issues).

Also modernizes the entire local-models stack — TTS, STT, wakeword, LLM, VLM and the semantic router now run fully local with up-to-date defaults and streaming support.

Verified against lerobot source at v0.4.2, v0.6.0 and main: the gRPC transport (proto + pickled dataclasses) is unchanged across these versions, so no transport changes were needed.

## VLA changes

- **New policy types**: `LeRobotPolicy.policy_type` now exposes all 8 server-supported policies — adds `groot` (GR00T N1.7, requires LeRobot >= 0.6.0 on the server), `tdmpc` and `vqbet`. The client derives its supported-policies error messaging from the same Literal (single source of truth). Other new LeRobot policies (eo1, evo1, molmoact2, xvla, world models) are blocked by the server's own allowlist upstream and documented as such.
- **rename_map**: exposes LeRobot's server-side observation-key renaming for checkpoints trained under feature names different from the dataset metadata. Documented as an advanced option, distinct from the required joint/camera maps.
- **Depth camera inputs**: camera keys whose dataset feature is single channel `(H, W, 1)` are treated as depth and can be mapped to a depth image topic or to the depth part of an RGBD topic (`RGBDCallback` gained a depth-only output mode). uint16 depth is cast to float32, since torch cannot ingest uint16 on the server side.
- **Joint-limit unit conversion**: new `VLAConfig.policy_action_units` (`radians`/`degrees`/`normalized`) converts URDF-derived limits (always radians per spec) into the policy's action space — e.g. the LeRobot SO-10x normalized motor convention — before capping. Manual `joint_limits` entries now override URDF-derived ones per joint, and a heuristic warns when most early actions get capped (the signature of a unit mismatch, which previously crushed all actions silently).
- **Chunk aggregation presets**: `VLAConfig.aggregate_fn_name` with the LeRobot client's presets (`latest_only` default; recommended for relative-action policies, where blending chunks resolved against different reference states is harmful).
- **Goal-handling fixes** (found in live evaluation): per-goal state (`_last_executed_timestep`, task-completed flag) resets at goal start; non-success loop exits now run action cleanup and abort explicitly (previously leaked action timers and made the next goal abort instantly); `Event`-based termination logging fixed.
- **Other fixes**:
  - Auto-generated feature specs never reached the policy server (client captured init params before the spec was generated).
  - float64 state features are now declared as float32 to the server, which silently drops non-float32 state features; logged once at model init.
  - Camera reads for observations no longer clear the callback's last message (slow cameras caused skipped inferences on tick mismatch).
  - Joint converters: `JointTrajectoryPoint` copied velocities into accelerations and assigned a float to the `time_from_start` Duration field (now a proper Duration with monotone per-point timing); `JointJog` called `.tolist()` on its float duration.
  - `camera_inputs_map` accepts live Topic values (in-process launches) in addition to serialized dicts.

## Local model changes

The contract stays the same — point `local_model_path` at any compatible model and the wrapper figures out the rest. Each wrapper now autodetects the model family and validates a new free-form `local_model_options` dict against the backend's actual signature (unknown keys fail loudly, listing valid ones).

- **TTS**: default is now Kyutai Pocket TTS (int8, via sherpa-onnx). All sherpa TTS families are autodetected from the bundle layout (pocket, supertonic, matcha, zipvoice, kitten, kokoro, vits). New `speaker_id` config; reference-voice options (e.g. `voice`, `num_steps`) go through `local_model_options`. Streaming synthesis is honored end to end (`stream=True` default) — audio chunks play while the rest is still being synthesized. `local_model_path` may also point at a local bundle directory.
- **STT**: default is now NVIDIA Parakeet TDT 0.6B v2 (int8). Nine sherpa recognizer families autodetected (moonshine v1/v2, qwen3-asr, nemo/parakeet transducers, sense-voice, paraformer, omnilingual, nemo-ctc, whisper).
- **Wakeword**: openWakeWord replaced with sherpa-onnx's open-vocabulary `KeywordSpotter`. The wake phrase is plain text in the config (`wakeword_phrase`, default "ok robot") — no per-phrase model files; the melspectrogram/embedding model paths are gone and a single `wakeword_model_path` archive is downloaded automatically.
- **LLM**: `n_ctx` defaults to the model's trained context length instead of llama-cpp's 512; quantization selectable via a reserved `filename` option. Qwen/Hermes-style `<tool_call>` tags are parsed out of text output (llama-cpp's GGUF-template handler renders tools into the prompt but never returns structured tool calls), which makes local tool calling and agentic routing work.
- **VLM**: default is now Qwen3-VL-2B (`ggml-org/Qwen3-VL-2B-Instruct-GGUF`). Families (qwen_vl, gemma, moondream, minicpm, llava/llava16, nanollava) map to the right llama-cpp chat handler and GGUF file. Full conversation history and multiple images per query are supported, as are streaming and `max_new_tokens`/`temperature` (previously ignored).
- **SemanticRouter**: agentic mode now runs fully local — `config=LLMConfig(enable_local_model=True)` with no clients deploys the local LLM and routes via tool calls.
- **Reasoning models**: new `strip_think_tokens` config (default True) removes `<think>` blocks from streaming and non-streaming output, including blocks left unterminated by the token limit (with a warning, since that means the model never produced an answer).
- **Robustness**: local LLM/VLM calls are serialized with an internal lock — llama-cpp contexts are not thread-safe, and concurrent component callbacks previously corrupted the context and aborted the process (`GGML_ASSERT`/SIGABRT).
- **Utilities**: `load_model_archive` for tar.bz2 model bundles; `load_model_repo` passes local directories through untouched.

## Notes

- All local-model dependencies stay optional and are raised with install instructions at deploy time: sherpa-onnx + sentencepiece (TTS/STT/wakeword), llama-cpp-python (LLM/VLM), huggingface-hub (only when downloading hub repos). grpc and torch remain lazy imports of the LeRobot client only.
- Serving GR00T checkpoints trained with `use_relative_actions=true` currently requires a lerobot policy-server patch (upstream fix: huggingface/lerobot#3981, pending).
- Companion simulation setup (Isaac Sim + LeIsaac + ROS2 bridge + recipes) lives in the private `embodied-agents-sim-setup` repo.
