### PR TITLE
MoveIt manipulation with a perception-fed planning scene

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,8 @@ jobs:
           apt-get update
           apt-get install -y python3-pip \
               ros-${{ matrix.ros_distro }}-control-msgs \
-              ros-${{ matrix.ros_distro }}-realsense2-camera-msgs
+              ros-${{ matrix.ros_distro }}-realsense2-camera-msgs \
+              ros-${{ matrix.ros_distro }}-moveit-msgs
 
       - name: Build workspace
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 
 file(GLOB_RECURSE MSG_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "msg/*.msg" )
 file(GLOB_RECURSE ACTION_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "action/*.action" )
@@ -22,7 +23,7 @@ file(GLOB_RECURSE ACTION_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "action/*.
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${MSG_FILES}
   ${ACTION_FILES}
-  DEPENDENCIES builtin_interfaces std_msgs sensor_msgs
+  DEPENDENCIES builtin_interfaces std_msgs sensor_msgs geometry_msgs
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/action/MoveManipulator.action
+++ b/action/MoveManipulator.action
@@ -1,11 +1,18 @@
 # Action definition for MoveIt components.
 
-# mode: one of "pose", "joints", "named", "cartesian".
+# mode: one of "pose", "joints", "named", "cartesian", "pick", "place".
 # If left empty, the mode is inferred from whichever target fields are populated.
 string mode
 
-# Target end-effector pose (mode: "pose"). header.frame_id defaults to the planning frame.
+# Target end-effector pose (mode: "pose"), or the pick/place location
+# (modes: "pick", "place"). header.frame_id defaults to the planning frame.
 geometry_msgs/PoseStamped target_pose
+# Planning scene object to pick (mode: "pick"): an object id (e.g.
+# "det__mug_0") or a label (e.g. "mug"), resolved against the objects this
+# component has placed in the scene. Alternative to locating the pick by
+# target_pose. The named object becomes the grasp target; everything else in
+# the scene remains an obstacle.
+string target_object
 # Joint-space target (mode: "joints"). Parallel arrays.
 string[] joint_names
 float64[] joint_positions

--- a/action/MoveManipulator.action
+++ b/action/MoveManipulator.action
@@ -1,0 +1,34 @@
+# Action definition for MoveIt components.
+
+# mode: one of "pose", "joints", "named", "cartesian".
+# If left empty, the mode is inferred from whichever target fields are populated.
+string mode
+
+# Target end-effector pose (mode: "pose"). header.frame_id defaults to the planning frame.
+geometry_msgs/PoseStamped target_pose
+# Joint-space target (mode: "joints"). Parallel arrays.
+string[] joint_names
+float64[] joint_positions
+# SRDF named target, e.g. "home" or "ready" (mode: "named")
+string named_target
+# End-effector waypoints for a straight-line Cartesian path (mode: "cartesian")
+geometry_msgs/Pose[] cartesian_waypoints
+# Reference frame for cartesian_waypoints. Empty = planning frame.
+string frame_id
+# Plan without executing (motion validity check)
+bool plan_only
+
+# Per-goal overrides of the configured scaling factors. 0.0 = use the config value
+float32 velocity_scaling
+float32 acceleration_scaling
+---
+bool success
+# Raw MoveItErrorCodes value returned by MoveIt
+int32 error_code
+# Human readable success/error description
+string message
+# Fraction of the requested Cartesian path that was achieved (cartesian mode only)
+float32 cartesian_fraction
+---
+# Current MoveIt state, PLANNING / MONITOR / EXECUTING
+string state

--- a/action/MoveManipulator.action
+++ b/action/MoveManipulator.action
@@ -6,6 +6,11 @@ string mode
 
 # Target end-effector pose (mode: "pose"), or the pick/place location
 # (modes: "pick", "place"). header.frame_id defaults to the planning frame.
+# NOTE: An identity quaternion is the wire default of an unfilled field, so it
+# is read as "no preference", not as a target. Pose goals then leave the orientation
+# to the planner (within the configured tolerance); Cartesian motions, including
+# the pick/place descend and retreat, hold the current end-effector
+# orientation. Any quaternion with a non-zero x, y or z is followed exactly.
 geometry_msgs/PoseStamped target_pose
 # Planning scene object to pick (mode: "pick"): an object id (e.g.
 # "det__mug_0") or a label (e.g. "mug"), resolved against the objects this
@@ -18,7 +23,9 @@ string[] joint_names
 float64[] joint_positions
 # SRDF named target, e.g. "home" or "ready" (mode: "named")
 string named_target
-# End-effector waypoints for a straight-line Cartesian path (mode: "cartesian")
+# End-effector waypoints for a straight-line Cartesian path (mode:
+# "cartesian"). Waypoints with an identity orientation hold the current
+# end-effector orientation.
 geometry_msgs/Pose[] cartesian_waypoints
 # Reference frame for cartesian_waypoints. Empty = planning frame.
 string frame_id

--- a/agents/callbacks.py
+++ b/agents/callbacks.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 import os
 import cv2
 import numpy as np
@@ -444,3 +444,57 @@ class JointStateCallback(GenericCallback):
             velocities=np.array(self.msg.velocity),
             efforts=np.array(self.msg.effort),
         )
+
+
+class Detections3DCallback(GenericCallback):
+    """
+    Callback class for Detections3D msg
+
+    Its get method returns a context string of the detected classes, like the
+    2D detections callback, so the output can be used in prompts and stored as
+    semantic memory. Consumers that need the geometry ask for the message itself
+    with `get_msg=True`.
+    """
+
+    def __init__(self, input_topic, node_name: Optional[str] = None) -> None:
+        """
+        Constructs a new instance.
+
+        :param      input_topic:  Subscription topic
+        :type       input_topic:  str
+        """
+        super().__init__(input_topic, node_name)
+        self.msg = input_topic.fixed if hasattr(input_topic, "fixed") else None
+
+    def _get_output(self, get_msg: bool = False, **_) -> Optional[Any]:
+        """
+        Processes labels and returns a context string for prompt engineering,
+        or the message itself when the metric boxes are needed.
+
+        :param      get_msg:  Return the Detections3D message instead of a
+                              context string
+        :type       get_msg:  bool
+
+        :returns:   Comma separated classnames, or the Detections3D message
+        :rtype:     Optional[Union[str, Detections3D]]
+        """
+        if not self.msg:
+            return None
+
+        if get_msg:
+            return self.msg
+
+        return create_detection_context(list(self.msg.labels))
+
+    def _get_ui_content(self, **_) -> str:
+        """Get UI content for Detections3D: what was found and how far away."""
+        if not self.msg or not self.msg.labels:
+            return "No objects detected"
+
+        frame = self.msg.header.frame_id or "camera frame"
+        objects = ", ".join(
+            f"{label} at ({box.center.position.x:.2f}, {box.center.position.y:.2f}, "
+            f"{box.center.position.z:.2f})"
+            for label, box in zip(self.msg.labels, self.msg.boxes)
+        )
+        return f"In {frame}: {objects}"

--- a/agents/callbacks.py
+++ b/agents/callbacks.py
@@ -110,7 +110,7 @@ class VideoCallback(GenericCallback):
         :returns:   Video as nd_array
         :rtype:     np.ndarray
         """
-        if not self.msg:
+        if self.msg is None:
             return None
 
         # return np.ndarray if fixed video has been read

--- a/agents/callbacks.py
+++ b/agents/callbacks.py
@@ -51,7 +51,7 @@ class StreamingStringCallback(TextCallback):
         :rtype: str | None
         """
 
-        if not self.msg:
+        if self.msg is None:
             return None
 
         # return str if fixed str has been read
@@ -79,7 +79,7 @@ class VideoCallback(GenericCallback):
         """
         super().__init__(input_topic, node_name)
         # fixed video needs to be a path to cv2 readable video
-        if hasattr(input_topic, "fixed"):
+        if self._is_fixed:
             if os.path.isfile(input_topic.fixed):
                 try:
                     # read all video frames
@@ -144,7 +144,7 @@ class RGBDCallback(GenericCallback):
         super().__init__(input_topic, node_name)
         self.msg = None
         # fixed RGBD message cannot be read from a file
-        if hasattr(input_topic, "fixed"):
+        if self._is_fixed:
             get_logger(self.node_name).error(
                 "RGBD message cannot be read from a fixed file"
             )
@@ -160,7 +160,7 @@ class RGBDCallback(GenericCallback):
         :returns:   Image and/or Depth as nd_array
         :rtype:     np.ndarray
         """
-        if not self.msg or not self.msg.rgb:
+        if self.msg is None or not self.msg.rgb:
             return None
 
         if depth_only:
@@ -207,7 +207,7 @@ class DetectionsMultiSourceCallback(GenericCallback):
         :type       input_topic:  str
         """
         super().__init__(input_topic, node_name)
-        self.msg = input_topic.fixed if hasattr(input_topic, "fixed") else None
+        self.msg = input_topic.fixed if self._is_fixed else None
         self.encoding = None
 
     def _get_output(self, **_) -> Optional[str]:
@@ -218,7 +218,7 @@ class DetectionsMultiSourceCallback(GenericCallback):
         :returns:   Comma separated classnames
         :rtype:     str
         """
-        if not self.msg:
+        if self.msg is None:
             return None
         # send fixed list of labels if it exists
         if isinstance(self.msg, list):
@@ -233,7 +233,7 @@ class DetectionsMultiSourceCallback(GenericCallback):
 
     def _get_ui_content(self, **_) -> str:
         """Get UI content for the first Detections2D msg in Detections2DMultiSource: draw bounding boxes and labels on the image."""
-        if not self.msg:
+        if self.msg is None:
             return ""
 
         # If msg is a list, return precomputed detection context
@@ -288,7 +288,7 @@ class DetectionsCallback(GenericCallback):
         :type       input_topic:  str
         """
         super().__init__(input_topic, node_name)
-        self.msg = input_topic.fixed if hasattr(input_topic, "fixed") else None
+        self.msg = input_topic.fixed if self._is_fixed else None
         self.encoding = None
 
     def _get_output(self, **_) -> Optional[str]:
@@ -299,7 +299,7 @@ class DetectionsCallback(GenericCallback):
         :returns:   Comma separated classnames
         :rtype:     str
         """
-        if not self.msg:
+        if self.msg is None:
             return None
 
         # send fixed list of labels if it exists
@@ -313,7 +313,7 @@ class DetectionsCallback(GenericCallback):
 
     def _get_ui_content(self, **_) -> str:
         """Get UI content for Detections2D: draw bounding boxes and labels on the image."""
-        if not self.msg:
+        if self.msg is None:
             return ""
 
         # If msg is a list, return precomputed detection context
@@ -363,7 +363,7 @@ class PointsOfInterestCallback(GenericCallback):
         :type       input_topic:  str
         """
         super().__init__(input_topic, node_name)
-        self.msg = input_topic.fixed if hasattr(input_topic, "fixed") else None
+        self.msg = input_topic.fixed if self._is_fixed else None
         self.encoding = None
 
     def _get_output(self, **_) -> Optional[np.ndarray]:
@@ -374,7 +374,7 @@ class PointsOfInterestCallback(GenericCallback):
         :returns:   Comma separated classnames
         :rtype:     str
         """
-        if not self.msg:
+        if self.msg is None:
             return None
 
         # send fixed list of points if it exists
@@ -390,7 +390,7 @@ class PointsOfInterestCallback(GenericCallback):
     def _get_ui_content(self, **_) -> str:
         """Get UI content for PointsOfInterest: draw points on the image."""
 
-        if not self.msg:
+        if self.msg is None:
             return ""
 
         points = self.get_output()
@@ -435,7 +435,7 @@ class JointStateCallback(GenericCallback):
         :returns:   Joint states as dict
         :rtype:     dict
         """
-        if not self.msg:
+        if self.msg is None:
             return None
 
         return JointsData(
@@ -464,7 +464,7 @@ class Detections3DCallback(GenericCallback):
         :type       input_topic:  str
         """
         super().__init__(input_topic, node_name)
-        self.msg = input_topic.fixed if hasattr(input_topic, "fixed") else None
+        self.msg = input_topic.fixed if self._is_fixed else None
 
     def _get_output(self, get_msg: bool = False, **_) -> Optional[Any]:
         """
@@ -478,7 +478,7 @@ class Detections3DCallback(GenericCallback):
         :returns:   Comma separated classnames, or the Detections3D message
         :rtype:     Optional[Union[str, Detections3D]]
         """
-        if not self.msg:
+        if self.msg is None:
             return None
 
         if get_msg:
@@ -488,7 +488,7 @@ class Detections3DCallback(GenericCallback):
 
     def _get_ui_content(self, **_) -> str:
         """Get UI content for Detections3D: what was found and how far away."""
-        if not self.msg or not self.msg.labels:
+        if self.msg is None or not self.msg.labels:
             return "No objects detected"
 
         frame = self.msg.header.frame_id or "camera frame"

--- a/agents/components/__init__.py
+++ b/agents/components/__init__.py
@@ -16,6 +16,9 @@ A Component is the main execution unit in _EmbodiedAgents_ and in essence each c
 * - **[VLA](agents.components.vla.md)**
   - Provides an interface to utilize Vision Language Action (VLA) models for manipulation and control tasks. It can use VLA Policies (such as SmolVLA, Pi0/Pi0.5, NVIDIA GR00T N1.7 etc.) served with HuggingFace LeRobot Async Policy Server and publish them to common topic formats in MoveIt Servo and ROS2 Control.
 
+* - **[MoveIt](agents.components.moveit.md)**
+  - Provides classical, collision aware manipulation by driving a running [MoveIt 2](https://moveit.ai) `move_group` node. Plans and executes end-effector pose goals, joint goals, named targets from the robot's SRDF and straight-line Cartesian paths, and controls the gripper. Complements the VLA component, which learns manipulation skills, by providing planned and collision checked motion.
+
 * - **[SpeechToText](agents.components.speechtotext.md)**
   - Converts spoken audio into text using speech-to-text models (e.g., Whisper). Suitable for voice command recognition. It also implements small on-board models for Voice Activity Detection (VAD) and Wakeword recognition, using audio capture devices onboard the robot.
 
@@ -51,6 +54,7 @@ from .map_encoding import MapEncoding
 from .memory import Memory
 from .mllm import MLLM, VLM
 from .model_component import ModelComponent
+from .moveit import MoveIt
 from .semantic_router import SemanticRouter
 from .speechtotext import SpeechToText
 from .texttospeech import TextToSpeech
@@ -67,6 +71,7 @@ __all__ = [
     "VLM",
     "LLM",
     "VLA",
+    "MoveIt",
     "SpeechToText",
     "TextToSpeech",
     "Vision",

--- a/agents/components/depth_lift.py
+++ b/agents/components/depth_lift.py
@@ -1,0 +1,205 @@
+"""Shared machinery for lifting 2D detections into metric 3D boxes.
+
+Components that publish Detections3D pair an rgb image with the depth registered to
+it, the calibration of that stream, and the transform into the configured
+`detections_frame`. This mixin holds that pairing and validation machinery.
+"""
+
+from typing import Any, Optional
+
+from ..utils import get_frame_id, get_stamp_secs
+
+
+class DepthLiftMixin:
+    """Depth, calibration and detector handling for a 3D-lifting component."""
+
+    def _init_lift_state(self) -> None:
+        """The detector for the 3D lifted camera and its parsed calibration,
+        each rebuilt only when the camera reports new values, and one-time
+        warnings."""
+        self._detector = None
+        self._detector_key = None
+        self._intrinsics = None
+        self._intrinsics_key = None
+        self._depth_encoding = None
+        self._depth_encoding_key = None
+        self._lift_msg = None
+        self._lift_depth = None
+        self._warned: set = set()
+
+    def _depth_snapshot(self) -> Optional[Any]:
+        """Depth as it stands the instant its picture is taken.
+
+        Read alongside the picture rather than at publish time.
+        Not needed for RGBD msgs
+        """
+        if self.depth_topic and (callback := self.callbacks.get(self.depth_topic.name)):
+            return callback.msg
+        return None
+
+    def _depth_for(self) -> Optional[Any]:
+        """The depth image registered to the lifted picture, or None"""
+        # For RGBD
+        if (depth := getattr(self._lift_msg, "depth", None)) is not None and depth.data:
+            return depth
+
+        if (depth := self._lift_depth) is None:
+            self._warn_once(
+                "no_depth",
+                f"Nothing has been received on depth topic "
+                f"'{self.depth_topic.name if self.depth_topic else '<unknown>'}', so no detection "
+                "can be placed in space.",
+                error=True,
+            )
+            return None
+
+        # For Image. Captured at the same instant, check for age nonetheless
+        age = abs(get_stamp_secs(self._lift_msg) - get_stamp_secs(depth))
+        if age > self.config.max_depth_age:
+            self._warn_once(
+                "depth_age",
+                f"Depth on '{self.depth_topic.name}' is {age:.2f}s away from the "
+                f"picture it would be paired with, more than max_depth_age "
+                f"({self.config.max_depth_age}s), so these detections are not "
+                "being published.",
+            )
+            return None
+        return depth
+
+    def _camera_intrinsics(self) -> Optional[Any]:
+        """Calibration of the stream the depth was measured on.
+        A camera_info topic wins when one was given.
+        """
+
+        from ..ros import read_camera_info
+
+        if self.camera_info_topic and (
+            info := self.callbacks.get(self.camera_info_topic.name)
+        ):
+            if (parsed := info.get_output()) is not None:
+                return parsed
+
+        info = getattr(self._lift_msg, "depth_camera_info", None)
+        if info is None:
+            return None
+        key = (
+            info.header.frame_id,
+            info.width,
+            info.height,
+            tuple(info.k),
+            tuple(info.p),
+        )
+        # Update key if it changed
+        if key != self._intrinsics_key:
+            self._intrinsics = read_camera_info(info)
+            self._intrinsics_key = key
+        return self._intrinsics
+
+    def _depth_detector(self):
+        """The 3D detector for the lifted camera, and the depth to run it on.
+
+        :returns: (detector, depth in millimeters), both None when this tick
+            cannot be lifted
+        """
+        from ..callbacks import image_pre_processing, process_encoding
+
+        from ..utils.perception3d import make_detector, prepare_depth
+
+        depth_msg = self._depth_for()
+        if depth_msg is None:
+            return None, None
+
+        intrinsics = self._camera_intrinsics()
+        if intrinsics is None:
+            self._warn_once(
+                "no_intrinsics",
+                "No camera calibration has been received, so depth cannot be "
+                "turned into distances. Pass the camera's `camera_info` topic, "
+                "or use an RGBD input, which carries its own.",
+                error=True,
+            )
+            return None, None
+
+        # The intrinsics need to describe the depth image
+        if (intrinsics.width, intrinsics.height) != (depth_msg.width, depth_msg.height):
+            self._warn_once(
+                "intrinsics_resolution",
+                f"The camera reports intrinsics for {intrinsics.width}x"
+                f"{intrinsics.height} images but publishes depth at "
+                f"{depth_msg.width}x{depth_msg.height}. Detections cannot be "
+                "placed in metric space until the two agree.",
+                error=True,
+            )
+            return None, None
+
+        # Check if the streams encoding changed (unlikely)
+        if depth_msg.encoding != self._depth_encoding_key:
+            self._depth_encoding = process_encoding(depth_msg.encoding)
+            self._depth_encoding_key = depth_msg.encoding
+
+        depth_mm = prepare_depth(
+            image_pre_processing(depth_msg, *self._depth_encoding),
+            encoding=depth_msg.encoding,
+            scale=self.config.depth_scale,
+        )
+
+        # Registered depth shares the color image's pixel grid preferrably
+        color_frame = get_frame_id(getattr(self._lift_msg, "rgb", self._lift_msg))
+        depth_frame = get_frame_id(depth_msg)
+        if color_frame and depth_frame and color_frame != depth_frame:
+            self._warn_once(
+                "frame_mismatch",
+                f"The depth stream reports frame '{depth_frame}' while the "
+                f"pictures are in '{color_frame}'. Depth registered to the "
+                "color image lives in the color camera's frame, so that is "
+                "the one used. If this depth stream is not the registered "
+                "one, every 3D box will be misplaced.",
+            )
+        camera_frame = color_frame or depth_frame
+        target = self.config.detections_frame
+        translation = rotation = None
+        if target != camera_frame:
+            listener = self.get_transform_listener(
+                camera_frame, target, self.config.static_camera_tf
+            )
+            if not listener.got_transform:
+                self._warn_once(
+                    "camera_transform",
+                    f"The transform from camera frame '{camera_frame}' to "
+                    f"'{target}' has not been resolved yet, so detections are "
+                    "not being published in 3D.",
+                )
+                return None, None
+            translation, rotation = listener.translation, listener.rotation
+
+        # Rebuilding is cheap, so the detector is kept only until something it
+        # was built from moves
+        key = (
+            camera_frame,
+            intrinsics.fx,
+            intrinsics.fy,
+            intrinsics.cx,
+            intrinsics.cy,
+            None if translation is None else tuple(translation),
+            None if rotation is None else tuple(rotation),
+        )
+        if key != self._detector_key:
+            self._detector = make_detector(
+                intrinsics,
+                translation=translation,
+                rotation=rotation,
+                depth_range=(self.config.min_depth, self.config.max_depth),
+            )
+            self._detector_key = key
+        return self._detector, depth_mm
+
+    # TODO: Upstream to sugarcoat component
+    def _warn_once(self, key: str, message: str, error: bool = False) -> None:
+        """Report a lasting misconfiguration the first time it is noticed"""
+        if key in self._warned:
+            return
+        self._warned.add(key)
+        if error:
+            self.get_logger().error(message)
+        else:
+            self.get_logger().warning(message)

--- a/agents/components/depth_lift.py
+++ b/agents/components/depth_lift.py
@@ -82,12 +82,18 @@ class DepthLiftMixin:
         info = getattr(self._lift_msg, "depth_camera_info", None)
         if info is None:
             return None
+        # width, height, K and P are full-frame calibration values that do not
+        # change when the driver applies binning or a region of interest
+        roi = getattr(info, "roi", None)
         key = (
             info.header.frame_id,
             info.width,
             info.height,
             tuple(info.k),
             tuple(info.p),
+            getattr(info, "binning_x", 0),
+            getattr(info, "binning_y", 0),
+            (roi.x_offset, roi.y_offset, roi.width, roi.height) if roi else None,
         )
         # Update key if it changed
         if key != self._intrinsics_key:

--- a/agents/components/llm.py
+++ b/agents/components/llm.py
@@ -470,8 +470,7 @@ class LLM(ModelComponent):
             msg_type = i.input_topic.msg_type
             # set trigger equal to a topic with type String if trigger not found
             if msg_type == String:
-                if not query:
-                    query = item
+                query = query or item
                 context[i.input_topic.name] = item
             elif msg_type in [DetectionsMultiSource, Detections]:
                 context[i.input_topic.name] = item

--- a/agents/components/mllm.py
+++ b/agents/components/mllm.py
@@ -7,6 +7,7 @@ from ..clients.db_base import DBClient
 from ..clients.model_base import ModelClient
 from ..config import MLLMConfig
 from ..ros import (
+    CameraInfo,
     FixedInput,
     Event,
     Image,
@@ -15,6 +16,7 @@ from ..ros import (
     Topic,
     DetectionsMultiSource,
     Detections,
+    Detections3D,
     RGBD,
     PointsOfInterest,
     ComponentRunType,
@@ -23,6 +25,7 @@ from ..ros import (
     component_action,
 )
 from ..utils import validate_func_args
+from ..utils.perception3d import resolve_lift_camera
 from .llm import LLM
 
 
@@ -45,6 +48,10 @@ class MLLM(LLM):
     :param trigger: The trigger value or topic for the MLLM component.
         This can be a single Topic object, a list of Topic objects, or a float value for a timed component. Defaults to 1.
     :type trigger: Union[Topic, list[Topic], float]
+    :param depth: Depth image topic registered to the camera the VLM grounds on, used together with `camera_info` to lift grounded boxes into metric 3D boxes when a Detections3D output is given (requires the "grounding" or "affordance" task). The depth frame is latched when the picture is captured for inference, so the boxes measure the scene the VLM actually saw.
+    :type depth: Optional[Topic]
+    :param camera_info: Camera intrinsics topic of the stream `depth` was measured on. Required alongside `depth` for a Detections3D output.
+    :type camera_info: Optional[Topic]
     :param component_name: The name of the MLLM component.
         This should be a string and defaults to "mllm_component".
     :type component_name: str
@@ -87,12 +94,14 @@ class MLLM(LLM):
         config: Optional[MLLMConfig] = None,
         db_client: Optional[DBClient] = None,
         trigger: Union[Topic, List[Topic], float, Event] = 1.0,
+        depth: Optional[Topic] = None,
+        camera_info: Optional[Topic] = None,
         component_name: str,
         **kwargs,
     ):
         self.allowed_inputs = {
             "Required": [String, [Image, RGBD]],
-            "Optional": [DetectionsMultiSource, Detections],
+            "Optional": [DetectionsMultiSource, Detections, CameraInfo],
         }
 
         config = config or MLLMConfig()
@@ -101,6 +110,52 @@ class MLLM(LLM):
             raise RuntimeError(
                 "MLLM/VLM component requires a model_client or enable_local_model=True in MLLMConfig."
             )
+
+        depth = depth or config._depth_topic
+        camera_info = camera_info or config._camera_info_topic
+        config._depth_topic = depth
+        config._camera_info_topic = camera_info
+        self.depth_topic, self.camera_info_topic = depth, camera_info
+
+        # Reject camera info if present in inputs
+        stray_info = [
+            t.name
+            for t in inputs
+            if issubclass(t.msg_type, CameraInfo)
+            and (camera_info is None or t.name != camera_info.name)
+        ]
+        if stray_info:
+            raise TypeError(
+                f"MLLM was given CameraInfo topic(s) {stray_info} among its "
+                "inputs. Intrinsics describe a camera rather than deliver "
+                "pictures to reason on, so they are passed as "
+                "`camera_info=Topic(...)`, as depth is passed as `depth=Topic(...)`."
+            )
+        self._aux_inputs = {t.name for t in (depth, camera_info) if t}
+
+        # Asking for a Detections3D output turns 3D lifting on
+        self._lift_to_3d = any(issubclass(t.msg_type, Detections3D) for t in outputs)
+        self._lift_camera = None
+        if self._lift_to_3d:
+            # Lifting to 3d only works for bounding box outputs
+            if config.task not in ("grounding", "affordance"):
+                raise TypeError(
+                    "MLLM was given a Detections3D output, which only the "
+                    "'grounding' and 'affordance' tasks can produce boxes for. "
+                    f"Set `task` in the MLLMConfig (currently {config.task!r})."
+                )
+            # The contract check names the picture stream the lift applies to
+            self._lift_camera = resolve_lift_camera(
+                inputs,
+                depth,
+                camera_info,
+                frame=config.detections_frame,
+                component="MLLM",
+            )
+            # Intrinsics and depth only get subscribed to when they feed a lift
+            for topic in (depth, camera_info):
+                if topic and all(t.name != topic.name for t in inputs):
+                    inputs = [*inputs, topic]
 
         super().__init__(
             inputs=inputs,
@@ -120,6 +175,7 @@ class MLLM(LLM):
             Detections,
             DetectionsMultiSource,
             PointsOfInterest,
+            Detections3D,
         ]
         self._images: List[Union[np.ndarray, ROSImage, ROSCompressedImage]] = []
 
@@ -180,16 +236,19 @@ class MLLM(LLM):
             self.messages = []
             return None
 
-        # aggregate all inputs that are available
+        # aggregate all inputs that are available. Depth and camera_info
+        # only feed the 3D lift, not the model
         for i in self.callbacks.values():
-            msg = i.msg
-            if (item := i.get_output()) is None:
+            if (
+                i.input_topic.name in self._aux_inputs
+                or (item := i.get_output()) is None
+            ):
                 continue
+            msg = i.msg
             msg_type = i.input_topic.msg_type
             # set trigger equal to a topic with type String if trigger not found
             if msg_type == String:
-                if not query:
-                    query = item
+                query = query or item
                 context[i.input_topic.name] = item
             elif msg_type in [DetectionsMultiSource, Detections]:
                 context[i.input_topic.name] = item

--- a/agents/components/mllm.py
+++ b/agents/components/mllm.py
@@ -196,7 +196,7 @@ class MLLM(LLM):
             # get images from image topics
             if issubclass(msg_type, (Image, RGBD)):
                 images.append(item)
-                if msg:
+                if msg is not None:
                     self._images.append(msg)  # Collect all images for publishing
 
         if not query or not images:

--- a/agents/components/mllm.py
+++ b/agents/components/mllm.py
@@ -26,10 +26,11 @@ from ..ros import (
 )
 from ..utils import validate_func_args
 from ..utils.perception3d import resolve_lift_camera
+from .depth_lift import DepthLiftMixin
 from .llm import LLM
 
 
-class MLLM(LLM):
+class MLLM(DepthLiftMixin, LLM):
     """
     This component utilizes multi-modal large language models (e.g. Llava) that can be used to process text and image data.
 
@@ -179,6 +180,11 @@ class MLLM(LLM):
         ]
         self._images: List[Union[np.ndarray, ROSImage, ROSCompressedImage]] = []
 
+        # Initialize detector for 3D lift and its parse calibration
+        self._init_lift_state()
+        # For capturing grounding query to name 3D boxes
+        self._lift_label: str = ""
+
     def custom_on_configure(self):
         # deploy local VLM if enabled
         if not self.model_client and self.config.enable_local_model:
@@ -194,6 +200,7 @@ class MLLM(LLM):
             self._string_publishers: List = []
             self._poi_publishers: List = []
             self._detections_publishers: List = []
+            self._detections3d_publishers: List = []
 
             # Loop through the list of topics and categorize them
             for topic in self.out_topics:
@@ -203,6 +210,8 @@ class MLLM(LLM):
                     self._poi_publishers.append(topic.name)
                 elif topic.msg_type in [Detections, DetectionsMultiSource]:
                     self._detections_publishers.append(topic.name)
+                elif topic.msg_type is Detections3D:
+                    self._detections3d_publishers.append(topic.name)
                 else:
                     pass
 
@@ -227,6 +236,9 @@ class MLLM(LLM):
         """
         self._images = []  # image msgs for publishing
         images = []  # image msg outputs as np arrays
+        # The 3D latched msg and depth
+        self._lift_msg = None
+        self._lift_depth = None
 
         # context dict to gather all String inputs for use in system prompt
         context = {}
@@ -257,9 +269,15 @@ class MLLM(LLM):
                 images.append(item)
                 if msg is not None:
                     self._images.append(msg)  # Collect all images for publishing
+                    if i.input_topic.name == self._lift_camera:
+                        self._lift_msg = msg
+                        self._lift_depth = self._depth_snapshot()
 
         if not query or not images:
             return None
+
+        # the query as given, before templates and RAG dress it up
+        self._lift_label = query
 
         # get RAG results if enabled in config and if docs retrieved
         rag_result = self._handle_rag_query(query) if self.config.enable_rag else None
@@ -472,6 +490,7 @@ class MLLM(LLM):
                     images=self._images if multi else next(iter(self._images), None),
                     time_stamp=self.get_ros_time(),
                 )
+            self._publish_grounded_3d(result["output"])
         elif self._task == "trajectory":
             for pub_name in self._poi_publishers:
                 self.publishers_dict[pub_name].publish(
@@ -479,6 +498,59 @@ class MLLM(LLM):
                     image=self._images[0],  # POI msg takes only one image
                     time_stamp=self.get_ros_time(),
                 )
+
+    def _publish_grounded_3d(self, pixels: List) -> None:
+        """Lift the grounded boxes into metric space and publish Detections3D."""
+
+        if not self._detections3d_publishers:
+            return
+        from ..utils.perception3d import (
+            boxes_from_detections,
+            detections_to_message_fields,
+        )
+
+        if self._lift_msg is None:
+            self._warn_once(
+                "no_lift_frame",
+                f"No picture was captured on '{self._lift_camera}', so the "
+                "grounded boxes cannot be placed in space.",
+            )
+            return
+
+        if not pixels:
+            fields = detections_to_message_fields([])
+        else:
+            detector, depth_mm = self._depth_detector()
+            if detector is None:
+                return
+            # the color image, which an RGBD frame carries nested
+            color = getattr(self._lift_msg, "rgb", self._lift_msg)
+            lifted = [
+                box
+                for box in boxes_from_detections(
+                    detector,
+                    depth_mm,
+                    pixels,
+                    image_size=(color.width, color.height),
+                    depth_range=(self.config.min_depth, self.config.max_depth),
+                )
+                # A box built from a handful of depth pixels is not trustworthy
+                if box.validity >= self.config.min_depth_validity
+            ]
+            # Every grounded box answers the same query, thus the same name
+            fields = detections_to_message_fields(
+                lifted,
+                labels=[self._lift_label] * len(pixels),
+                boxes_2d=pixels,
+            )
+
+        for pub_name in self._detections3d_publishers:
+            self.publishers_dict[pub_name].publish(
+                fields["output"],
+                **{k: v for k, v in fields.items() if k != "output"},
+                frame_id=self.config.detections_frame,
+                time_stamp=self.get_ros_time(),
+            )
 
     def _execution_step(self, *args, **kwargs):
         """_execution_step.

--- a/agents/components/mllm.py
+++ b/agents/components/mllm.py
@@ -39,6 +39,9 @@ class MLLM(DepthLiftMixin, LLM):
     :type inputs: list[Topic | FixedInput]
     :param outputs: The output topics for the MLLM component.
         This should be a list of Topic objects. String, Detections2D and PointsOfInterest2D types is handled automatically.
+        With the "grounding" or "affordance" task, a Detections3D output additionally lifts the
+        grounded boxes into metric space (see the `depth` and `camera_info` parameters), labeled
+        with the query that grounded them.
     :type outputs: list[Topic]
     :param model_client: The model client for the MLLM component.
         This should be an instance of ModelClient. Optional if ``enable_local_model`` is set to True in the config.

--- a/agents/components/mllm.py
+++ b/agents/components/mllm.py
@@ -398,21 +398,20 @@ class MLLM(LLM):
                     image=self._images[0],  # POI msg takes only one image
                     time_stamp=self.get_ros_time(),
                 )
-        elif self._task == "grounding":
-            result["output"] = [
-                {"bboxes": result["output"], "labels": [], "scores": []}
-            ]
+        elif self._task in ("grounding", "affordance"):
+            boxes = {"bboxes": result["output"], "labels": [], "scores": []}
             for pub_name in self._detections_publishers:
-                self.publishers_dict[pub_name].publish(
-                    **result, images=self._images, time_stamp=self.get_ros_time()
+                publisher = self.publishers_dict[pub_name]
+                # NOTE: The model grounds against the image set as a whole, so there
+                # is one set of boxes: a multi source topic takes it as a list
+                # of one, a single source topic takes it on its own
+                multi = issubclass(
+                    publisher.output_topic.msg_type, DetectionsMultiSource
                 )
-        elif self._task == "affordance":
-            result["output"] = [
-                {"bboxes": result["output"], "labels": [], "scores": []}
-            ]
-            for pub_name in self._detections_publishers:
-                self.publishers_dict[pub_name].publish(
-                    **result, images=self._images, time_stamp=self.get_ros_time()
+                publisher.publish(
+                    [boxes] if multi else boxes,
+                    images=self._images if multi else next(iter(self._images), None),
+                    time_stamp=self.get_ros_time(),
                 )
         elif self._task == "trajectory":
             for pub_name in self._poi_publishers:

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -1024,6 +1024,7 @@ class MoveIt(Component):
                 message,
                 min_thickness=self.config.min_object_thickness,
                 padding=self.config.object_padding,
+                include_labels=self.config.scene_detection_labels,
             ),
             now,
         )

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -898,7 +898,8 @@ class MoveIt(Component):
         Objects the detector stopped reporting are kept for
         `scene_object_ttl` seconds before a refresh removes them, so
         detection dropouts do not flicker. Attached objects are never evicted
-        or re-added.
+        or re-added. While an object is held the scene is frozen entirely. The
+        first refresh after release reconciles it.
 
         :param message: Detections to refresh from, when the caller has
             already read them. Default reads the latest received message
@@ -908,6 +909,16 @@ class MoveIt(Component):
             build_remove_object,
             collision_objects_from_detections,
         )
+
+        with self._scene_lock:
+            held = any(
+                entry.get("attached") for entry in self._scene_objects.values()
+            )
+        if held:
+            return (
+                "Scene refresh skipped while an object is held: the scene "
+                "stays as captured before the grasp, until release"
+            )
 
         if message is None:
             if not self._detections_topic:
@@ -968,7 +979,10 @@ class MoveIt(Component):
         """Split a refresh into objects to add and tracked ids gone stale.
 
         Attached objects are exempt from both sides, the rest expire by
-        their last sighting.
+        their last sighting. Refreshes are frozen while holding, so attached
+        entries normally never reach this; the exemption remains as the
+        guard for an attach landing between the freeze check and this
+        partition.
 
         :param objects: Collision objects built from the latest detections
         :param now: Refresh time, for the TTL comparison
@@ -1873,7 +1887,7 @@ class MoveIt(Component):
             "type": "function",
             "function": {
                 "name": "update_planning_scene",
-                "description": "Update the motion planning scene from the latest camera detections, so that the next motions plan around the objects currently seen. Call before planning a motion in a scene that may have changed.",
+                "description": "Update the motion planning scene from the latest camera detections, so that the next motions plan around the objects currently seen. Call before planning a motion in a scene that may have changed. While an object is held in the gripper the scene is frozen and this does nothing; it resumes after release.",
                 "parameters": {"type": "object", "properties": {}, "required": []},
             },
         },

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -696,6 +696,312 @@ class MoveIt(Component):
                 self.health_status.set_healthy()
         return result
 
+    def _command_gripper(
+        self, named_target: Optional[str], position: float, description: str
+    ) -> Tuple[bool, str]:
+        """Send a gripper command through the configured backend
+
+        :returns: (success, human readable description of what happened)
+        """
+        if not self._gripper_client:
+            return False, "The component is not active, cannot command the gripper"
+
+        handler = self._gripper_client
+        handler.reset()
+
+        if self.config.gripper_mode == "gripper_command":
+            from control_msgs.action import GripperCommand
+
+            goal = GripperCommand.Goal()
+            goal.command.position = position
+            goal.command.max_effort = self.config.gripper_max_effort
+        else:
+            if not self.config.gripper_group_name:
+                return False, (
+                    "No gripper is configured. Set 'gripper_group_name' in "
+                    "MoveItConfig to control a gripper through move_group."
+                )
+            try:
+                group, joint_positions = self._resolve_named_target(named_target)
+            except ValueError as e:
+                return False, str(e)
+            goal = build_move_group_goal(
+                joints_to_constraints(
+                    joint_positions, tolerance=self.config.goal_joint_tolerance
+                ),
+                group,
+                pipeline_id=self.config.planning_pipeline,
+                planner_id=self.config.planner_id,
+                num_attempts=self.config.num_planning_attempts,
+                allowed_time=self.config.allowed_planning_time,
+                velocity_scaling=self.config.max_velocity_scaling,
+                acceleration_scaling=self.config.max_acceleration_scaling,
+            )
+
+        if not handler.send_request(goal):
+            return False, f"Gripper '{description}' command was not accepted"
+
+        deadline = time.time() + self.config.execution_timeout
+        while not handler.action_returned and time.time() < deadline:
+            time.sleep(1 / self.config.loop_rate)
+
+        if not handler.action_returned:
+            handler.cancel_request()
+            return False, f"Gripper '{description}' command timed out"
+
+        error_code = getattr(handler.action_result, "error_code", None)
+        if error_code is not None:
+            status = moveit_error_string(getattr(error_code, "val", 0))
+            if status != "SUCCESS":
+                return False, f"Gripper '{description}' command failed: {status}"
+        return True, f"Gripper moved to '{description}'"
+
+    # =========================================================================
+    # PLANNING SCENE
+    # =========================================================================
+
+    def _apply_scene(
+        self, collision_objects=(), attached_objects=()
+    ) -> bool:
+        """Apply scene changes as one diff through move_group.
+
+        :param collision_objects: World objects to add, move or remove
+        :param attached_objects: Objects to attach to or detach from the robot
+        :returns: Whether move_group confirmed the change
+        """
+        from moveit_msgs.srv import ApplyPlanningScene
+
+        from ..utils.moveit import build_scene_diff
+
+        if not self._apply_scene_client:
+            self.get_logger().error(
+                "The planning scene client is not available, is the component active?"
+            )
+            return False
+
+        request = ApplyPlanningScene.Request()
+        request.scene = build_scene_diff(collision_objects, attached_objects)
+        response = self._apply_scene_client.send_request(request)
+        if response is None or not response.success:
+            self.get_logger().error(
+                "move_group did not apply the planning scene change"
+            )
+            return False
+        return True
+
+    def _resolve_touch_links(self, explicit: Optional[List[str]]) -> List[str]:
+        """Links allowed to stay in contact with an attached object.
+
+        Priority: the `touch_links` passed to the `attach_object` call, then
+        the configured `touch_links`, then the robot SRDF (gripper group
+        links or the end effector's neighborhood), then the end effector
+        link alone with a warning.
+        """
+        from ..utils.moveit import derive_touch_links
+
+        if not explicit and not self.config.touch_links and self._srdf is None:
+            # Fetch SRDF and cache along with the named targets
+            self._named_target_states()
+        return derive_touch_links(
+            self._srdf,
+            self.config.end_effector_link,
+            gripper_group=self.config.gripper_group_name or "",
+            explicit=explicit or self.config.touch_links,
+            logger_name=self.node_name,
+        )
+
+    def _do_attach(
+        self,
+        object_id: str,
+        link_name: str = "",
+        touch_links: Optional[List[str]] = None,
+    ) -> Tuple[bool, str]:
+        """Attach a scene object to a robot link.
+
+        :returns: (success, human readable description of what happened)
+        """
+        from ..utils.moveit import build_attached_object
+
+        link = link_name or self.config.end_effector_link
+        if not link:
+            return False, (
+                "No link to attach to: pass link_name or set "
+                "'end_effector_link' in the component config"
+            )
+
+        links = self._resolve_touch_links(touch_links)
+        if not self._apply_scene(
+            attached_objects=[build_attached_object(object_id, link, links)]
+        ):
+            return False, f"Could not attach '{object_id}' to '{link}'"
+
+        with self._scene_lock:
+            if entry := self._scene_objects.get(object_id):
+                entry["attached"] = link
+        return True, (
+            f"Attached '{object_id}' to '{link}' (touch links: {', '.join(links)})"
+        )
+
+    def _do_detach(self, object_id: str, remove: bool = False) -> Tuple[bool, str]:
+        """Detach an attached object, returning it to the world.
+
+        :returns: (success, human readable description of what happened)
+        """
+        from ..utils.moveit import build_detach_object, build_remove_object
+
+        if not self._apply_scene(
+            attached_objects=[build_detach_object(object_id)]
+        ):
+            return False, f"Could not detach '{object_id}'"
+
+        with self._scene_lock:
+            if entry := self._scene_objects.get(object_id):
+                entry.pop("attached", None)
+
+        if not remove:
+            return True, f"Detached '{object_id}', it remains in the scene"
+
+        # Detaching returns the object to the world, so removing it is a
+        # separate scene change
+        if not self._apply_scene([build_remove_object(object_id)]):
+            return False, (
+                f"Detached '{object_id}' but could not remove it from the scene"
+            )
+        with self._scene_lock:
+            self._scene_objects.pop(object_id, None)
+        return True, f"Detached '{object_id}' and removed it from the scene"
+
+    def _refresh_scene_from_detections(self, message: Optional[Any] = None) -> str:
+        """Push detections into the planning scene as one diff.
+
+        Objects the detector stopped reporting are kept for
+        `scene_object_ttl` seconds before a refresh removes them, so
+        detection dropouts do not flicker. Attached objects are never evicted
+        or re-added.
+
+        :param message: Detections to refresh from, when the caller has
+            already read them. Default reads the latest received message
+        :returns: What happened, for the caller and for tool use
+        """
+        from ..utils.moveit import (
+            build_remove_object,
+            collision_objects_from_detections,
+        )
+
+        if message is None:
+            if not self._detections_topic:
+                return (
+                    "No detections input is connected to this component, so "
+                    "there is nothing to update the planning scene from"
+                )
+            callback = self.callbacks.get(self._detections_topic.name)
+            # the callback's default output is a text summary for prompts, get
+            # the message itself for the boxes
+            message = callback.get_output(get_msg=True) if callback else None
+            if message is None:
+                return "No detections have been received yet"
+
+        now = time.time()
+        objects, stale = self._partition_scene_changes(
+            collision_objects_from_detections(
+                message,
+                min_thickness=self.config.min_object_thickness,
+                padding=self.config.object_padding,
+            ),
+            now,
+        )
+
+        changes = objects + [build_remove_object(object_id) for object_id in stale]
+        if not changes:
+            return "The planning scene is already up to date"
+        if not self._apply_scene(changes):
+            return "Could not update the planning scene"
+
+        added = []
+        with self._scene_lock:
+            for obj in objects:
+                # allocate only on first sighting, bump the rest in place
+                entry = self._scene_objects.setdefault(
+                    obj.id, {"source": "detection", "last_seen": now}
+                )
+                entry["last_seen"] = now
+                # an ADD moves an existing object, so the geometry follows it
+                position = obj.primitive_poses[0].position
+                dimensions = obj.primitives[0].dimensions
+                entry["center"] = (position.x, position.y, position.z)
+                entry["size"] = (dimensions[0], dimensions[1], dimensions[2])
+                added.append(obj.id)
+            for object_id in stale:
+                self._scene_objects.pop(object_id, None)
+
+        summary = f"Planning scene updated with {len(added)} detected object(s)"
+        if added:
+            summary += f": {', '.join(added)}"
+        if stale:
+            summary += f"; removed {len(stale)} stale object(s)"
+        return summary
+
+    def _partition_scene_changes(
+        self, objects: List[Any], now: float
+    ) -> Tuple[List[Any], List[str]]:
+        """Split a refresh into objects to add and tracked ids gone stale.
+
+        Attached objects are exempt from both sides, the rest expire by
+        their last sighting.
+
+        :param objects: Collision objects built from the latest detections
+        :param now: Refresh time, for the TTL comparison
+        :returns: (objects to add, tracked ids to remove)
+        """
+        seen = {obj.id for obj in objects}
+        attached, stale = set(), []
+        with self._scene_lock:
+            for object_id, entry in self._scene_objects.items():
+                if entry.get("attached"):
+                    attached.add(object_id)
+                elif (
+                    entry["source"] == "detection"
+                    and object_id not in seen
+                    and now - entry["last_seen"] > self.config.scene_object_ttl
+                ):
+                    stale.append(object_id)
+        if attached:
+            objects = [obj for obj in objects if obj.id not in attached]
+        return objects, stale
+
+    def _scene_refresh_tick(self):
+        """Continuous mode refresh, skipping ticks that would change nothing.
+
+        A tick refreshes only when a detections message arrived since the
+        last applied one, or a tracked object has outlived its TTL and is due
+        for removal.
+        """
+        callback = self.callbacks.get(self._detections_topic.name)
+        # the callback's default output is a text summary for prompts, get
+        # the message itself for the boxes
+        message = callback.get_output(get_msg=True) if callback else None
+        if message is None:
+            return
+
+        now = time.time()
+        if message is self._last_scene_message and not self._has_stale_objects(now):
+            # Dont refresh
+            return
+
+        self._last_scene_message = message
+        result = self._refresh_scene_from_detections(message)
+        self.get_logger().debug(result)
+
+    def _has_stale_objects(self, now: float) -> bool:
+        """Whether any tracked detection has outlived the TTL"""
+        with self._scene_lock:
+            return any(
+                entry["source"] == "detection"
+                and not entry.get("attached")
+                and now - entry["last_seen"] > self.config.scene_object_ttl
+                for entry in self._scene_objects.values()
+            )
+
     # =========================================================================
     # COMPONENT ACTIONS
     # =========================================================================
@@ -714,11 +1020,12 @@ class MoveIt(Component):
     )
     def open_gripper(self) -> str:
         """Open the gripper"""
-        return self._command_gripper(
+        _, message = self._command_gripper(
             named_target=self.config.gripper_open_target,
             position=self.config.gripper_open_position,
             description="open",
         )
+        return message
 
     @component_action(
         description={
@@ -734,11 +1041,12 @@ class MoveIt(Component):
     )
     def close_gripper(self) -> str:
         """Close the gripper"""
-        return self._command_gripper(
+        _, message = self._command_gripper(
             named_target=self.config.gripper_close_target,
             position=self.config.gripper_close_position,
             description="close",
         )
+        return message
 
     @component_action(
         description={
@@ -768,9 +1076,10 @@ class MoveIt(Component):
                 "Setting a specific gripper position requires gripper_mode to be "
                 "'gripper_command'. Use open_gripper or close_gripper instead."
             )
-        return self._command_gripper(
+        _, message = self._command_gripper(
             named_target=None, position=float(position), description=str(position)
         )
+        return message
 
     @component_action(
         description={
@@ -822,96 +1131,6 @@ class MoveIt(Component):
             for group, group_states in states.items()
             if group_states
         )
-
-    def _command_gripper(
-        self, named_target: Optional[str], position: float, description: str
-    ) -> str:
-        """Send a gripper command through the configured backend"""
-        if not self._gripper_client:
-            return "The component is not active, cannot command the gripper"
-
-        handler = self._gripper_client
-        handler.reset()
-
-        if self.config.gripper_mode == "gripper_command":
-            from control_msgs.action import GripperCommand
-
-            goal = GripperCommand.Goal()
-            goal.command.position = position
-            goal.command.max_effort = self.config.gripper_max_effort
-        else:
-            if not self.config.gripper_group_name:
-                return (
-                    "No gripper is configured. Set 'gripper_group_name' in "
-                    "MoveItConfig to control a gripper through move_group."
-                )
-            try:
-                group, joint_positions = self._resolve_named_target(named_target)
-            except ValueError as e:
-                return str(e)
-            goal = build_move_group_goal(
-                joints_to_constraints(
-                    joint_positions, tolerance=self.config.goal_joint_tolerance
-                ),
-                group,
-                pipeline_id=self.config.planning_pipeline,
-                planner_id=self.config.planner_id,
-                num_attempts=self.config.num_planning_attempts,
-                allowed_time=self.config.allowed_planning_time,
-                velocity_scaling=self.config.max_velocity_scaling,
-                acceleration_scaling=self.config.max_acceleration_scaling,
-            )
-
-        if not handler.send_request(goal):
-            return f"Gripper '{description}' command was not accepted"
-
-        deadline = time.time() + self.config.execution_timeout
-        while not handler.action_returned and time.time() < deadline:
-            time.sleep(1 / self.config.loop_rate)
-
-        if not handler.action_returned:
-            handler.cancel_request()
-            return f"Gripper '{description}' command timed out"
-
-        error_code = getattr(handler.action_result, "error_code", None)
-        if error_code is not None:
-            status = moveit_error_string(getattr(error_code, "val", 0))
-            if status != "SUCCESS":
-                return f"Gripper '{description}' command failed: {status}"
-        return f"Gripper moved to '{description}'"
-
-    # =========================================================================
-    # PLANNING SCENE
-    # =========================================================================
-
-    def _apply_scene(
-        self, collision_objects=(), attached_objects=()
-    ) -> bool:
-        """Apply scene changes as one diff through move_group.
-
-        :param collision_objects: World objects to add, move or remove
-        :param attached_objects: Objects to attach to or detach from the robot
-        :returns: Whether move_group confirmed the change
-        """
-        from moveit_msgs.srv import ApplyPlanningScene
-
-        from ..utils.moveit import build_scene_diff
-
-        if not self._apply_scene_client:
-            self.get_logger().error(
-                "The planning scene client is not available, is the component active?"
-            )
-            return False
-
-        request = ApplyPlanningScene.Request()
-        request.scene = build_scene_diff(collision_objects, attached_objects)
-        response = self._apply_scene_client.send_request(request)
-        if response is None or not response.success:
-            self.get_logger().error(
-                "move_group did not apply the planning scene change"
-            )
-            return False
-        return True
 
     @component_action(
         description={
@@ -1149,27 +1368,6 @@ class MoveIt(Component):
             return "move_group did not answer the octomap clear request"
         return "Cleared the planning scene octomap"
 
-    def _resolve_touch_links(self, explicit: Optional[List[str]]) -> List[str]:
-        """Links allowed to stay in contact with an attached object.
-
-        Priority: the `touch_links` passed to the `attach_object` call, then
-        the configured `touch_links`, then the robot SRDF (gripper group
-        links or the end effector's neighborhood), then the end effector
-        link alone with a warning.
-        """
-        from ..utils.moveit import derive_touch_links
-
-        if not explicit and not self.config.touch_links and self._srdf is None:
-            # Fetch SRDF and cache along with the named targets
-            self._named_target_states()
-        return derive_touch_links(
-            self._srdf,
-            self.config.end_effector_link,
-            gripper_group=self.config.gripper_group_name or "",
-            explicit=explicit or self.config.touch_links,
-            logger_name=self.node_name,
-        )
-
     @component_action(
         description={
             "type": "function",
@@ -1213,25 +1411,8 @@ class MoveIt(Component):
             Default resolves them from the config or the robot SRDF
         :returns: What happened, for the caller and for tool use
         """
-        from ..utils.moveit import build_attached_object
-
-        link = link_name or self.config.end_effector_link
-        if not link:
-            return (
-                "No link to attach to: pass link_name or set "
-                "'end_effector_link' in the component config"
-            )
-
-        links = self._resolve_touch_links(touch_links)
-        if not self._apply_scene(
-            attached_objects=[build_attached_object(object_id, link, links)]
-        ):
-            return f"Could not attach '{object_id}' to '{link}'"
-
-        with self._scene_lock:
-            if entry := self._scene_objects.get(object_id):
-                entry["attached"] = link
-        return f"Attached '{object_id}' to '{link}' (touch links: {', '.join(links)})"
+        _, message = self._do_attach(object_id, link_name, touch_links)
+        return message
 
     @component_action(
         description={
@@ -1267,162 +1448,8 @@ class MoveIt(Component):
             physically happened
         :returns: What happened, for the caller and for tool use
         """
-        from ..utils.moveit import build_detach_object, build_remove_object
-
-        if not self._apply_scene(
-            attached_objects=[build_detach_object(object_id)]
-        ):
-            return f"Could not detach '{object_id}'"
-
-        with self._scene_lock:
-            if entry := self._scene_objects.get(object_id):
-                entry.pop("attached", None)
-
-        if not remove:
-            return f"Detached '{object_id}', it remains in the scene"
-
-        # Detaching returns the object to the world, so removing it is a
-        # separate scene change
-        if not self._apply_scene([build_remove_object(object_id)]):
-            return f"Detached '{object_id}' but could not remove it from the scene"
-        with self._scene_lock:
-            self._scene_objects.pop(object_id, None)
-        return f"Detached '{object_id}' and removed it from the scene"
-
-    def _refresh_scene_from_detections(self, message: Optional[Any] = None) -> str:
-        """Push detections into the planning scene as one diff.
-
-        Objects the detector stopped reporting are kept for
-        `scene_object_ttl` seconds before a refresh removes them, so
-        detection dropouts do not flicker. Attached objects are never evicted
-        or re-added.
-
-        :param message: Detections to refresh from, when the caller has
-            already read them. Default reads the latest received message
-        :returns: What happened, for the caller and for tool use
-        """
-        from ..utils.moveit import (
-            build_remove_object,
-            collision_objects_from_detections,
-        )
-
-        if message is None:
-            if not self._detections_topic:
-                return (
-                    "No detections input is connected to this component, so "
-                    "there is nothing to update the planning scene from"
-                )
-            callback = self.callbacks.get(self._detections_topic.name)
-            # the callback's default output is a text summary for prompts, get
-            # the message itself for the boxes
-            message = callback.get_output(get_msg=True) if callback else None
-            if message is None:
-                return "No detections have been received yet"
-
-        now = time.time()
-        objects, stale = self._partition_scene_changes(
-            collision_objects_from_detections(
-                message,
-                min_thickness=self.config.min_object_thickness,
-                padding=self.config.object_padding,
-            ),
-            now,
-        )
-
-        changes = objects + [build_remove_object(object_id) for object_id in stale]
-        if not changes:
-            return "The planning scene is already up to date"
-        if not self._apply_scene(changes):
-            return "Could not update the planning scene"
-
-        added = []
-        with self._scene_lock:
-            for obj in objects:
-                # allocate only on first sighting, bump the rest in place
-                entry = self._scene_objects.setdefault(
-                    obj.id, {"source": "detection", "last_seen": now}
-                )
-                entry["last_seen"] = now
-                # an ADD moves an existing object, so the geometry follows it
-                position = obj.primitive_poses[0].position
-                dimensions = obj.primitives[0].dimensions
-                entry["center"] = (position.x, position.y, position.z)
-                entry["size"] = (dimensions[0], dimensions[1], dimensions[2])
-                added.append(obj.id)
-            for object_id in stale:
-                self._scene_objects.pop(object_id, None)
-
-        summary = f"Planning scene updated with {len(added)} detected object(s)"
-        if added:
-            summary += f": {', '.join(added)}"
-        if stale:
-            summary += f"; removed {len(stale)} stale object(s)"
-        return summary
-
-    def _partition_scene_changes(
-        self, objects: List[Any], now: float
-    ) -> Tuple[List[Any], List[str]]:
-        """Split a refresh into objects to add and tracked ids gone stale.
-
-        Attached objects are exempt from both sides, the rest expire by
-        their last sighting.
-
-        :param objects: Collision objects built from the latest detections
-        :param now: Refresh time, for the TTL comparison
-        :returns: (objects to add, tracked ids to remove)
-        """
-        seen = {obj.id for obj in objects}
-        attached, stale = set(), []
-        with self._scene_lock:
-            for object_id, entry in self._scene_objects.items():
-                if entry.get("attached"):
-                    attached.add(object_id)
-                elif (
-                    entry["source"] == "detection"
-                    and object_id not in seen
-                    and now - entry["last_seen"] > self.config.scene_object_ttl
-                ):
-                    stale.append(object_id)
-        if attached:
-            objects = [obj for obj in objects if obj.id not in attached]
-        return objects, stale
-
-    def _scene_refresh_tick(self):
-        """Continuous mode refresh, skipping ticks that would change nothing.
-
-        A tick refreshes only when a detections message arrived since the
-        last applied one, or a tracked object has outlived its TTL and is due
-        for removal. With a source
-        slower than the timer (e.g. VLM), objects from the
-        last message are re-applied about once per TTL period, keeping the
-        snapshot alive rather than evicting a scene that was simply not
-        re-observed.
-        """
-        callback = self.callbacks.get(self._detections_topic.name)
-        # the callback's default output is a text summary for prompts, get
-        # the message itself for the boxes
-        message = callback.get_output(get_msg=True) if callback else None
-        if message is None:
-            return
-
-        now = time.time()
-        if message is self._last_scene_message and not self._has_stale_objects(now):
-            # Dont refresh
-            return
-
-        self._last_scene_message = message
-        result = self._refresh_scene_from_detections(message)
-        self.get_logger().debug(result)
-
-    def _has_stale_objects(self, now: float) -> bool:
-        """Whether any tracked detection has outlived the TTL"""
-        with self._scene_lock:
-            return any(
-                entry["source"] == "detection"
-                and not entry.get("attached")
-                and now - entry["last_seen"] > self.config.scene_object_ttl
-                for entry in self._scene_objects.values()
-            )
+        _, message = self._do_detach(object_id, remove)
+        return message
 
     @component_action(
         description={

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -27,7 +27,7 @@ from ..utils.moveit import (
     moveit_error_string,
     parse_planner_interfaces,
     pose_to_constraints,
-    SRDF_PARAMETER
+    SRDF_PARAMETER,
 )
 from .component_base import Component
 
@@ -437,6 +437,12 @@ class MoveIt(Component):
         acceleration = goal.acceleration_scaling or self.config.max_acceleration_scaling
         return float(velocity), float(acceleration)
 
+    def _publish_state(self, goal_handle, state: str) -> None:
+        """Report the current step of a sequence through the goal feedback"""
+        feedback = MoveManipulator.Feedback()
+        feedback.state = state
+        goal_handle.publish_feedback(feedback)
+
     def _feedback_forwarder(self, handler: ActionClientHandler, goal_handle):
         """Create a listener that republishes move_group feedback on our goal"""
 
@@ -445,11 +451,8 @@ class MoveIt(Component):
             if feedback is None:
                 return
             state = getattr(getattr(feedback, "feedback", feedback), "state", "")
-            if not state:
-                return
-            message = MoveManipulator.Feedback()
-            message.state = str(state)
-            goal_handle.publish_feedback(message)
+            if state:
+                self._publish_state(goal_handle, str(state))
 
         return _forward
 
@@ -500,14 +503,11 @@ class MoveIt(Component):
             mode = MoveMode.from_goal(goal)
             self.get_logger().info(f"Received a '{mode.value}' motion goal")
 
-            if self.config.scene_update_mode == "on_goal" and self._detections_topic:
-                feedback = MoveManipulator.Feedback()
-                feedback.state = "UPDATING_SCENE"
-                goal_handle.publish_feedback(feedback)
-                # NOTE: The scene is advisory. A failure here doesnt abort the mission.
-                # It degrades to planning against the previous scene.
-                scene_status = self._refresh_scene_from_detections()
-                self.get_logger().info(scene_status)
+            self._refresh_before_goal(goal_handle)
+
+            if mode is MoveMode.PICK:
+                outcome = self._execute_pick(goal, goal_handle, result, deadline)
+                return self._finish_sequence(outcome, goal_handle, result)
 
             if mode is MoveMode.CARTESIAN:
                 trajectory = self._plan_cartesian_path(goal, result)
@@ -545,23 +545,10 @@ class MoveIt(Component):
                     return self._terminate(goal_handle, result, abort=True)
 
             outcome = self._await_result(handler, goal_handle, deadline)
-
-            if outcome == "preempted":
-                return self._terminate(
-                    goal_handle, result, listener=listener, handler=handler
-                )
-            if outcome == "canceled":
-                result.message = "Motion canceled"
-                return self._terminate(
-                    goal_handle, result, cancel=True, listener=listener, handler=handler
-                )
-            if outcome == "timeout":
-                result.message = (
-                    f"Motion did not complete within {self.config.execution_timeout}s"
-                )
-                return self._terminate(
-                    goal_handle, result, abort=True, listener=listener, handler=handler
-                )
+            if terminated := self._terminate_by_wait(
+                outcome, goal_handle, result, listener, handler
+            ):
+                return terminated
 
             error_code = getattr(handler.action_result, "error_code", None)
             code = getattr(error_code, "val", 0)
@@ -696,6 +683,38 @@ class MoveIt(Component):
                 self.health_status.set_healthy()
         return result
 
+    def _terminate_by_wait(
+        self,
+        waited: str,
+        goal_handle,
+        result: Any,
+        listener=None,
+        handler: Optional[ActionClientHandler] = None,
+    ) -> Optional[Any]:
+        """Terminate a goal whose wait ended without a result, if it did.
+
+        :param waited: What _await_result reported
+        :returns: The terminated result, or None when the motion returned
+            normally and the caller should read its outcome
+        """
+        if waited == "preempted":
+            return self._terminate(
+                goal_handle, result, listener=listener, handler=handler
+            )
+        if waited == "canceled":
+            result.message = "Motion canceled"
+            return self._terminate(
+                goal_handle, result, cancel=True, listener=listener, handler=handler
+            )
+        if waited == "timeout":
+            result.message = (
+                f"Motion did not complete within {self.config.execution_timeout}s"
+            )
+            return self._terminate(
+                goal_handle, result, abort=True, listener=listener, handler=handler
+            )
+        return None
+
     def _command_gripper(
         self, named_target: Optional[str], position: float, description: str
     ) -> Tuple[bool, str]:
@@ -760,9 +779,7 @@ class MoveIt(Component):
     # PLANNING SCENE
     # =========================================================================
 
-    def _apply_scene(
-        self, collision_objects=(), attached_objects=()
-    ) -> bool:
+    def _apply_scene(self, collision_objects=(), attached_objects=()) -> bool:
         """Apply scene changes as one diff through move_group.
 
         :param collision_objects: World objects to add, move or remove
@@ -849,9 +866,7 @@ class MoveIt(Component):
         """
         from ..utils.moveit import build_detach_object, build_remove_object
 
-        if not self._apply_scene(
-            attached_objects=[build_detach_object(object_id)]
-        ):
+        if not self._apply_scene(attached_objects=[build_detach_object(object_id)]):
             return False, f"Could not detach '{object_id}'"
 
         with self._scene_lock:
@@ -970,7 +985,7 @@ class MoveIt(Component):
         return objects, stale
 
     def _scene_refresh_tick(self):
-        """Continuous mode refresh, skipping ticks that would change nothing.
+        """The `continuous` mode scene refresh. Skips ticks that would change nothing.
 
         A tick refreshes only when a detections message arrived since the
         last applied one, or a tracked object has outlived its TTL and is due
@@ -1001,6 +1016,310 @@ class MoveIt(Component):
                 and now - entry["last_seen"] > self.config.scene_object_ttl
                 for entry in self._scene_objects.values()
             )
+
+    def _refresh_before_goal(self, goal_handle) -> None:
+        """The on_goal mode scene refresh, before any planning starts.
+
+        NOTE: The scene is advisory. A failure here doesnt abort the mission.
+        It degrades to planning against the previous scene.
+        """
+        if self.config.scene_update_mode != "on_goal" or not self._detections_topic:
+            return
+        self._publish_state(goal_handle, "UPDATING_SCENE")
+        scene_status = self._refresh_scene_from_detections()
+        self.get_logger().info(scene_status)
+
+    # =========================================================================
+    # PICK AND PLACE
+    # =========================================================================
+    # TODO: The step-sequencing machinery here (_finish_sequence,
+    # _sequence_motion, per-step feedback) is a custom routine engine.
+    # Rebase it on the Routine/MonitoredAction primitives once
+    # https://github.com/automatika-robotics/sugarcoat/issues/55 lands with
+    # result conditions, goal parameterization and inter-step data flow.
+
+    def _finish_sequence(self, outcome: str, goal_handle, result: Any) -> Any:
+        """Transition a sequence goal by the outcome of its last step"""
+        if outcome == "canceled":
+            result.message = result.message or "Motion canceled"
+            return self._terminate(goal_handle, result, cancel=True)
+        if outcome == "preempted":
+            return self._terminate(goal_handle, result)
+        result.success = outcome == "ok"
+        return self._terminate(goal_handle, result, abort=not result.success)
+
+    def _sequence_motion(
+        self,
+        handler: ActionClientHandler,
+        motion_goal: Any,
+        goal_handle,
+        deadline: float,
+    ) -> Tuple[str, str]:
+        """Run one motion of a sequence to completion.
+
+        :param handler: Action client carrying the motion (move or execute)
+        :param motion_goal: Goal for that client
+        :returns: (outcome, message) with outcome "ok", "aborted",
+            "canceled" or "preempted"
+        """
+        handler.reset()
+        if not handler.send_request(motion_goal):
+            return "aborted", "move_group did not accept the motion goal"
+
+        waited = self._await_result(handler, goal_handle, deadline)
+        if waited == "preempted":
+            return "preempted", "Goal preempted by a new goal"
+        if waited == "canceled":
+            return "canceled", "Motion canceled"
+        if waited == "timeout":
+            return "aborted", (
+                f"Motion did not complete within {self.config.execution_timeout}s"
+            )
+
+        code = getattr(getattr(handler.action_result, "error_code", None), "val", 0)
+        status = moveit_error_string(code)
+        if status != "SUCCESS":
+            return "aborted", f"Motion failed: {status}"
+        return "ok", status
+
+    def _pose_motion_goal(self, x: float, y: float, z: float, orientation=None) -> Any:
+        """A collision-aware motion goal to an end-effector position.
+
+        :param orientation: Optional end-effector orientation. All-zero or
+            None means no preference: identity, with the configured
+            orientation tolerance giving the planner its freedom
+        """
+        from ..ros import ROSPoseStamped
+
+        target = ROSPoseStamped()
+        target.header.frame_id = self.config.pose_reference_frame
+        position = target.pose.position
+        position.x, position.y, position.z = float(x), float(y), float(z)
+        if orientation is not None and any((
+            orientation.x,
+            orientation.y,
+            orientation.z,
+            orientation.w,
+        )):
+            target.pose.orientation = orientation
+        else:
+            target.pose.orientation.w = 1.0
+
+        constraints = pose_to_constraints(
+            target,
+            link_name=self.config.end_effector_link,
+            position_tolerance=self.config.goal_position_tolerance,
+            orientation_tolerance=self.config.goal_orientation_tolerance,
+        )
+        return build_move_group_goal(
+            constraints,
+            self.config.arm_group_name,
+            pipeline_id=self.config.planning_pipeline,
+            planner_id=self.config.planner_id,
+            num_attempts=self.config.num_planning_attempts,
+            allowed_time=self.config.allowed_planning_time,
+            velocity_scaling=self.config.max_velocity_scaling,
+            acceleration_scaling=self.config.max_acceleration_scaling,
+        )
+
+    def _sequence_descent(
+        self, x: float, y: float, z: float, orientation, goal_handle, deadline: float
+    ) -> Tuple[str, str]:
+        """Straight-line end-effector motion with contact permitted.
+
+        Collision checking is off for this one motion, so the gripper may reach
+        into the target's collision box. Everything before and after remains
+        collision-aware.
+
+        :returns: (outcome, message), as in _sequence_motion
+        """
+        from moveit_msgs.action import ExecuteTrajectory
+
+        from ..ros import ROSPose
+
+        waypoint = ROSPose()
+        waypoint.position.x, waypoint.position.y, waypoint.position.z = (
+            float(x),
+            float(y),
+            float(z),
+        )
+        if orientation is not None and any((
+            orientation.x,
+            orientation.y,
+            orientation.z,
+            orientation.w,
+        )):
+            waypoint.orientation = orientation
+        else:
+            waypoint.orientation.w = 1.0
+
+        request = build_cartesian_request(
+            [waypoint],
+            frame_id=self.config.pose_reference_frame,
+            group_name=self.config.arm_group_name,
+            link_name=self.config.end_effector_link,
+            max_step=self.config.cartesian_max_step,
+            jump_threshold=self.config.cartesian_jump_threshold,
+            avoid_collisions=False,
+            velocity_scaling=self.config.max_velocity_scaling,
+            acceleration_scaling=self.config.max_acceleration_scaling,
+        )
+        response = self._cartesian_client.send_request(request)
+        if not response:
+            return "aborted", "No response from the Cartesian path service"
+        if response.fraction < self.config.cartesian_fraction_threshold:
+            return "aborted", (
+                f"Only {response.fraction:.0%} of the straight-line segment is "
+                "achievable"
+            )
+
+        execute_goal = ExecuteTrajectory.Goal()
+        execute_goal.trajectory = response.solution
+        return self._sequence_motion(
+            self._exec_client, execute_goal, goal_handle, deadline
+        )
+
+    def _resolve_pick_target(
+        self, goal: Any
+    ) -> Tuple[str, Tuple[float, float, float], Tuple[float, float, float]]:
+        """Find the scene object a pick goal refers to.
+
+        Attached objects are never candidates (already held).
+
+        :returns: (object id, center, size) from the scene bookkeeping
+        :raises ValueError: When nothing in the scene matches
+        """
+        from ..utils.moveit import DETECTION_ID_PREFIX
+
+        # Candidates: everything with known geometry, minus attached objects
+        with self._scene_lock:
+            candidates = {
+                object_id: (entry["center"], entry["size"])
+                for object_id, entry in self._scene_objects.items()
+                if "center" in entry and not entry.get("attached")
+            }
+
+        name = (goal.target_object or "").strip()
+        if name:
+            # 1. target_object as an exact scene id
+            if name in candidates:
+                return name, *candidates[name]
+            # 2. target_object as a detection label, best rank wins
+            matches = [
+                object_id
+                for object_id in candidates
+                if object_id.startswith(f"{DETECTION_ID_PREFIX}{name}_")
+            ]
+            if matches:
+                # ranks order by score. 0 is the strongest detection
+                best = min(matches, key=lambda object_id: (len(object_id), object_id))
+                return best, *candidates[best]
+            raise ValueError(
+                f"No scene object matches '{name}'. Objects in the scene: "
+                f"{sorted(candidates) or 'none'}"
+            )
+
+        # 3. If no name is given, take nearest object to target_pose, within the radius
+        position = goal.target_pose.pose.position
+        nearest = min(
+            candidates.items(),
+            key=lambda item: (
+                (item[1][0][0] - position.x) ** 2
+                + (item[1][0][1] - position.y) ** 2
+                + (item[1][0][2] - position.z) ** 2
+            ),
+            default=None,
+        )
+        if nearest:
+            object_id, (center, size) = nearest
+            distance = (
+                sum(
+                    (a - b) ** 2
+                    for a, b in zip(center, (position.x, position.y, position.z))
+                )
+                ** 0.5
+            )
+            if distance <= self.config.target_match_radius:
+                return object_id, center, size
+        raise ValueError(
+            "No scene object within "
+            f"{self.config.target_match_radius} m of the given pose. Add the "
+            "object to the planning scene first, or name it with target_object."
+        )
+
+    def _execute_pick(
+        self, goal: Any, goal_handle, result: Any, deadline: float
+    ) -> str:
+        """Grasp a scene object and lift it.
+
+        Approach above the object (collision-aware), open, descend straight
+        onto it (contact permitted), close, attach, lift.
+
+        :returns: Outcome of the last step, for _finish_sequence
+        """
+        object_id, center, size = self._resolve_pick_target(goal)
+        self.get_logger().info(f"Picking '{object_id}' at {center}")
+        approach_z = center[2] + size[2] / 2 + self.config.approach_clearance
+        orientation = goal.target_pose.pose.orientation
+
+        self._publish_state(goal_handle, "PRE_GRASP")
+        outcome, message = self._sequence_motion(
+            self._move_client,
+            self._pose_motion_goal(center[0], center[1], approach_z, orientation),
+            goal_handle,
+            deadline,
+        )
+        if outcome != "ok":
+            result.message = f"Pre-grasp: {message}"
+            return outcome
+
+        self._publish_state(goal_handle, "OPEN_GRIPPER")
+        ok, message = self._command_gripper(
+            named_target=self.config.gripper_open_target,
+            position=self.config.gripper_open_position,
+            description="open",
+        )
+        if not ok:
+            result.message = message
+            return "aborted"
+
+        self._publish_state(goal_handle, "DESCEND")
+        outcome, message = self._sequence_descent(
+            center[0], center[1], center[2], orientation, goal_handle, deadline
+        )
+        if outcome != "ok":
+            result.message = f"Descent: {message}"
+            return outcome
+
+        self._publish_state(goal_handle, "GRASP")
+        ok, message = self._command_gripper(
+            named_target=self.config.gripper_close_target,
+            position=self.config.gripper_close_position,
+            description="close",
+        )
+        if not ok:
+            result.message = message
+            return "aborted"
+
+        self._publish_state(goal_handle, "ATTACH")
+        ok, message = self._do_attach(object_id)
+        if not ok:
+            result.message = message
+            return "aborted"
+
+        self._publish_state(goal_handle, "LIFT")
+        outcome, message = self._sequence_motion(
+            self._move_client,
+            self._pose_motion_goal(center[0], center[1], approach_z, orientation),
+            goal_handle,
+            deadline,
+        )
+        if outcome != "ok":
+            result.message = f"Lift: {message}"
+            return outcome
+
+        result.message = f"Picked '{object_id}'"
+        return "ok"
 
     # =========================================================================
     # COMPONENT ACTIONS

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -141,8 +141,10 @@ class MoveIt(Component):
         self._get_scene_client: Optional[ServiceClientHandler] = None
         self._clear_octomap_client: Optional[ServiceClientHandler] = None
 
-        # Named targets read from the SRDF, resolved lazily and cached
+        # Named targets read from the SRDF, resolved lazily and cached, and
+        # the raw SRDF they were read from
         self._named_targets: Optional[Dict[str, Dict[str, Dict[str, float]]]] = None
+        self._srdf: Optional[str] = None
 
         # Objects this component has placed in the planning scene, as
         # id -> {"source": "manual" | "detection", "last_seen": time}
@@ -362,6 +364,8 @@ class MoveIt(Component):
                 })
                 if response and response.values and response.values[0].string_value:
                     srdf = response.values[0].string_value
+                    # Keep raw for consumers that read more than named targets
+                    self._srdf = srdf
                 else:
                     self.get_logger().warning(
                         f"Could not read '{SRDF_PARAMETER}' from "
@@ -1103,3 +1107,143 @@ class MoveIt(Component):
         if response is None:
             return "move_group did not answer the octomap clear request"
         return "Cleared the planning scene octomap"
+
+    def _resolve_touch_links(self, explicit: Optional[List[str]]) -> List[str]:
+        """Links allowed to stay in contact with an attached object.
+
+        Priority: the `touch_links` passed to the `attach_object` call, then
+        the configured `touch_links`, then the robot SRDF (gripper group
+        links or the end effector's neighborhood), then the end effector
+        link alone with a warning.
+        """
+        from ..utils.moveit import derive_touch_links
+
+        if not explicit and not self.config.touch_links and self._srdf is None:
+            # Fetch SRDF and cache along with the named targets
+            self._named_target_states()
+        return derive_touch_links(
+            self._srdf,
+            self.config.end_effector_link,
+            gripper_group=self.config.gripper_group_name or "",
+            explicit=explicit or self.config.touch_links,
+            logger_name=self.node_name,
+        )
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "attach_object",
+                "description": "Attach a planning scene object to the robot's gripper, so it moves with the arm and contact with the gripper stops counting as a collision. Call right after closing the gripper on an object; without it, the first motion while holding the object fails on a collision between gripper and object.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "object_id": {
+                            "type": "string",
+                            "description": "Name of the object in the planning scene, as listed by list_collision_objects.",
+                        },
+                        "link_name": {
+                            "type": "string",
+                            "description": "Robot link to attach the object to. Default is the configured end effector link.",
+                        },
+                    },
+                    "required": ["object_id"],
+                },
+            },
+        },
+        active=True,
+        phase=ActionPhase.EXECUTION,
+    )
+    def attach_object(
+        self,
+        object_id: str,
+        link_name: str = "",
+        touch_links: Optional[List[str]] = None,
+    ) -> str:
+        """Attach a scene object to a robot link, as on a grasp.
+
+        move_group removes the object from the world and carries it with the
+        link; contact with the touch links stops counting as collision.
+
+        :param object_id: Name of an object already in the planning scene
+        :param link_name: Link the object is rigidly attached to. Empty uses
+            the configured end effector link
+        :param touch_links: Links allowed to stay in contact with the object.
+            Default resolves them from the config or the robot SRDF
+        :returns: What happened, for the caller and for tool use
+        """
+        from ..utils.moveit import build_attached_object
+
+        link = link_name or self.config.end_effector_link
+        if not link:
+            return (
+                "No link to attach to: pass link_name or set "
+                "'end_effector_link' in the component config"
+            )
+
+        links = self._resolve_touch_links(touch_links)
+        if not self._apply_scene(
+            attached_objects=[build_attached_object(object_id, link, links)]
+        ):
+            return f"Could not attach '{object_id}' to '{link}'"
+
+        with self._scene_lock:
+            if entry := self._scene_objects.get(object_id):
+                entry["attached"] = link
+        return f"Attached '{object_id}' to '{link}' (touch links: {', '.join(links)})"
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "detach_object",
+                "description": "Detach a held object from the robot's gripper in the planning scene. Call after releasing an object. By default the object stays in the scene where it was released.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "object_id": {
+                            "type": "string",
+                            "description": "Name of the attached object.",
+                        },
+                        "remove": {
+                            "type": "boolean",
+                            "description": "Also delete the object from the scene entirely, e.g. after handing it away. Default is false.",
+                        },
+                    },
+                    "required": ["object_id"],
+                },
+            },
+        },
+        active=True,
+        phase=ActionPhase.EXECUTION,
+    )
+    def detach_object(self, object_id: str, remove: bool = False) -> str:
+        """Detach an attached object, returning it to the world.
+
+        :param object_id: Name the object was attached under
+        :param remove: Also remove the object from the scene entirely. The
+            default keeps it where it was released, which matches what
+            physically happened
+        :returns: What happened, for the caller and for tool use
+        """
+        from ..utils.moveit import build_detach_object, build_remove_object
+
+        if not self._apply_scene(
+            attached_objects=[build_detach_object(object_id)]
+        ):
+            return f"Could not detach '{object_id}'"
+
+        with self._scene_lock:
+            if entry := self._scene_objects.get(object_id):
+                entry.pop("attached", None)
+
+        if not remove:
+            return f"Detached '{object_id}', it remains in the scene"
+
+        # Detaching returns the object to the world, so removing it is a
+        # separate scene change
+        if not self._apply_scene([build_remove_object(object_id)]):
+            return f"Detached '{object_id}' but could not remove it from the scene"
+        with self._scene_lock:
+            self._scene_objects.pop(object_id, None)
+        return f"Detached '{object_id}' and removed it from the scene"

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -984,9 +984,14 @@ class MoveIt(Component):
             return f"Could not add '{object_id}' to the planning scene"
 
         with self._scene_lock:
+            # geometry as applied (thickness floor included)
+            position = obj.primitive_poses[0].position
+            dimensions = obj.primitives[0].dimensions
             self._scene_objects[object_id] = {
                 "source": "manual",
                 "last_seen": time.time(),
+                "center": (position.x, position.y, position.z),
+                "size": (dimensions[0], dimensions[1], dimensions[2]),
             }
         return f"Added '{object_id}' to the planning scene"
 
@@ -1338,6 +1343,11 @@ class MoveIt(Component):
                     obj.id, {"source": "detection", "last_seen": now}
                 )
                 entry["last_seen"] = now
+                # an ADD moves an existing object, so the geometry follows it
+                position = obj.primitive_poses[0].position
+                dimensions = obj.primitives[0].dimensions
+                entry["center"] = (position.x, position.y, position.z)
+                entry["size"] = (dimensions[0], dimensions[1], dimensions[2])
                 added.append(obj.id)
             for object_id in stale:
                 self._scene_objects.pop(object_id, None)

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -36,12 +36,14 @@ class MoveIt(Component):
     """
     This component provides classical, collision aware manipulation by driving a running [MoveIt 2](https://moveit.ai) `move_group` node.
 
-    The component runs as a ROS2 Action Server exposing the `<component_name>/manipulate_with_moveit` action, which takes a motion target and plans and executes a path to it. Four kinds of targets are supported, selected with the goal's `mode` field (or inferred from the fields that are populated):
+    The component runs as a ROS2 Action Server exposing the `<component_name>/manipulate_with_moveit` action, which takes a motion target and plans and executes a path to it. Six kinds of targets are supported, selected with the goal's `mode` field (or inferred from the fields that are populated):
 
     - **pose**: an end-effector pose, planned with the configured planner and reached within the configured position/orientation tolerances.
     - **joints**: explicit joint positions.
     - **named**: a named target defined in the robot's SRDF (e.g. "home", "ready"), resolved to joint positions by reading the SRDF from the running `move_group` node.
     - **cartesian**: a straight-line end-effector path through a list of waypoints, computed with MoveIt's Cartesian path service and executed only if enough of the path is achievable (see `cartesian_fraction_threshold`).
+    - **pick**: a full grasp sequence on a planning scene object, named with `target_object` (a scene id or detection label) or located by `target_pose`: approach above it, open the gripper, descend, close, attach the object and lift it.
+    - **place**: the inverse sequence for the currently attached object: approach above `target_pose`, descend, open the gripper, detach (the object stays in the scene where released) and retreat.
 
     Gripper control is available as component actions (`open_gripper`, `close_gripper`, `set_gripper`), either through the gripper planning group or through a gripper controller, based on the `gripper_mode` config parameter. All component actions and the action server itself are discoverable as tools by the Cortex component, making the manipulator directly usable by LLM agents.
 
@@ -507,6 +509,10 @@ class MoveIt(Component):
 
             if mode is MoveMode.PICK:
                 outcome = self._execute_pick(goal, goal_handle, result, deadline)
+                return self._finish_sequence(outcome, goal_handle, result)
+
+            if mode is MoveMode.PLACE:
+                outcome = self._execute_place(goal, goal_handle, result, deadline)
                 return self._finish_sequence(outcome, goal_handle, result)
 
             if mode is MoveMode.CARTESIAN:
@@ -1319,6 +1325,98 @@ class MoveIt(Component):
             return outcome
 
         result.message = f"Picked '{object_id}'"
+        return "ok"
+
+    def _execute_place(
+        self, goal: Any, goal_handle, result: Any, deadline: float
+    ) -> str:
+        """Set the held object down at the goal pose and release it.
+
+        The inverse of pick: approach above the release pose (planned with
+        the held object still attached), descend straight down (contact
+        permitted), open, detach and retreat back up. The object stays in the
+        scene where it was released.
+
+        :returns: Outcome of the last step, for _finish_sequence
+        :raises ValueError: When nothing is attached
+        """
+        with self._scene_lock:
+            held = next(
+                (
+                    (object_id, entry["size"])
+                    for object_id, entry in self._scene_objects.items()
+                    if entry.get("attached")
+                ),
+                None,
+            )
+        if not held:
+            raise ValueError(
+                "Nothing is attached to the gripper: pick an object before placing"
+            )
+        object_id, size = held
+
+        # target_pose gives where the object's center ends up and the gripper
+        # holds the object at its center
+        position = goal.target_pose.pose.position
+        orientation = goal.target_pose.pose.orientation
+        approach_z = position.z + size[2] / 2 + self.config.approach_clearance
+        self.get_logger().info(
+            f"Placing '{object_id}' at "
+            f"({position.x:.3f}, {position.y:.3f}, {position.z:.3f})"
+        )
+
+        self._publish_state(goal_handle, "PRE_PLACE")
+        outcome, message = self._sequence_motion(
+            self._move_client,
+            self._pose_motion_goal(position.x, position.y, approach_z, orientation),
+            goal_handle,
+            deadline,
+        )
+        if outcome != "ok":
+            result.message = f"Pre-place: {message}"
+            return outcome
+
+        self._publish_state(goal_handle, "DESCEND")
+        outcome, message = self._sequence_descent(
+            position.x, position.y, position.z, orientation, goal_handle, deadline
+        )
+        if outcome != "ok":
+            result.message = f"Descent: {message}"
+            return outcome
+
+        self._publish_state(goal_handle, "RELEASE")
+        ok, message = self._command_gripper(
+            named_target=self.config.gripper_open_target,
+            position=self.config.gripper_open_position,
+            description="open",
+        )
+        if not ok:
+            result.message = message
+            return "aborted"
+
+        self._publish_state(goal_handle, "DETACH")
+        ok, message = self._do_detach(object_id)
+        if not ok:
+            result.message = message
+            return "aborted"
+        # The object now sits where it was released, not where it was picked
+        with self._scene_lock:
+            if entry := self._scene_objects.get(object_id):
+                entry["center"] = (position.x, position.y, position.z)
+                entry["last_seen"] = time.time()
+
+        self._publish_state(goal_handle, "RETREAT")
+        outcome, message = self._sequence_motion(
+            self._move_client,
+            self._pose_motion_goal(position.x, position.y, approach_z, orientation),
+            goal_handle,
+            deadline,
+        )
+        if outcome != "ok":
+            result.message = f"Retreat: {message}"
+            return outcome
+
+        result.message = f"Placed '{object_id}'"
         return "ok"
 
     # =========================================================================

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -7,6 +7,7 @@ from ..ros import (
     ActionClientHandler,
     ActionPhase,
     ComponentRunType,
+    Detections3D,
     GetParameters,
     MoveManipulator,
     ServiceClientConfig,
@@ -46,7 +47,7 @@ class MoveIt(Component):
 
     :param config: The configuration for the MoveIt component. `arm_group_name` is required and must match a planning group in the robot's SRDF.
     :type config: MoveItConfig
-    :param inputs: Optional input topics for the component. Not required for manipulation.
+    :param inputs: Optional input topics for the component, limited to Detections3D type: detected objects used to populate the planning scene (see `scene_update_mode` in the config), so that motions plan around what the robot's cameras see. Not required for manipulation.
     :type inputs: Optional[list[Topic]]
     :param outputs: Optional output topics for the component. Not required for manipulation.
     :type outputs: Optional[list[Topic]]
@@ -101,6 +102,9 @@ class MoveIt(Component):
         ensure_moveit_msgs()
 
         self.config: MoveItConfig = config
+
+        self.allowed_inputs = {"Required": [], "Optional": [Detections3D]}
+        self._detections_topic = inputs[0] if inputs else None
 
         # Set the component to run as an action server
         self.run_type = ComponentRunType.ACTION_SERVER

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -1,0 +1,792 @@
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..config import MoveItConfig
+from ..ros import (
+    ActionClientConfig,
+    ActionClientHandler,
+    ActionPhase,
+    ComponentRunType,
+    GetParameters,
+    MoveManipulator,
+    ServiceClientConfig,
+    ServiceClientHandler,
+    component_action,
+)
+from ..utils import validate_func_args
+from ..utils.moveit import (
+    MoveMode,
+    build_cartesian_request,
+    build_move_group_goal,
+    ensure_moveit_msgs,
+    joints_to_constraints,
+    load_named_targets,
+    moveit_error_string,
+    parse_planner_interfaces,
+    pose_to_constraints,
+    SRDF_PARAMETER
+)
+from .component_base import Component
+
+
+class MoveIt(Component):
+    """
+    This component provides classical, collision aware manipulation by driving a running [MoveIt 2](https://moveit.ai) `move_group` node.
+
+    The component runs as a ROS2 Action Server exposing the `<component_name>/manipulate_with_moveit` action, which takes a motion target and plans and executes a path to it. Four kinds of targets are supported, selected with the goal's `mode` field (or inferred from the fields that are populated):
+
+    - **pose**: an end-effector pose, planned with the configured planner and reached within the configured position/orientation tolerances.
+    - **joints**: explicit joint positions.
+    - **named**: a named target defined in the robot's SRDF (e.g. "home", "ready"), resolved to joint positions by reading the SRDF from the running `move_group` node.
+    - **cartesian**: a straight-line end-effector path through a list of waypoints, computed with MoveIt's Cartesian path service and executed only if enough of the path is achievable (see `cartesian_fraction_threshold`).
+
+    Gripper control is available as component actions (`open_gripper`, `close_gripper`, `set_gripper`), either through the gripper planning group or through a gripper controller, based on the `gripper_mode` config parameter. All component actions and the action server itself are discoverable as tools by the Cortex component, making the manipulator directly usable by LLM agents.
+
+    This component requires a running `move_group` node, which is normally launched from the robot's MoveIt configuration package. It can be brought up alongside the components in the same recipe (see the example below), and the `moveit_msgs` package must be installed (`ros-<distro>-moveit-msgs`).
+
+    :param config: The configuration for the MoveIt component. `arm_group_name` is required and must match a planning group in the robot's SRDF.
+    :type config: MoveItConfig
+    :param inputs: Optional input topics for the component. Not required for manipulation.
+    :type inputs: Optional[list[Topic]]
+    :param outputs: Optional output topics for the component. Not required for manipulation.
+    :type outputs: Optional[list[Topic]]
+    :param component_name: The name of the MoveIt component.
+    :type component_name: str
+    :param kwargs: Additional keyword arguments.
+
+    Example usage:
+    ```python
+    from agents.components import MoveIt
+    from agents.config import MoveItConfig
+    from agents.ros import Launcher
+
+    config = MoveItConfig(
+        arm_group_name="panda_arm",
+        gripper_group_name="hand",
+        max_velocity_scaling=0.2,
+    )
+    manipulator = MoveIt(config=config, component_name="manipulator")
+
+    launcher = Launcher()
+    # bring up the robot's MoveIt configuration alongside the component
+    launcher.include_launch_file(
+        package="moveit_resources_panda_moveit_config", launch_file="demo.launch.py"
+    )
+    launcher.add_pkg(components=[manipulator])
+    launcher.bringup()
+    ```
+
+    A motion goal can then be sent to the running component, e.g. from the command line:
+    ```shell
+    ros2 action send_goal /manipulator/manipulate_with_moveit automatika_embodied_agents/action/MoveManipulator "{mode: named, named_target: ready}"
+    ```
+
+    And the gripper can be commanded with:
+    ```shell
+    ros2 service call /manipulator/execute_method automatika_ros_sugar/srv/ExecuteMethod "{name: open_gripper, kwargs_json: '{}'}"
+    ```
+    """
+
+    @validate_func_args
+    def __init__(
+        self,
+        *,
+        config: MoveItConfig,
+        component_name: str,
+        inputs: Optional[List] = None,
+        outputs: Optional[List] = None,
+        **kwargs,
+    ):
+        # Fail fast with installation instructions
+        ensure_moveit_msgs()
+
+        self.config: MoveItConfig = config
+
+        # Set the component to run as an action server
+        self.run_type = ComponentRunType.ACTION_SERVER
+
+        # TODO: Trigger will be passed by serialized component in the kwargs
+        # We will remove it here. This can be improved by passing kwargs differently
+        if "trigger" in list(kwargs.keys()):
+            kwargs.pop("trigger")
+
+        super().__init__(
+            inputs=inputs,
+            outputs=outputs,
+            config=self.config,
+            trigger=None,
+            component_name=component_name,
+            main_action_type=MoveManipulator,
+            **kwargs,
+        )
+
+        # set a meaningful component action name
+        self.main_action_name = f"{self.node_name}/manipulate_with_moveit"
+
+        # Clients to move_group, created on activation
+        self._move_client: Optional[ActionClientHandler] = None
+        self._exec_client: Optional[ActionClientHandler] = None
+        self._gripper_client: Optional[ActionClientHandler] = None
+        self._cartesian_client: Optional[ServiceClientHandler] = None
+        self._param_client: Optional[ServiceClientHandler] = None
+        self._planner_client: Optional[ServiceClientHandler] = None
+
+        # Named targets read from the SRDF, resolved lazily and cached
+        self._named_targets: Optional[Dict[str, Dict[str, Dict[str, float]]]] = None
+
+    # =========================================================================
+    # LIFECYCLE
+    # =========================================================================
+
+    def create_all_action_clients(self):
+        """Create action clients to the move_group node"""
+        super().create_all_action_clients()
+
+        from control_msgs.action import GripperCommand
+        from moveit_msgs.action import ExecuteTrajectory, MoveGroup
+
+        # NOTE: The client handler cancels a goal when it receives no new feedback
+        # within feedback_check_timeout. move_group only publishes feedback on
+        # state transitions (planning -> executing), so this is set to the
+        # execution timeout to avoid cancelling long but healthy motions
+        self._move_client = ActionClientHandler(
+            self, config=self._action_client_config(MoveGroup, "move_action")
+        )
+        self._exec_client = ActionClientHandler(
+            self,
+            config=self._action_client_config(ExecuteTrajectory, "execute_trajectory"),
+        )
+        if self.config.gripper_mode == "gripper_command":
+            self._gripper_client = ActionClientHandler(
+                self,
+                config=ActionClientConfig(
+                    action_type=GripperCommand,
+                    name=self.config.gripper_command_action,
+                    timeout_secs=self.config.server_timeout,
+                    feedback_check_timeout=self.config.execution_timeout,
+                ),
+            )
+        else:
+            # A separate handler on the same action, so that gripper motions
+            # do not disturb the state of an in-flight arm goal
+            self._gripper_client = ActionClientHandler(
+                self, config=self._action_client_config(MoveGroup, "move_action")
+            )
+
+    def destroy_all_action_clients(self):
+        """Destroy action clients to the move_group node"""
+        super().destroy_all_action_clients()
+
+        for handler in (self._move_client, self._exec_client, self._gripper_client):
+            if handler:
+                handler.client.destroy()
+        self._move_client = self._exec_client = self._gripper_client = None
+
+    def create_all_service_clients(self):
+        """Create service clients to the move_group node"""
+        super().create_all_service_clients()
+
+        from moveit_msgs.srv import GetCartesianPath, QueryPlannerInterfaces
+
+        self._cartesian_client = ServiceClientHandler(
+            self,
+            config=ServiceClientConfig(
+                srv_type=GetCartesianPath,
+                name=self._resolve_name("compute_cartesian_path"),
+                timeout_secs=self.config.server_timeout,
+            ),
+        )
+        self._planner_client = ServiceClientHandler(
+            self,
+            config=ServiceClientConfig(
+                srv_type=QueryPlannerInterfaces,
+                name=self._resolve_name("query_planner_interface"),
+                timeout_secs=self.config.server_timeout,
+            ),
+        )
+        # Named targets live in the SRDF, which is a parameter of the move_group
+        # node
+        self._param_client = ServiceClientHandler(
+            self,
+            config=ServiceClientConfig(
+                srv_type=GetParameters,
+                name=self._resolve_name(
+                    f"{self.config.move_group_node_name}/get_parameters"
+                ),
+                timeout_secs=self.config.server_timeout,
+            ),
+        )
+
+    def destroy_all_service_clients(self):
+        """Destroy service clients to the move_group node"""
+        super().destroy_all_service_clients()
+
+        for handler in (
+            self._cartesian_client,
+            self._planner_client,
+            self._param_client,
+        ):
+            if handler:
+                self.destroy_client(handler.client)
+        self._cartesian_client = self._planner_client = self._param_client = None
+
+    def custom_on_activate(self):
+        """Activate component and check the configured planner against move_group"""
+        super().custom_on_activate()
+        self._validate_planner_config()
+
+    def _execution_step(self, *_, **__):
+        """NOT USED. The component is triggered through its action server"""
+        pass
+
+    # =========================================================================
+    # HELPERS
+    # =========================================================================
+
+    def _resolve_name(self, name: str) -> str:
+        """Get the fully qualified name of a move_group interface
+
+        :param name: Interface name, e.g. "move_action"
+        :returns: Absolute interface name, e.g. "/robot_a/move_action"
+        """
+        namespace = (self.config.move_group_namespace or "").strip().strip("/")
+        return f"/{namespace}/{name}" if namespace else f"/{name}"
+
+    def _action_client_config(self, action_type: type, name: str) -> ActionClientConfig:
+        """Client config for an action provided by move_group"""
+        return ActionClientConfig(
+            action_type=action_type,
+            name=self._resolve_name(name),
+            timeout_secs=self.config.server_timeout,
+            feedback_check_timeout=self.config.execution_timeout,
+        )
+
+    def _validate_planner_config(self) -> None:
+        """Warn if the configured pipeline/planner is not provided by move_group"""
+        if not self.config.planning_pipeline and not self.config.planner_id:
+            return
+        if not self._planner_client:
+            return
+        from moveit_msgs.srv import QueryPlannerInterfaces
+
+        # get all planning pipeline and planners
+        response = self._planner_client.send_request(QueryPlannerInterfaces.Request())
+        if not response:
+            self.get_logger().warning(
+                "Could not query the available planners from move_group, skipping "
+                "validation of 'planning_pipeline' and 'planner_id'"
+            )
+            return
+        # verify pipeline
+        pipelines = parse_planner_interfaces(response)
+        pipeline = self.config.planning_pipeline
+        if pipeline and pipeline not in pipelines:
+            self.get_logger().warning(
+                f"Configured planning_pipeline '{pipeline}' is not provided by "
+                f"move_group. Available pipelines: {sorted(pipelines)}"
+            )
+            return
+        # verify planner in pipeline
+        if self.config.planner_id:
+            available = (
+                pipelines.get(pipeline)
+                if pipeline
+                else [p for ids in pipelines.values() for p in ids]
+            )
+            if available and self.config.planner_id not in available:
+                self.get_logger().warning(
+                    f"Configured planner_id '{self.config.planner_id}' is not "
+                    f"provided by move_group. Available planners: {sorted(available)}"
+                )
+
+    def _named_target_states(self) -> Dict[str, Dict[str, Dict[str, float]]]:
+        """Get named targets per planning group, reading the SRDF once
+
+        The SRDF is read from the running move_group node, falling back to
+        the configured SRDF file when the node cannot provide it.
+        """
+        if self._named_targets is None:
+            srdf = None
+            if self._param_client:
+                response = self._param_client.send_request_from_dict({
+                    "names": [SRDF_PARAMETER]
+                })
+                if response and response.values and response.values[0].string_value:
+                    srdf = response.values[0].string_value
+                else:
+                    self.get_logger().warning(
+                        f"Could not read '{SRDF_PARAMETER}' from "
+                        f"'{self._param_client.config.name}'"
+                    )
+            self._named_targets = load_named_targets(
+                srdf=srdf,
+                srdf_file=self.config.srdf_file,
+                overrides=self.config.named_targets,
+                logger_name=self.node_name,
+            )
+        return self._named_targets
+
+    def _resolve_named_target(self, name: str) -> Tuple[str, Dict[str, float]]:
+        """Resolve a named target to a planning group and joint positions
+
+        :param name: Named target, as defined in the robot SRDF
+        :raises ValueError: If the target is not defined for any known group
+        """
+        states = self._named_target_states()
+        # Prefer the arm group, then the gripper group, then any other group
+        groups = [self.config.arm_group_name]
+        if self.config.gripper_group_name:
+            groups.append(self.config.gripper_group_name)
+        groups += [group for group in states if group not in groups]
+
+        for group in groups:
+            if name in states.get(group, {}):
+                return group, states[group][name]
+
+        available = {
+            group: sorted(group_states) for group, group_states in states.items()
+        }
+        raise ValueError(
+            f"Named target '{name}' is not defined in the robot SRDF. "
+            f"Available named targets per group: {available}"
+        )
+
+    def _scalings(self, goal: Any) -> Tuple[float, float]:
+        """Per-goal scaling overrides, falling back to the configured values"""
+        velocity = goal.velocity_scaling or self.config.max_velocity_scaling
+        acceleration = goal.acceleration_scaling or self.config.max_acceleration_scaling
+        return float(velocity), float(acceleration)
+
+    def _feedback_forwarder(self, handler: ActionClientHandler, goal_handle):
+        """Create a listener that republishes move_group feedback on our goal"""
+
+        def _forward():
+            feedback = handler.feedback_msg
+            if feedback is None:
+                return
+            state = getattr(getattr(feedback, "feedback", feedback), "state", "")
+            if not state:
+                return
+            message = MoveManipulator.Feedback()
+            message.state = str(state)
+            goal_handle.publish_feedback(message)
+
+        return _forward
+
+    def _await_result(
+        self, handler: ActionClientHandler, goal_handle, deadline: float
+    ) -> str:
+        """Wait for a client goal to return, propagating cancellation
+
+        :returns: One of 'returned', 'canceled', 'preempted', 'timeout'
+        """
+        poll_period = 1 / self.config.loop_rate
+        while not handler.action_returned:
+            if not goal_handle.is_active:
+                handler.cancel_request()
+                return "preempted"
+            if goal_handle.is_cancel_requested:
+                handler.cancel_request()
+                return "canceled"
+            if time.time() > deadline:
+                handler.cancel_request()
+                return "timeout"
+            time.sleep(poll_period)
+        return "returned"
+
+    # =========================================================================
+    # MAIN ACTION
+    # =========================================================================
+
+    def main_action_callback(self, goal_handle):
+        """
+        Callback for the MoveIt component main action server
+
+        :param goal_handle: Incoming action goal
+        :type goal_handle: MoveManipulator.Goal
+
+        :return: Action result
+        :rtype: MoveManipulator.Result
+        """
+        goal = goal_handle.request
+        result = MoveManipulator.Result()
+        result.success = False
+
+        handler: Optional[ActionClientHandler] = None
+        listener = None
+        deadline = time.time() + self.config.execution_timeout
+
+        try:
+            mode = MoveMode.from_goal(goal)
+            self.get_logger().info(f"Received a '{mode.value}' motion goal")
+
+            if mode is MoveMode.CARTESIAN:
+                trajectory = self._plan_cartesian_path(goal, result)
+                if trajectory is None:
+                    return self._terminate(goal_handle, result, abort=True)
+                if goal.plan_only:
+                    result.success = True
+                    result.message = (
+                        f"Planned {result.cartesian_fraction:.2%} of the requested path"
+                    )
+                    return self._terminate(goal_handle, result)
+
+                from moveit_msgs.action import ExecuteTrajectory
+
+                execute_goal = ExecuteTrajectory.Goal()
+                execute_goal.trajectory = trajectory
+                handler = self._exec_client
+                handler.reset()
+                if not handler.send_request(execute_goal):
+                    result.message = (
+                        "move_group did not accept the trajectory for execution"
+                    )
+                    return self._terminate(goal_handle, result, abort=True)
+            else:
+                move_goal = self._build_move_goal(goal, mode)
+                handler = self._move_client
+                handler.reset()
+                listener = self._feedback_forwarder(handler, goal_handle)
+                handler.add_feedback_listener(listener)
+                if not handler.send_request(move_goal):
+                    result.message = (
+                        "move_group did not accept the motion goal. Is the "
+                        f"'{self._resolve_name('move_action')}' server available?"
+                    )
+                    return self._terminate(goal_handle, result, abort=True)
+
+            outcome = self._await_result(handler, goal_handle, deadline)
+
+            if outcome == "preempted":
+                return self._terminate(
+                    goal_handle, result, listener=listener, handler=handler
+                )
+            if outcome == "canceled":
+                result.message = "Motion canceled"
+                return self._terminate(
+                    goal_handle, result, cancel=True, listener=listener, handler=handler
+                )
+            if outcome == "timeout":
+                result.message = (
+                    f"Motion did not complete within {self.config.execution_timeout}s"
+                )
+                return self._terminate(
+                    goal_handle, result, abort=True, listener=listener, handler=handler
+                )
+
+            error_code = getattr(handler.action_result, "error_code", None)
+            code = getattr(error_code, "val", 0)
+            result.error_code = code
+            result.message = moveit_error_string(code)
+            result.success = result.message == "SUCCESS"
+            return self._terminate(
+                goal_handle,
+                result,
+                abort=not result.success,
+                listener=listener,
+                handler=handler,
+            )
+
+        except Exception as e:
+            self.get_logger().error(f"Motion execution error - {e}")
+            result.message = str(e)
+            return self._terminate(
+                goal_handle, result, abort=True, listener=listener, handler=handler
+            )
+
+    def _build_move_goal(self, goal: Any, mode: MoveMode) -> Any:
+        """Build a MoveGroup goal for a pose, joints or named target"""
+        group_name = self.config.arm_group_name
+        velocity, acceleration = self._scalings(goal)
+
+        if mode is MoveMode.POSE:
+            target_pose = goal.target_pose
+            if not target_pose.header.frame_id:
+                target_pose.header.frame_id = self.config.pose_reference_frame
+            constraints = pose_to_constraints(
+                target_pose,
+                link_name=self.config.end_effector_link,
+                position_tolerance=self.config.goal_position_tolerance,
+                orientation_tolerance=self.config.goal_orientation_tolerance,
+            )
+        elif mode is MoveMode.JOINTS:
+            if len(goal.joint_names) != len(goal.joint_positions):
+                raise ValueError(
+                    "joint_names and joint_positions must have the same length, got "
+                    f"{len(goal.joint_names)} and {len(goal.joint_positions)}"
+                )
+            constraints = joints_to_constraints(
+                dict(zip(goal.joint_names, goal.joint_positions)),
+                tolerance=self.config.goal_joint_tolerance,
+            )
+        else:
+            group_name, joint_positions = self._resolve_named_target(goal.named_target)
+            constraints = joints_to_constraints(
+                joint_positions, tolerance=self.config.goal_joint_tolerance
+            )
+
+        return build_move_group_goal(
+            constraints,
+            group_name,
+            pipeline_id=self.config.planning_pipeline,
+            planner_id=self.config.planner_id,
+            num_attempts=self.config.num_planning_attempts,
+            allowed_time=self.config.allowed_planning_time,
+            velocity_scaling=velocity,
+            acceleration_scaling=acceleration,
+            plan_only=goal.plan_only,
+        )
+
+    def _plan_cartesian_path(self, goal: Any, result: Any) -> Optional[Any]:
+        """Compute a Cartesian path, returning the trajectory if usable"""
+        velocity, acceleration = self._scalings(goal)
+        request = build_cartesian_request(
+            goal.cartesian_waypoints,
+            frame_id=goal.frame_id or self.config.pose_reference_frame,
+            group_name=self.config.arm_group_name,
+            link_name=self.config.end_effector_link,
+            max_step=self.config.cartesian_max_step,
+            jump_threshold=self.config.cartesian_jump_threshold,
+            avoid_collisions=self.config.cartesian_avoid_collisions,
+            velocity_scaling=velocity,
+            acceleration_scaling=acceleration,
+        )
+        # NOTE: The service handler waits for the server with a timeout, but
+        # blocks until the response arrives once the request is sent
+        response = self._cartesian_client.send_request(request)
+        if not response:
+            result.message = (
+                "No response from the Cartesian path service at "
+                f"'{self._resolve_name('compute_cartesian_path')}'"
+            )
+            return None
+
+        result.cartesian_fraction = float(response.fraction)
+        result.error_code = response.error_code.val
+        if response.fraction < self.config.cartesian_fraction_threshold:
+            result.message = (
+                f"Only {response.fraction:.2%} of the requested Cartesian path is "
+                f"achievable, below the configured threshold of "
+                f"{self.config.cartesian_fraction_threshold:.2%}"
+            )
+            return None
+        return response.solution
+
+    def _terminate(
+        self,
+        goal_handle,
+        result: Any,
+        abort: bool = False,
+        cancel: bool = False,
+        listener=None,
+        handler: Optional[ActionClientHandler] = None,
+    ) -> Any:
+        """Transition the goal to its terminal state and clean up
+
+        A goal that is no longer active was already terminated elsewhere
+        (preempted by a new goal), so it is not transitioned again.
+        """
+        if listener and handler:
+            handler.remove_feedback_listener(listener)
+
+        with self._main_goal_lock:
+            if not goal_handle.is_active:
+                self.get_logger().info(
+                    "Goal already terminated (preempted by a new goal), stopping motion"
+                )
+            elif cancel or goal_handle.is_cancel_requested:
+                goal_handle.canceled()
+                self.get_logger().info("Goal canceled by client")
+            elif abort:
+                goal_handle.abort()
+                self.get_logger().error(f"Motion failed: {result.message}")
+                self.health_status.set_fail_component()
+            else:
+                goal_handle.succeed()
+                self.get_logger().info(f"Motion completed: {result.message}")
+                self.health_status.set_healthy()
+        return result
+
+    # =========================================================================
+    # COMPONENT ACTIONS
+    # =========================================================================
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "open_gripper",
+                "description": "Open the robot's gripper, for example before grasping an object or to release a held object.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        active=True,
+        phase=ActionPhase.EXECUTION,
+    )
+    def open_gripper(self) -> str:
+        """Open the gripper"""
+        return self._command_gripper(
+            named_target=self.config.gripper_open_target,
+            position=self.config.gripper_open_position,
+            description="open",
+        )
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "close_gripper",
+                "description": "Close the robot's gripper, for example to grasp an object that the gripper is positioned around.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        active=True,
+        phase=ActionPhase.EXECUTION,
+    )
+    def close_gripper(self) -> str:
+        """Close the gripper"""
+        return self._command_gripper(
+            named_target=self.config.gripper_close_target,
+            position=self.config.gripper_close_position,
+            description="close",
+        )
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "set_gripper",
+                "description": "Move the robot's gripper to a specific opening, for grasping objects of a known size. Only available when the gripper is controlled through a gripper controller.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "position": {
+                            "type": "number",
+                            "description": "Target gripper position, in the units used by the gripper controller (usually meters of finger opening).",
+                        }
+                    },
+                    "required": ["position"],
+                },
+            },
+        },
+        active=True,
+        phase=ActionPhase.EXECUTION,
+    )
+    def set_gripper(self, position: float) -> str:
+        """Move the gripper to a given position"""
+        if self.config.gripper_mode != "gripper_command":
+            return (
+                "Setting a specific gripper position requires gripper_mode to be "
+                "'gripper_command'. Use open_gripper or close_gripper instead."
+            )
+        return self._command_gripper(
+            named_target=None, position=float(position), description=str(position)
+        )
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "stop_motion",
+                "description": "Immediately stop the arm and the gripper by cancelling any motion that is currently being executed.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        active=True,
+        phase=ActionPhase.EXECUTION,
+    )
+    def stop_motion(self) -> str:
+        """Cancel any motion in progress"""
+        stopped = []
+        for name, handler in (
+            ("arm", self._move_client),
+            ("trajectory", self._exec_client),
+            ("gripper", self._gripper_client),
+        ):
+            if handler and handler.goal_accepted:
+                success, _ = handler.cancel_request()
+                if success:
+                    stopped.append(name)
+        if not stopped:
+            return "No motion is currently being executed"
+        self.get_logger().warning(f"Stopped motion: {', '.join(stopped)}")
+        return f"Stopped motion: {', '.join(stopped)}"
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "get_named_targets",
+                "description": "List the named poses the robot arm and gripper can be sent to, as defined in the robot's configuration (e.g. 'home', 'ready').",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        phase=ActionPhase.BOTH,
+    )
+    def get_named_targets(self) -> str:
+        """List the named targets available per planning group"""
+        states = self._named_target_states()
+        if not states:
+            return "No named targets are defined for this robot"
+        return "; ".join(
+            f"{group}: {', '.join(sorted(group_states))}"
+            for group, group_states in states.items()
+            if group_states
+        )
+
+    def _command_gripper(
+        self, named_target: Optional[str], position: float, description: str
+    ) -> str:
+        """Send a gripper command through the configured backend"""
+        if not self._gripper_client:
+            return "The component is not active, cannot command the gripper"
+
+        handler = self._gripper_client
+        handler.reset()
+
+        if self.config.gripper_mode == "gripper_command":
+            from control_msgs.action import GripperCommand
+
+            goal = GripperCommand.Goal()
+            goal.command.position = position
+            goal.command.max_effort = self.config.gripper_max_effort
+        else:
+            if not self.config.gripper_group_name:
+                return (
+                    "No gripper is configured. Set 'gripper_group_name' in "
+                    "MoveItConfig to control a gripper through move_group."
+                )
+            try:
+                group, joint_positions = self._resolve_named_target(named_target)
+            except ValueError as e:
+                return str(e)
+            goal = build_move_group_goal(
+                joints_to_constraints(
+                    joint_positions, tolerance=self.config.goal_joint_tolerance
+                ),
+                group,
+                pipeline_id=self.config.planning_pipeline,
+                planner_id=self.config.planner_id,
+                num_attempts=self.config.num_planning_attempts,
+                allowed_time=self.config.allowed_planning_time,
+                velocity_scaling=self.config.max_velocity_scaling,
+                acceleration_scaling=self.config.max_acceleration_scaling,
+            )
+
+        if not handler.send_request(goal):
+            return f"Gripper '{description}' command was not accepted"
+
+        deadline = time.time() + self.config.execution_timeout
+        while not handler.action_returned and time.time() < deadline:
+            time.sleep(1 / self.config.loop_rate)
+
+        if not handler.action_returned:
+            handler.cancel_request()
+            return f"Gripper '{description}' command timed out"
+
+        error_code = getattr(handler.action_result, "error_code", None)
+        if error_code is not None:
+            status = moveit_error_string(getattr(error_code, "val", 0))
+            if status != "SUCCESS":
+                return f"Gripper '{description}' command failed: {status}"
+        return f"Gripper moved to '{description}'"

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -151,6 +151,10 @@ class MoveIt(Component):
         self._scene_objects: Dict[str, Dict[str, Any]] = {}
         self._scene_lock = threading.Lock()
 
+        # Continuous mode refresh timer and message last applied
+        self._scene_timer = None
+        self._last_scene_message: Optional[Any] = None
+
     # =========================================================================
     # LIFECYCLE
     # =========================================================================
@@ -285,6 +289,29 @@ class MoveIt(Component):
         """Activate component and check the configured planner against move_group"""
         super().custom_on_activate()
         self._validate_planner_config()
+
+        if self.config.scene_update_mode != "manual" and not self._detections_topic:
+            self.get_logger().warning(
+                f"scene_update_mode is '{self.config.scene_update_mode}' but the "
+                "component has no Detections3D input topic to update the "
+                "planning scene from"
+            )
+        elif self.config.scene_update_mode == "continuous":
+            from ..ros import MutuallyExclusiveCallbackGroup
+
+            # Create a timer for updating the scene
+            self._scene_timer = self.create_timer(
+                1.0 / self.config.scene_update_rate,
+                self._scene_refresh_tick,
+                callback_group=MutuallyExclusiveCallbackGroup(),
+            )
+
+    def custom_on_deactivate(self):
+        """Stop the scene refresh before the clients it uses are destroyed"""
+        if self._scene_timer:
+            self.destroy_timer(self._scene_timer)
+            self._scene_timer = None
+        super().custom_on_deactivate()
 
     def _execution_step(self, *_, **__):
         """NOT USED. The component is triggered through its action server"""
@@ -472,6 +499,15 @@ class MoveIt(Component):
         try:
             mode = MoveMode.from_goal(goal)
             self.get_logger().info(f"Received a '{mode.value}' motion goal")
+
+            if self.config.scene_update_mode == "on_goal" and self._detections_topic:
+                feedback = MoveManipulator.Feedback()
+                feedback.state = "UPDATING_SCENE"
+                goal_handle.publish_feedback(feedback)
+                # NOTE: The scene is advisory. A failure here doesnt abort the mission.
+                # It degrades to planning against the previous scene.
+                scene_status = self._refresh_scene_from_detections()
+                self.get_logger().info(scene_status)
 
             if mode is MoveMode.CARTESIAN:
                 trajectory = self._plan_cartesian_path(goal, result)
@@ -1247,3 +1283,152 @@ class MoveIt(Component):
         with self._scene_lock:
             self._scene_objects.pop(object_id, None)
         return f"Detached '{object_id}' and removed it from the scene"
+
+    def _refresh_scene_from_detections(self, message: Optional[Any] = None) -> str:
+        """Push detections into the planning scene as one diff.
+
+        Objects the detector stopped reporting are kept for
+        `scene_object_ttl` seconds before a refresh removes them, so
+        detection dropouts do not flicker. Attached objects are never evicted
+        or re-added.
+
+        :param message: Detections to refresh from, when the caller has
+            already read them. Default reads the latest received message
+        :returns: What happened, for the caller and for tool use
+        """
+        from ..utils.moveit import (
+            build_remove_object,
+            collision_objects_from_detections,
+        )
+
+        if message is None:
+            if not self._detections_topic:
+                return (
+                    "No detections input is connected to this component, so "
+                    "there is nothing to update the planning scene from"
+                )
+            callback = self.callbacks.get(self._detections_topic.name)
+            # the callback's default output is a text summary for prompts, get
+            # the message itself for the boxes
+            message = callback.get_output(get_msg=True) if callback else None
+            if message is None:
+                return "No detections have been received yet"
+
+        now = time.time()
+        objects, stale = self._partition_scene_changes(
+            collision_objects_from_detections(
+                message,
+                min_thickness=self.config.min_object_thickness,
+                padding=self.config.object_padding,
+            ),
+            now,
+        )
+
+        changes = objects + [build_remove_object(object_id) for object_id in stale]
+        if not changes:
+            return "The planning scene is already up to date"
+        if not self._apply_scene(changes):
+            return "Could not update the planning scene"
+
+        added = []
+        with self._scene_lock:
+            for obj in objects:
+                # allocate only on first sighting, bump the rest in place
+                entry = self._scene_objects.setdefault(
+                    obj.id, {"source": "detection", "last_seen": now}
+                )
+                entry["last_seen"] = now
+                added.append(obj.id)
+            for object_id in stale:
+                self._scene_objects.pop(object_id, None)
+
+        summary = f"Planning scene updated with {len(added)} detected object(s)"
+        if added:
+            summary += f": {', '.join(added)}"
+        if stale:
+            summary += f"; removed {len(stale)} stale object(s)"
+        return summary
+
+    def _partition_scene_changes(
+        self, objects: List[Any], now: float
+    ) -> Tuple[List[Any], List[str]]:
+        """Split a refresh into objects to add and tracked ids gone stale.
+
+        Attached objects are exempt from both sides, the rest expire by
+        their last sighting.
+
+        :param objects: Collision objects built from the latest detections
+        :param now: Refresh time, for the TTL comparison
+        :returns: (objects to add, tracked ids to remove)
+        """
+        seen = {obj.id for obj in objects}
+        attached, stale = set(), []
+        with self._scene_lock:
+            for object_id, entry in self._scene_objects.items():
+                if entry.get("attached"):
+                    attached.add(object_id)
+                elif (
+                    entry["source"] == "detection"
+                    and object_id not in seen
+                    and now - entry["last_seen"] > self.config.scene_object_ttl
+                ):
+                    stale.append(object_id)
+        if attached:
+            objects = [obj for obj in objects if obj.id not in attached]
+        return objects, stale
+
+    def _scene_refresh_tick(self):
+        """Continuous mode refresh, skipping ticks that would change nothing.
+
+        A tick refreshes only when a detections message arrived since the
+        last applied one, or a tracked object has outlived its TTL and is due
+        for removal. With a source
+        slower than the timer (e.g. VLM), objects from the
+        last message are re-applied about once per TTL period, keeping the
+        snapshot alive rather than evicting a scene that was simply not
+        re-observed.
+        """
+        callback = self.callbacks.get(self._detections_topic.name)
+        # the callback's default output is a text summary for prompts, get
+        # the message itself for the boxes
+        message = callback.get_output(get_msg=True) if callback else None
+        if message is None:
+            return
+
+        now = time.time()
+        if message is self._last_scene_message and not self._has_stale_objects(now):
+            # Dont refresh
+            return
+
+        self._last_scene_message = message
+        result = self._refresh_scene_from_detections(message)
+        self.get_logger().debug(result)
+
+    def _has_stale_objects(self, now: float) -> bool:
+        """Whether any tracked detection has outlived the TTL"""
+        with self._scene_lock:
+            return any(
+                entry["source"] == "detection"
+                and not entry.get("attached")
+                and now - entry["last_seen"] > self.config.scene_object_ttl
+                for entry in self._scene_objects.values()
+            )
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "update_planning_scene",
+                "description": "Update the motion planning scene from the latest camera detections, so that the next motions plan around the objects currently seen. Call before planning a motion in a scene that may have changed.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        active=True,
+        phase=ActionPhase.EXECUTION,
+    )
+    def update_planning_scene(self) -> str:
+        """Update the planning scene from the latest received detections.
+
+        :returns: What happened, for the caller and for tool use
+        """
+        return self._refresh_scene_from_detections()

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -142,6 +143,11 @@ class MoveIt(Component):
 
         # Named targets read from the SRDF, resolved lazily and cached
         self._named_targets: Optional[Dict[str, Dict[str, Dict[str, float]]]] = None
+
+        # Objects this component has placed in the planning scene, as
+        # id -> {"source": "manual" | "detection", "last_seen": time}
+        self._scene_objects: Dict[str, Dict[str, Any]] = {}
+        self._scene_lock = threading.Lock()
 
     # =========================================================================
     # LIFECYCLE
@@ -833,3 +839,267 @@ class MoveIt(Component):
             if status != "SUCCESS":
                 return f"Gripper '{description}' command failed: {status}"
         return f"Gripper moved to '{description}'"
+
+    # =========================================================================
+    # PLANNING SCENE
+    # =========================================================================
+
+    def _apply_scene(
+        self, collision_objects=(), attached_objects=()
+    ) -> bool:
+        """Apply scene changes as one diff through move_group.
+
+        :param collision_objects: World objects to add, move or remove
+        :param attached_objects: Objects to attach to or detach from the robot
+        :returns: Whether move_group confirmed the change
+        """
+        from moveit_msgs.srv import ApplyPlanningScene
+
+        from ..utils.moveit import build_scene_diff
+
+        if not self._apply_scene_client:
+            self.get_logger().error(
+                "The planning scene client is not available, is the component active?"
+            )
+            return False
+
+        request = ApplyPlanningScene.Request()
+        request.scene = build_scene_diff(collision_objects, attached_objects)
+        response = self._apply_scene_client.send_request(request)
+        if response is None or not response.success:
+            self.get_logger().error(
+                "move_group did not apply the planning scene change"
+            )
+            return False
+        return True
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "add_collision_object",
+                "description": "Add a box-shaped obstacle to the motion planning scene, so that subsequent arm motions avoid it. Use for known fixed objects like tables, walls or shelves.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "object_id": {
+                            "type": "string",
+                            "description": "Name for the object in the scene. Re-using a name moves the existing object.",
+                        },
+                        "center": {
+                            "type": "array",
+                            "items": {"type": "number"},
+                            "description": "Center of the box as [x, y, z] in meters.",
+                        },
+                        "size": {
+                            "type": "array",
+                            "items": {"type": "number"},
+                            "description": "Full extents of the box as [x, y, z] in meters.",
+                        },
+                        "frame_id": {
+                            "type": "string",
+                            "description": "Frame the center is given in. Empty uses the planning frame.",
+                        },
+                    },
+                    "required": ["object_id", "center", "size"],
+                },
+            },
+        },
+        active=True,
+        phase=ActionPhase.EXECUTION,
+    )
+    def add_collision_object(
+        self,
+        object_id: str,
+        center: List[float],
+        size: List[float],
+        frame_id: str = "",
+    ) -> str:
+        """Add a box-shaped collision object to the planning scene.
+
+        :param object_id: Scene-wide name; re-using one moves the object
+        :param center: Center of the box as [x, y, z] in meters
+        :param size: Full extents of the box as [x, y, z] in meters
+        :param frame_id: Frame the center is given in. Empty falls back to the
+            configured `pose_reference_frame`, and an empty frame is read by
+            move_group as its planning frame
+        :returns: What happened, for the caller and for tool use
+        """
+        from ..utils.moveit import build_collision_object
+
+        if len(center) != 3 or len(size) != 3:
+            raise ValueError(
+                "center and size must each have 3 values (x, y, z), got "
+                f"{len(center)} and {len(size)}"
+            )
+
+        obj = build_collision_object(
+            object_id,
+            frame_id or self.config.pose_reference_frame,
+            tuple(float(value) for value in center),
+            tuple(float(value) for value in size),
+            min_thickness=self.config.min_object_thickness,
+        )
+        if not self._apply_scene([obj]):
+            return f"Could not add '{object_id}' to the planning scene"
+
+        with self._scene_lock:
+            self._scene_objects[object_id] = {
+                "source": "manual",
+                "last_seen": time.time(),
+            }
+        return f"Added '{object_id}' to the planning scene"
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "remove_collision_object",
+                "description": "Remove an obstacle from the motion planning scene by its name.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "object_id": {
+                            "type": "string",
+                            "description": "Name of the object to remove, as it was added or as listed by list_collision_objects.",
+                        },
+                    },
+                    "required": ["object_id"],
+                },
+            },
+        },
+        active=True,
+        phase=ActionPhase.EXECUTION,
+    )
+    def remove_collision_object(self, object_id: str) -> str:
+        """Remove one collision object from the planning scene.
+
+        :param object_id: Id the object was added under
+        :returns: What happened, for the caller and for tool use
+        """
+        from ..utils.moveit import build_remove_object
+
+        if not self._apply_scene([build_remove_object(object_id)]):
+            return f"Could not remove '{object_id}' from the planning scene"
+
+        with self._scene_lock:
+            self._scene_objects.pop(object_id, None)
+        return f"Removed '{object_id}' from the planning scene"
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "clear_collision_objects",
+                "description": "Remove the obstacles this component has added to the motion planning scene.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "detections_only": {
+                            "type": "boolean",
+                            "description": "Only remove objects that came from detections, keeping manually added ones. Default is false.",
+                        },
+                    },
+                    "required": [],
+                },
+            },
+        },
+        active=True,
+        phase=ActionPhase.EXECUTION,
+    )
+    def clear_collision_objects(self, detections_only: bool = False) -> str:
+        """Remove the collision objects this component put in the scene.
+
+        Only objects this component knows it added are touched, so obstacles
+        placed by other tools stay where they are.
+
+        :param detections_only: Only remove detection-sourced objects,
+            keeping manually added ones
+        :returns: What happened, for the caller and for tool use
+        """
+        from ..utils.moveit import build_remove_object
+
+        with self._scene_lock:
+            ids = [
+                object_id
+                for object_id, entry in self._scene_objects.items()
+                if not detections_only or entry["source"] == "detection"
+            ]
+        if not ids:
+            return "The planning scene holds no objects added by this component"
+
+        if not self._apply_scene([build_remove_object(i) for i in ids]):
+            return "Could not clear the planning scene objects"
+
+        with self._scene_lock:
+            for object_id in ids:
+                self._scene_objects.pop(object_id, None)
+        return f"Removed {len(ids)} object(s) from the planning scene"
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "list_collision_objects",
+                "description": "List the obstacles currently in the motion planning scene.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        active=True,
+        phase=ActionPhase.BOTH,
+    )
+    def list_collision_objects(self) -> str:
+        """List the collision objects in the planning scene.
+
+        The scene is read back from move_group, which is authoritative: it
+        also shows objects placed there by other tools. When move_group does
+        not answer, the objects this component itself added are listed.
+
+        :returns: The object names, for the caller and for tool use
+        """
+        from moveit_msgs.msg import PlanningSceneComponents
+        from moveit_msgs.srv import GetPlanningScene
+
+        if self._get_scene_client:
+            request = GetPlanningScene.Request()
+            request.components.components = PlanningSceneComponents.WORLD_OBJECT_NAMES
+            response = self._get_scene_client.send_request(request)
+            if response is not None:
+                names = sorted(o.id for o in response.scene.world.collision_objects)
+                if not names:
+                    return "The planning scene contains no collision objects"
+                return f"Collision objects in the planning scene: {', '.join(names)}"
+
+        with self._scene_lock:
+            names = sorted(self._scene_objects)
+        if not names:
+            return "The planning scene contains no collision objects"
+        return (
+            "move_group did not answer; objects added by this component: "
+            f"{', '.join(names)}"
+        )
+
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "clear_octomap",
+                "description": "Clear the octomap built from depth sensors in the motion planning scene. Use when stale sensor data blocks valid motions.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        active=True,
+        phase=ActionPhase.EXECUTION,
+    )
+    def clear_octomap(self) -> str:
+        """Clear the octomap accumulated in the planning scene.
+
+        :returns: What happened, for the caller and for tool use
+        """
+        if not self._clear_octomap_client:
+            return "The octomap client is not available, is the component active?"
+
+        response = self._clear_octomap_client.send_request(Empty.Request())
+        if response is None:
+            return "move_group did not answer the octomap clear request"
+        return "Cleared the planning scene octomap"

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -625,7 +625,8 @@ class MoveIt(Component):
         request = build_cartesian_request(
             goal.cartesian_waypoints,
             frame_id=goal.frame_id or self.config.pose_reference_frame,
-            group_name=self.config.arm_group_name,
+            # A dedicated Cartesian group, if any. Carries the orientation-tracking IK
+            group_name=self.config.cartesian_group_name or self.config.arm_group_name,
             link_name=self.config.end_effector_link,
             max_step=self.config.cartesian_max_step,
             jump_threshold=self.config.cartesian_jump_threshold,
@@ -911,9 +912,7 @@ class MoveIt(Component):
         )
 
         with self._scene_lock:
-            held = any(
-                entry.get("attached") for entry in self._scene_objects.values()
-            )
+            held = any(entry.get("attached") for entry in self._scene_objects.values())
         if held:
             return (
                 "Scene refresh skipped while an object is held: the scene "
@@ -1176,7 +1175,7 @@ class MoveIt(Component):
         request = build_cartesian_request(
             [waypoint],
             frame_id=self.config.pose_reference_frame,
-            group_name=self.config.arm_group_name,
+            group_name=self.config.cartesian_group_name or self.config.arm_group_name,
             link_name=self.config.end_effector_link,
             max_step=self.config.cartesian_max_step,
             jump_threshold=self.config.cartesian_jump_threshold,

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -41,7 +41,7 @@ class MoveIt(Component):
     - **pose**: an end-effector pose, planned with the configured planner and reached within the configured position/orientation tolerances.
     - **joints**: explicit joint positions.
     - **named**: a named target defined in the robot's SRDF (e.g. "home", "ready"), resolved to joint positions by reading the SRDF from the running `move_group` node.
-    - **cartesian**: a straight-line end-effector path through a list of waypoints, computed with MoveIt's Cartesian path service and executed only if enough of the path is achievable (see `cartesian_fraction_threshold`).
+    - **cartesian**: a straight-line end-effector path through a list of waypoints, computed with MoveIt's Cartesian path service and executed only if enough of the path is achievable (see `cartesian_fraction_threshold`). Waypoints without an orientation preference (identity) hold the current end-effector orientation, read from move_group's FK service — an arbitrary default may not be achievable, especially on underactuated arms.
     - **pick**: a full grasp sequence on a planning scene object, named with `target_object` (a scene id or detection label) or located by `target_pose`: approach above it, open the gripper, descend, close, attach the object and lift it.
     - **place**: the inverse sequence for the currently attached object: approach above `target_pose`, descend, open the gripper, detach (the object stays in the scene where released) and retreat.
 
@@ -142,6 +142,7 @@ class MoveIt(Component):
         self._apply_scene_client: Optional[ServiceClientHandler] = None
         self._get_scene_client: Optional[ServiceClientHandler] = None
         self._clear_octomap_client: Optional[ServiceClientHandler] = None
+        self._fk_client: Optional[ServiceClientHandler] = None
 
         # Named targets read from the SRDF, resolved lazily and cached, and
         # the raw SRDF they were read from
@@ -269,6 +270,19 @@ class MoveIt(Component):
             ),
         )
 
+        from moveit_msgs.srv import GetPositionFK
+
+        # Current end-effector pose, used to give Cartesian motions an
+        # achievable default orientation
+        self._fk_client = ServiceClientHandler(
+            self,
+            config=ServiceClientConfig(
+                srv_type=GetPositionFK,
+                name=self._resolve_name("compute_fk"),
+                timeout_secs=self.config.server_timeout,
+            ),
+        )
+
     def destroy_all_service_clients(self):
         """Destroy service clients to the move_group node"""
         super().destroy_all_service_clients()
@@ -280,12 +294,13 @@ class MoveIt(Component):
             self._apply_scene_client,
             self._get_scene_client,
             self._clear_octomap_client,
+            self._fk_client,
         ):
             if handler:
                 self.destroy_client(handler.client)
         self._cartesian_client = self._planner_client = self._param_client = None
         self._apply_scene_client = self._get_scene_client = None
-        self._clear_octomap_client = None
+        self._clear_octomap_client = self._fk_client = None
 
     def custom_on_activate(self):
         """Activate component and check the configured planner against move_group"""
@@ -432,6 +447,77 @@ class MoveIt(Component):
             f"Named target '{name}' is not defined in the robot SRDF. "
             f"Available named targets per group: {available}"
         )
+
+    @staticmethod
+    def _orientation_given(orientation: Optional[Any]) -> bool:
+        """Whether a quaternion expresses an actual orientation preference.
+
+        ROS2 defaults an untouched Quaternion field to identity (w=1), so an
+        identity on the wire cannot be distinguished from "no preference"
+        and is read as such. Any quaternion with a rotation axis (a non-zero
+        x, y or z) counts as explicit.
+        """
+        return orientation is not None and any((
+            orientation.x,
+            orientation.y,
+            orientation.z,
+        ))
+
+    def _current_ee_orientation(self) -> Optional[Any]:
+        """Orientation of the end effector, read from move_group's FK service.
+
+        Used as the default orientation of Cartesian motions. The Cartesian
+        interpolator validates the achieved orientation of every step, and
+        holding the current orientation is achievable wherever the arm can
+        move at all, where an arbitrary default (identity) may not be —
+        especially on underactuated arms.
+
+        :returns: geometry_msgs Quaternion, or None when FK is unavailable
+        """
+        if not self._fk_client or not self.config.end_effector_link:
+            return None
+        from moveit_msgs.srv import GetPositionFK
+
+        request = GetPositionFK.Request()
+        request.header.frame_id = self.config.pose_reference_frame
+        request.fk_link_names = [self.config.end_effector_link]
+        # an empty diff state means "the current monitored state"
+        request.robot_state.is_diff = True
+        response = self._fk_client.send_request(request)
+        if (
+            response is None
+            or getattr(response.error_code, "val", 0) != 1
+            or not response.pose_stamped
+        ):
+            self.get_logger().warning(
+                "Could not read the current end-effector pose from "
+                f"'{self._resolve_name('compute_fk')}'"
+            )
+            return None
+        return response.pose_stamped[0].pose.orientation
+
+    def _orient_waypoints(self, waypoints: Any) -> List[Any]:
+        """Give waypoints without an orientation preference an achievable one.
+
+        Waypoints carrying no orientation (see `_orientation_given`) follow
+        the current end-effector orientation. Waypoints with an explicit
+        orientation pass through unchanged, as does everything when FK is
+        unavailable (identity, the previous behavior).
+        """
+        from copy import deepcopy
+
+        oriented, default = [], None
+        for waypoint in waypoints:
+            if self._orientation_given(waypoint.orientation):
+                oriented.append(waypoint)
+                continue
+            if default is None:
+                default = self._current_ee_orientation()
+            if default is not None:
+                waypoint = deepcopy(waypoint)
+                waypoint.orientation = default
+            oriented.append(waypoint)
+        return oriented
 
     def _scalings(self, goal: Any) -> Tuple[float, float]:
         """Per-goal scaling overrides, falling back to the configured values"""
@@ -623,7 +709,7 @@ class MoveIt(Component):
         """Compute a Cartesian path, returning the trajectory if usable"""
         velocity, acceleration = self._scalings(goal)
         request = build_cartesian_request(
-            goal.cartesian_waypoints,
+            self._orient_waypoints(goal.cartesian_waypoints),
             frame_id=goal.frame_id or self.config.pose_reference_frame,
             # A dedicated Cartesian group, if any. Carries the orientation-tracking IK
             group_name=self.config.cartesian_group_name or self.config.arm_group_name,
@@ -1104,8 +1190,8 @@ class MoveIt(Component):
     def _pose_motion_goal(self, x: float, y: float, z: float, orientation=None) -> Any:
         """A collision-aware motion goal to an end-effector position.
 
-        :param orientation: Optional end-effector orientation. All-zero or
-            None means no preference: identity, with the configured
+        :param orientation: Optional end-effector orientation. None or
+            identity means no preference, with the configured
             orientation tolerance giving the planner its freedom
         """
         from ..ros import ROSPoseStamped
@@ -1114,12 +1200,7 @@ class MoveIt(Component):
         target.header.frame_id = self.config.pose_reference_frame
         position = target.pose.position
         position.x, position.y, position.z = float(x), float(y), float(z)
-        if orientation is not None and any((
-            orientation.x,
-            orientation.y,
-            orientation.z,
-            orientation.w,
-        )):
+        if self._orientation_given(orientation):
             target.pose.orientation = orientation
         else:
             target.pose.orientation.w = 1.0
@@ -1162,15 +1243,12 @@ class MoveIt(Component):
             float(y),
             float(z),
         )
-        if orientation is not None and any((
-            orientation.x,
-            orientation.y,
-            orientation.z,
-            orientation.w,
-        )):
+        if self._orientation_given(orientation):
             waypoint.orientation = orientation
-        else:
-            waypoint.orientation.w = 1.0
+        # Without a preference the waypoint holds the orientation the
+        # approach motion just reached: straight down at the current
+        # orientation is achievable, an arbitrary default may not be
+        waypoint = self._orient_waypoints([waypoint])[0]
 
         request = build_cartesian_request(
             [waypoint],

--- a/agents/components/moveit.py
+++ b/agents/components/moveit.py
@@ -8,6 +8,7 @@ from ..ros import (
     ActionPhase,
     ComponentRunType,
     Detections3D,
+    Empty,
     GetParameters,
     MoveManipulator,
     ServiceClientConfig,
@@ -134,6 +135,10 @@ class MoveIt(Component):
         self._cartesian_client: Optional[ServiceClientHandler] = None
         self._param_client: Optional[ServiceClientHandler] = None
         self._planner_client: Optional[ServiceClientHandler] = None
+        # Planning scene clients
+        self._apply_scene_client: Optional[ServiceClientHandler] = None
+        self._get_scene_client: Optional[ServiceClientHandler] = None
+        self._clear_octomap_client: Optional[ServiceClientHandler] = None
 
         # Named targets read from the SRDF, resolved lazily and cached
         self._named_targets: Optional[Dict[str, Dict[str, Dict[str, float]]]] = None
@@ -221,6 +226,35 @@ class MoveIt(Component):
             ),
         )
 
+        # Planning scene services, only used from the action and component-action
+        # threads
+        from moveit_msgs.srv import ApplyPlanningScene, GetPlanningScene
+
+        self._apply_scene_client = ServiceClientHandler(
+            self,
+            config=ServiceClientConfig(
+                srv_type=ApplyPlanningScene,
+                name=self._resolve_name("apply_planning_scene"),
+                timeout_secs=self.config.server_timeout,
+            ),
+        )
+        self._get_scene_client = ServiceClientHandler(
+            self,
+            config=ServiceClientConfig(
+                srv_type=GetPlanningScene,
+                name=self._resolve_name("get_planning_scene"),
+                timeout_secs=self.config.server_timeout,
+            ),
+        )
+        self._clear_octomap_client = ServiceClientHandler(
+            self,
+            config=ServiceClientConfig(
+                srv_type=Empty,
+                name=self._resolve_name("clear_octomap"),
+                timeout_secs=self.config.server_timeout,
+            ),
+        )
+
     def destroy_all_service_clients(self):
         """Destroy service clients to the move_group node"""
         super().destroy_all_service_clients()
@@ -229,10 +263,15 @@ class MoveIt(Component):
             self._cartesian_client,
             self._planner_client,
             self._param_client,
+            self._apply_scene_client,
+            self._get_scene_client,
+            self._clear_octomap_client,
         ):
             if handler:
                 self.destroy_client(handler.client)
         self._cartesian_client = self._planner_client = self._param_client = None
+        self._apply_scene_client = self._get_scene_client = None
+        self._clear_octomap_client = None
 
     def custom_on_activate(self):
         """Activate component and check the configured planner against move_group"""

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -10,7 +10,6 @@ from ..clients.model_base import ModelClient
 from ..config import VisionConfig
 from ..ros import (
     CameraInfo,
-    CompressedImage,
     DetectionsMultiSource,
     Detections,
     Detections3D,
@@ -32,6 +31,7 @@ from ..utils import (
     get_frame_id,
     get_stamp_secs,
 )
+from ..utils.perception3d import resolve_lift_camera
 from .model_component import ModelComponent
 from .component_base import ComponentRunType
 
@@ -137,11 +137,17 @@ class Vision(ModelComponent):
 
         # Asking for a Detections3D output turns 3D lifting on
         self._lift_to_3d = any(issubclass(t.msg_type, Detections3D) for t in outputs)
-        self._lift_camera = self._check_3d_contract(inputs, depth, camera_info)
-
-        # Add intrinsics and depth to inputs. They only get subscribed to with a
-        # Detections3D output
+        self._lift_camera = None
         if self._lift_to_3d:
+            # The contract check names the picture stream the lift applies to
+            self._lift_camera = resolve_lift_camera(
+                inputs,
+                depth,
+                camera_info,
+                frame=self.config.detections_frame,
+                component="Vision",
+            )
+            # Intrinsics and depth only get subscribed to when they feed a lift
             for topic in (depth, camera_info):
                 if topic and all(t.name != topic.name for t in inputs):
                     inputs = [*inputs, topic]
@@ -207,70 +213,6 @@ class Vision(ModelComponent):
                 "than deliver pictures to run inference on, so they cannot be used"
                 " as the component trigger."
             )
-
-    def _check_3d_contract(
-        self,
-        inputs: List[Union[Topic, FixedInput]],
-        depth: Optional[Topic],
-        camera_info: Optional[Topic],
-    ) -> Optional[str]:
-        """Check the component can produce the 3D detections it was asked for."""
-        if not self._lift_to_3d:
-            return None
-
-        # Check if detection frame has been set. 3D Boxes are axis aligned in it.
-        if not self.config.detections_frame:
-            raise TypeError(
-                "Vision was given a Detections3D output, which needs a frame to "
-                "report boxes in. Set `detections_frame` on the VisionConfig to "
-                "the frame the consumer works in, such as a robotic arm's planning "
-                "frame."
-            )
-
-        pictures = [
-            t
-            for t in inputs
-            if issubclass(t.msg_type, (Image, RGBD))
-            and (not depth or t.name != depth.name)
-        ]
-        if camera_info and not issubclass(camera_info.msg_type, CameraInfo):
-            raise TypeError(
-                "Vision camera_info topic must be of type CameraInfo, got "
-                f"{camera_info.msg_type.__name__}."
-            )
-
-        # Prefer RGBD over plain image. Return first RGBD if multiple.
-        # Otherwise the first Image topic is taken at the end
-        # and the rest are named in a warning.
-        rgbd = [t for t in pictures if issubclass(t.msg_type, RGBD)]
-        if rgbd:
-            return rgbd[0].name
-
-        if not depth:
-            raise TypeError(
-                "Vision was given a Detections3D output, which requires depth "
-                "to place detections in space. Either give it an RGBD input, "
-                "which carries depth registered to its picture, or pass the "
-                "camera's registered depth topic as `depth=Topic(...)` along "
-                f"with its `camera_info=Topic(...)`. Inputs given: "
-                f"{[t.name for t in inputs]}"
-            )
-        if issubclass(depth.msg_type, CompressedImage) or not issubclass(
-            depth.msg_type, Image
-        ):
-            raise TypeError(
-                "Vision depth topic must be an uncompressed Image, got "
-                f"{depth.msg_type.__name__}."
-            )
-        if not camera_info:
-            raise TypeError(
-                "Vision was given a depth topic but no camera_info topic. Depth "
-                "pixels cannot be turned into distances without the calibration "
-                "of the stream they were measured on: pass it as "
-                "`camera_info=Topic(...)`."
-            )
-        # Take first image topic by default
-        return pictures[0].name
 
     @staticmethod
     def _resolve_detection_set(

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -785,6 +785,7 @@ class Vision(DepthLiftMixin, ModelComponent):
         self._images = []
         # Where the lifted camera's picture sits in this tick's results
         self._lift_index: Optional[int] = None
+        # The 3D latched msg and depth
         self._lift_msg = None
         self._lift_depth = None
 

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -630,6 +630,13 @@ class Vision(ModelComponent):
 
         return {"images": images, **self.inference_params}
 
+    def _source_frame(self) -> Optional[str]:
+        """Frame of the camera the detections were made in"""
+        if len(self._images) != 1:
+            return None
+        source = getattr(self._images[0], "rgb", self._images[0])
+        return getattr(getattr(source, "header", None), "frame_id", None) or None
+
     def _execution_step(self, *args, **kwargs):
         """_execution_step.
 
@@ -661,6 +668,7 @@ class Vision(ModelComponent):
         self._publish(
             result,
             images=self._images,
+            frame_id=self._source_frame(),
             time_stamp=self.get_ros_time(),
         )
         if self.config.enable_visualization:

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -91,7 +91,18 @@ class Vision(ModelComponent):
             TrackingsMultiSource,
         ]
 
+        # Raw image captures
         self._images: List[Union[np.ndarray, ROSImage, ROSCompressedImage]] = []
+
+        # Sort which image inputs are actually run through the model, and which are
+        # only there to be captured by component actions
+        self._inference_set = self._resolve_detection_set(inputs, outputs, trigger)
+        self._spectators = [
+            topic.name
+            for topic in inputs
+            if issubclass(topic.msg_type, (Image, RGBD))
+            and topic.name not in self._inference_set
+        ]
 
         super().__init__(
             inputs,
@@ -113,14 +124,75 @@ class Vision(ModelComponent):
                 hasattr(model_client, "_model")
                 and self.model_client._model.setup_trackers  # type: ignore
             ):
-                model_client._model._num_trackers = len(inputs)
+                # one tracker per camera inferenced on, not per input
+                model_client._model._num_trackers = len(self._inference_set)
         else:
             if not self.config.enable_local_classifier:
                 raise TypeError(
                     "Vision component either requires a model client or enable_local_classifier needs to be set True in the VisionConfig."
                 )
 
+    @staticmethod
+    def _resolve_detection_set(
+        inputs: List[Union[Topic, FixedInput]],
+        outputs: List[Topic],
+        trigger: Union[Topic, List[Topic], float],
+    ) -> List[str]:
+        """Decide which image inputs are run through the model each tick.
+
+        A component receives one picture per tick when it is triggered by a
+        topic (EVENT mode), and all of its images at once when it is timed (TIMED mode).
+
+        Single source outputs describe one camera, so they can only be used when
+        a tick produces one picture. Image inputs left out are still subscribed
+        and can be captured with component actions but they are not used for inference.
+
+        :returns: Names of the image topics to run detection on
+        """
+        pictures = [t for t in inputs if issubclass(t.msg_type, (Image, RGBD))]
+        multi_source = any(
+            issubclass(t.msg_type, (DetectionsMultiSource, TrackingsMultiSource))
+            for t in outputs
+        )
+        single_source = any(
+            issubclass(t.msg_type, (Detections, Trackings)) for t in outputs
+        )
+
+        if isinstance(trigger, (int, float)):
+            # Timed: the whole detection set reaches the model together, so
+            # several cameras need a message that can hold several
+            inference_on = pictures if multi_source else pictures[:1]
+            per_tick = len(inference_on)
+        else:
+            # Triggered: only the topic that fired is read, so a tick carries
+            # one picture however many topics can trigger one
+            triggers = trigger if isinstance(trigger, List) else [trigger]
+            inference_on = [t for t in pictures if t.name in {t.name for t in triggers}]
+            per_tick = 1
+
+        if single_source and per_tick > 1:
+            raise TypeError(
+                f"{[t.name for t in inference_on]} are all used for inference in the "
+                "same pass, so their inference results cannot be published on a "
+                "Detections or Trackings topic, which describes one camera. "
+                "Use a DetectionsMultiSource or TrackingsMultiSource output, "
+                "or trigger the component on the cameras to take them one at "
+                "a time."
+            )
+        return [t.name for t in inference_on]
+
     def custom_on_configure(self):
+        # Warn which image inputs are never used for inference
+        if self._spectators:
+            self.get_logger().warning(
+                f"Not running inference on {self._spectators}: this component "
+                f"runs inference on {self._inference_set}. Those topics can still be "
+                "captured with a component action (like take_picture and record_video). "
+                "To run inference on all of them, give the component a "
+                "DetectionsMultiSource or TrackingsMultiSource output topic, "
+                "or make them all component triggers."
+            )
+
         # deploy local model if enabled
         if not self.model_client and self.config.enable_local_classifier:
             self._deploy_local_model()
@@ -618,17 +690,40 @@ class Vision(ModelComponent):
         else:
             images = []
 
-            for i in self.callbacks.values():
+            for name, i in self.callbacks.items():
+                # Inputs outside the inference set are ignored
+                if name not in self._inference_set:
+                    continue
                 msg = i.msg
                 if (item := i.get_output(clear_last=True)) is not None:
                     images.append(item)
-                    if msg:
+                    if msg is not None:
                         self._images.append(msg)
 
         if not images:
             return None
 
         return {"images": images, **self.inference_params}
+
+    def _publish(self, result, **kwargs) -> None:
+        """Publish the detections, giving each topic the shape it can carry.
+
+        Inference returns one set of detections per image. A single source
+        message describes one camera and takes that camera's set on its own,
+        while a multi source message takes the whole list.
+        """
+        output = result.pop("output")
+        images = kwargs.pop("images", None)
+        for publisher in self.publishers_dict.values():
+            if issubclass(publisher.output_topic.msg_type, (Detections, Trackings)):
+                publisher.publish(
+                    output[0],
+                    images=images[0] if images else None,
+                    **result,
+                    **kwargs,
+                )
+            else:
+                publisher.publish(output, images=images, **result, **kwargs)
 
     def _source_frame(self) -> Optional[str]:
         """Frame of the camera the detections were made in"""

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -9,8 +9,11 @@ import cv2
 from ..clients.model_base import ModelClient
 from ..config import VisionConfig
 from ..ros import (
+    CameraInfo,
+    CompressedImage,
     DetectionsMultiSource,
     Detections,
+    Detections3D,
     Trackings,
     FixedInput,
     Image,
@@ -50,6 +53,17 @@ class Vision(ModelComponent):
     :param trigger: The trigger value or topic for the vision component.
         This can be a single Topic object, a list of Topic objects, or a float value for timed components.
     :type trigger: Union[Topic, list[Topic], float]
+    :param depth: Optional depth image topic, for a camera that publishes depth separately
+        rather than bundled in an RGBD message. The depth must be registered to the pictures
+        being detected on, which is what a stereo camera publishes as its aligned or
+        `depth_registered` stream. Only used when a Detections3D output is given, and it
+        must be accompanied by `camera_info`.
+    :type depth: Optional[Topic]
+    :param camera_info: Optional CameraInfo topic describing the depth stream. Required
+        alongside `depth`, and usable on its own with an RGBD input to override the
+        calibration that message carries. Like `depth`, it is passed here rather than
+        listed in `inputs`, which is reserved for pictures to detect on.
+    :type camera_info: Optional[Topic]
     :param component_name: The name of the vision component.
         This should be a string and defaults to "vision_component".
     :type component_name: str
@@ -79,29 +93,64 @@ class Vision(ModelComponent):
         model_client: Optional[ModelClient] = None,
         config: Optional[VisionConfig] = None,
         trigger: Union[Topic, List[Topic], float] = 1.0,
+        depth: Optional[Topic] = None,
+        camera_info: Optional[Topic] = None,
         component_name: str,
         **kwargs,
     ):
         self.config: VisionConfig = config or VisionConfig()
-        self.allowed_inputs = {"Required": [[Image, RGBD]]}
+        self.allowed_inputs = {"Required": [[Image, RGBD]], "Optional": [CameraInfo]}
         self.handled_outputs = [
             Detections,
             Trackings,
             DetectionsMultiSource,
             TrackingsMultiSource,
+            Detections3D,
         ]
 
         # Raw image captures
         self._images: List[Union[np.ndarray, ROSImage, ROSCompressedImage]] = []
 
+        self.depth, self.camera_info = depth, camera_info
+
+        # Reject camera info if present in inputs
+        stray_info = [
+            t.name
+            for t in inputs
+            if issubclass(t.msg_type, CameraInfo)
+            and (camera_info is None or t.name != camera_info.name)
+        ]
+        if stray_info:
+            raise TypeError(
+                f"Vision was given CameraInfo topic(s) {stray_info} among its "
+                "inputs. Intrinsics describe a camera rather than deliver "
+                "pictures to detect on, so they are passed as "
+                "`camera_info=Topic(...)`, as depth is passed as `depth=Topic(...)`."
+            )
+        self._aux_inputs = {t.name for t in (depth, camera_info) if t}
+
+        # Asking for a Detections3D output turns 3D lifting on
+        self._lift_to_3d = any(issubclass(t.msg_type, Detections3D) for t in outputs)
+        self._lift_camera = self._check_3d_contract(inputs, depth, camera_info)
+
+        # Add intrinsics and depth to inputs. They only get subscribed to with a
+        # Detections3D output
+        if self._lift_to_3d:
+            for topic in (depth, camera_info):
+                if topic and all(t.name != topic.name for t in inputs):
+                    inputs = [*inputs, topic]
+
         # Sort which image inputs are actually run through the model, and which are
         # only there to be captured by component actions
-        self._inference_set = self._resolve_detection_set(inputs, outputs, trigger)
+        self._inference_set = self._resolve_detection_set(
+            inputs, outputs, trigger, self._aux_inputs, self._lift_camera
+        )
         self._spectators = [
             topic.name
             for topic in inputs
             if issubclass(topic.msg_type, (Image, RGBD))
             and topic.name not in self._inference_set
+            and topic.name not in self._aux_inputs
         ]
 
         super().__init__(
@@ -132,11 +181,85 @@ class Vision(ModelComponent):
                     "Vision component either requires a model client or enable_local_classifier needs to be set True in the VisionConfig."
                 )
 
+        triggers = getattr(self, "trig_callbacks", {})
+        if any(name in triggers for name in self._aux_inputs):
+            raise TypeError(
+                "Vision depth and camera_info topics describe a camera rather "
+                "than deliver pictures to run inference on, so they cannot be used"
+                " as the component trigger."
+            )
+
+    def _check_3d_contract(
+        self,
+        inputs: List[Union[Topic, FixedInput]],
+        depth: Optional[Topic],
+        camera_info: Optional[Topic],
+    ) -> Optional[str]:
+        """Check the component can produce the 3D detections it was asked for."""
+        if not self._lift_to_3d:
+            return None
+
+        # Check if detection frame has been set. 3D Boxes are axis aligned in it.
+        if not self.config.detections_frame:
+            raise TypeError(
+                "Vision was given a Detections3D output, which needs a frame to "
+                "report boxes in. Set `detections_frame` on the VisionConfig to "
+                "the frame the consumer works in, such as a robotic arm's planning "
+                "frame."
+            )
+
+        pictures = [
+            t
+            for t in inputs
+            if issubclass(t.msg_type, (Image, RGBD))
+            and (not depth or t.name != depth.name)
+        ]
+        if camera_info and not issubclass(camera_info.msg_type, CameraInfo):
+            raise TypeError(
+                "Vision camera_info topic must be of type CameraInfo, got "
+                f"{camera_info.msg_type.__name__}."
+            )
+
+        # Prefer RGBD over plain image. Return first RGBD if multiple.
+        # Otherwise the first Image topic is taken at the end
+        # and the rest are named in a warning.
+        rgbd = [t for t in pictures if issubclass(t.msg_type, RGBD)]
+        if rgbd:
+            return rgbd[0].name
+
+        if not depth:
+            raise TypeError(
+                "Vision was given a Detections3D output, which requires depth "
+                "to place detections in space. Either give it an RGBD input, "
+                "which carries depth registered to its picture, or pass the "
+                "camera's registered depth topic as `depth=Topic(...)` along "
+                f"with its `camera_info=Topic(...)`. Inputs given: "
+                f"{[t.name for t in inputs]}"
+            )
+        if issubclass(depth.msg_type, CompressedImage) or not issubclass(
+            depth.msg_type, Image
+        ):
+            raise TypeError(
+                "Vision depth topic must be an uncompressed Image, got "
+                f"{depth.msg_type.__name__}."
+            )
+        if not camera_info:
+            raise TypeError(
+                "Vision was given a depth topic but no camera_info topic. Depth "
+                "pixels cannot be turned into distances without the calibration "
+                "of the stream they were measured on: pass it as "
+                "`camera_info=Topic(...)`."
+            )
+        # Take first image topic by default
+        return pictures[0].name
+
     @staticmethod
     def _resolve_detection_set(
         inputs: List[Union[Topic, FixedInput]],
         outputs: List[Topic],
         trigger: Union[Topic, List[Topic], float],
+        aux_inputs: Optional[set] = None,
+        lift_camera: Optional[str] = None,
     ) -> List[str]:
         """Decide which image inputs are run through the model each tick.
 
@@ -149,7 +272,12 @@ class Vision(ModelComponent):
 
         :returns: Names of the image topics to run detection on
         """
-        pictures = [t for t in inputs if issubclass(t.msg_type, (Image, RGBD))]
+        aux_inputs = aux_inputs or set()
+        pictures = [
+            t
+            for t in inputs
+            if issubclass(t.msg_type, (Image, RGBD)) and t.name not in aux_inputs
+        ]
         multi_source = any(
             issubclass(t.msg_type, (DetectionsMultiSource, TrackingsMultiSource))
             for t in outputs
@@ -160,8 +288,9 @@ class Vision(ModelComponent):
 
         if isinstance(trigger, (int, float)):
             # Timed: the whole detection set reaches the model together, so
-            # several cameras need a message that can hold several
-            inference_on = pictures if multi_source else pictures[:1]
+            # requires a multi message
+            single = [t for t in pictures if t.name == lift_camera] or pictures[:1]
+            inference_on = pictures if multi_source else single
             per_tick = len(inference_on)
         else:
             # Triggered: only the topic that fired is read, so a tick carries
@@ -191,6 +320,25 @@ class Vision(ModelComponent):
                 "To run inference on all of them, give the component a "
                 "DetectionsMultiSource or TrackingsMultiSource output topic, "
                 "or make them all component triggers."
+            )
+
+        # Depth and intrinsics are only read to place detections in space
+        if not self._lift_to_3d and (unused := sorted(self._aux_inputs)):
+            self.get_logger().warning(
+                f"Ignoring {unused}: depth and intrinsics are only used to place "
+                "detections in metric space, and this component has no "
+                "Detections3D output topic to publish those on. The topics are "
+                "not being subscribed to."
+            )
+
+        # Only one camera's depth and calibration are given, an RGBD topic or
+        # the first Image topic will be used in case of more than one inputs
+        if self._lift_camera and len(self._inference_set) > 1:
+            self.get_logger().warning(
+                f"Lifting detections into 3D only from '{self._lift_camera}': "
+                f"the depth and calibration given describe that camera. "
+                f"Detections from {[n for n in self._inference_set if n != self._lift_camera]} "
+                "are only published in 2D."
             )
 
         # deploy local model if enabled

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -45,6 +45,9 @@ class Vision(DepthLiftMixin, ModelComponent):
     :type inputs: list[Union[Topic, FixedInput]]
     :param outputs: The output topics for the object detection.
         This should be a list of Topic objects, Detection and Tracking types are handled automatically.
+        A Detections3D output turns on the 3D lift: detections are placed in metric space using
+        depth (from an RGBD input or the `depth` topic) and published as boxes in the configured
+        `detections_frame`.
     :type outputs: list[Topic]
     :param model_client: Optional model client for the vision component to access remote vision models. If not provided, enable_local_classifier should be set to True in VisionConfig
         This should be an instance of ModelClient. Defaults to None.

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -113,6 +113,10 @@ class Vision(ModelComponent):
         # Raw image captures
         self._images: List[Union[np.ndarray, ROSImage, ROSCompressedImage]] = []
 
+        depth = depth or self.config._depth_topic
+        camera_info = camera_info or self.config._camera_info_topic
+        self.config._depth_topic = depth
+        self.config._camera_info_topic = camera_info
         self.depth_topic, self.camera_info_topic = depth, camera_info
 
         # Reject camera info if present in inputs

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -29,14 +29,14 @@ from ..utils import (
     draw_points_2d,
     draw_detection_bounding_boxes,
     get_frame_id,
-    get_stamp_secs,
 )
 from ..utils.perception3d import resolve_lift_camera
+from .depth_lift import DepthLiftMixin
 from .model_component import ModelComponent
 from .component_base import ComponentRunType
 
 
-class Vision(ModelComponent):
+class Vision(DepthLiftMixin, ModelComponent):
     """
     This component performs object detection and tracking on input images and outputs a list of detected objects, along with their bounding boxes and confidence scores.
 
@@ -193,18 +193,10 @@ class Vision(ModelComponent):
                     "Vision component either requires a model client or enable_local_classifier needs to be set True in the VisionConfig."
                 )
 
-        # the detector for the 3D lifted camera and its parsed calibration,
-        # each rebuilt only when the camera reports new values, and one-time warnings
-        self._detector = None
-        self._detector_key = None
-        self._intrinsics = None
-        self._intrinsics_key = None
-        self._depth_encoding = None
-        self._depth_encoding_key = None
+        # Initialize detector for 3D lift and its parse calibration
+        self._init_lift_state()
+        # Where the lifted camera's picture sits in this tick's results
         self._lift_index: Optional[int] = None
-        self._lift_msg = None
-        self._lift_depth = None
-        self._warned: set = set()
 
         triggers = getattr(self, "trig_callbacks", {})
         if any(name in triggers for name in self._aux_inputs):
@@ -783,183 +775,6 @@ class Vision(ModelComponent):
                 break
 
         cv2.destroyAllWindows()
-
-    def _depth_snapshot(self) -> Optional[Any]:
-        """Depth as it stands the instant its picture is taken.
-
-        Read alongside the picture rather than at publish time.
-        Not needed for RGBD msgs
-        """
-        if self.depth_topic and (callback := self.callbacks.get(self.depth_topic.name)):
-            return callback.msg
-        return None
-
-    def _depth_for(self) -> Optional[Any]:
-        """The depth image registered to the lifted picture, or None"""
-        # For RGBD
-        if (depth := getattr(self._lift_msg, "depth", None)) is not None and depth.data:
-            return depth
-
-        if (depth := self._lift_depth) is None:
-            self._warn_once(
-                "no_depth",
-                f"Nothing has been received on depth topic "
-                f"'{self.depth_topic.name if self.depth_topic else '<unknown>'}', so no detection "
-                "can be placed in space.",
-                error=True,
-            )
-            return None
-
-        # For Image. Captured at the same instant, check for age nonetheless
-        age = abs(get_stamp_secs(self._lift_msg) - get_stamp_secs(depth))
-        if age > self.config.max_depth_age:
-            self._warn_once(
-                "depth_age",
-                f"Depth on '{self.depth_topic.name}' is {age:.2f}s away from the "
-                f"picture it would be paired with, more than max_depth_age "
-                f"({self.config.max_depth_age}s), so these detections are not "
-                "being published.",
-            )
-            return None
-        return depth
-
-    def _camera_intrinsics(self) -> Optional[Any]:
-        """Calibration of the stream the depth was measured on.
-        A camera_info topic wins when one was given.
-        """
-
-        from ..ros import read_camera_info
-
-        if self.camera_info_topic and (
-            info := self.callbacks.get(self.camera_info_topic.name)
-        ):
-            if (parsed := info.get_output()) is not None:
-                return parsed
-
-        info = getattr(self._lift_msg, "depth_camera_info", None)
-        if info is None:
-            return None
-        key = (
-            info.header.frame_id,
-            info.width,
-            info.height,
-            tuple(info.k),
-            tuple(info.p),
-        )
-        # Update key if it changed
-        if key != self._intrinsics_key:
-            self._intrinsics = read_camera_info(info)
-            self._intrinsics_key = key
-        return self._intrinsics
-
-    def _depth_detector(self):
-        """The 3D detector for the lifted camera, and the depth to run it on.
-
-        :returns: (detector, depth in millimeters), both None when this tick
-            cannot be lifted
-        """
-        from ..callbacks import image_pre_processing, process_encoding
-
-        from ..utils.perception3d import make_detector, prepare_depth
-
-        depth_msg = self._depth_for()
-        if depth_msg is None:
-            return None, None
-
-        intrinsics = self._camera_intrinsics()
-        if intrinsics is None:
-            self._warn_once(
-                "no_intrinsics",
-                "No camera calibration has been received, so depth cannot be "
-                "turned into distances. Pass the camera's `camera_info` topic, "
-                "or use an RGBD input, which carries its own.",
-                error=True,
-            )
-            return None, None
-
-        # The intrinsics need to describe the depth image
-        if (intrinsics.width, intrinsics.height) != (depth_msg.width, depth_msg.height):
-            self._warn_once(
-                "intrinsics_resolution",
-                f"The camera reports intrinsics for {intrinsics.width}x"
-                f"{intrinsics.height} images but publishes depth at "
-                f"{depth_msg.width}x{depth_msg.height}. Detections cannot be "
-                "placed in metric space until the two agree.",
-                error=True,
-            )
-            return None, None
-
-        # Check if the streams encoding changed (unlikely)
-        if depth_msg.encoding != self._depth_encoding_key:
-            self._depth_encoding = process_encoding(depth_msg.encoding)
-            self._depth_encoding_key = depth_msg.encoding
-
-        depth_mm = prepare_depth(
-            image_pre_processing(depth_msg, *self._depth_encoding),
-            encoding=depth_msg.encoding,
-            scale=self.config.depth_scale,
-        )
-
-        # Registered depth shares the color image's pixel grid preferrably
-        color_frame = get_frame_id(getattr(self._lift_msg, "rgb", self._lift_msg))
-        depth_frame = get_frame_id(depth_msg)
-        if color_frame and depth_frame and color_frame != depth_frame:
-            self._warn_once(
-                "frame_mismatch",
-                f"The depth stream reports frame '{depth_frame}' while the "
-                f"pictures are in '{color_frame}'. Depth registered to the "
-                "color image lives in the color camera's frame, so that is "
-                "the one used. If this depth stream is not the registered "
-                "one, every 3D box will be misplaced.",
-            )
-        camera_frame = color_frame or depth_frame
-        target = self.config.detections_frame
-        translation = rotation = None
-        if target != camera_frame:
-            listener = self.get_transform_listener(
-                camera_frame, target, self.config.static_camera_tf
-            )
-            if not listener.got_transform:
-                self._warn_once(
-                    "camera_transform",
-                    f"The transform from camera frame '{camera_frame}' to "
-                    f"'{target}' has not been resolved yet, so detections are "
-                    "not being published in 3D.",
-                )
-                return None, None
-            translation, rotation = listener.translation, listener.rotation
-
-        # Rebuilding is cheap, so the detector is kept only until something it
-        # was built from moves
-        key = (
-            camera_frame,
-            intrinsics.fx,
-            intrinsics.fy,
-            intrinsics.cx,
-            intrinsics.cy,
-            None if translation is None else tuple(translation),
-            None if rotation is None else tuple(rotation),
-        )
-        if key != self._detector_key:
-            self._detector = make_detector(
-                intrinsics,
-                translation=translation,
-                rotation=rotation,
-                depth_range=(self.config.min_depth, self.config.max_depth),
-            )
-            self._detector_key = key
-        return self._detector, depth_mm
-
-    # TODO: Upstream to sugarcoat component
-    def _warn_once(self, key: str, message: str, error: bool = False) -> None:
-        """Report a lasting misconfiguration the first time it is noticed"""
-        if key in self._warned:
-            return
-        self._warned.add(key)
-        if error:
-            self.get_logger().error(message)
-        else:
-            self.get_logger().warning(message)
 
     def _create_input(self, *_, **kwargs) -> Optional[Dict[str, Any]]:
         """Create inference input for ObjectDetection models

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -954,6 +954,10 @@ class Vision(DepthLiftMixin, ModelComponent):
             result["images"] = inference_input["images"]
             self.queue.put_nowait(result)
 
+    def _handle_websocket_streaming(self):
+        """Not used -- Vision publishes detections per frame."""
+        pass
+
     def _warmup(self):
         """Warm up and stat check"""
         import time

--- a/agents/components/vision.py
+++ b/agents/components/vision.py
@@ -29,6 +29,8 @@ from ..utils import (
     load_model,
     draw_points_2d,
     draw_detection_bounding_boxes,
+    get_frame_id,
+    get_stamp_secs,
 )
 from .model_component import ModelComponent
 from .component_base import ComponentRunType
@@ -111,7 +113,7 @@ class Vision(ModelComponent):
         # Raw image captures
         self._images: List[Union[np.ndarray, ROSImage, ROSCompressedImage]] = []
 
-        self.depth, self.camera_info = depth, camera_info
+        self.depth_topic, self.camera_info_topic = depth, camera_info
 
         # Reject camera info if present in inputs
         stray_info = [
@@ -180,6 +182,19 @@ class Vision(ModelComponent):
                 raise TypeError(
                     "Vision component either requires a model client or enable_local_classifier needs to be set True in the VisionConfig."
                 )
+
+        # the detector for the 3D lifted camera and its parsed calibration,
+        # each rebuilt only when the camera reports new values, and one-time warnings
+        self._detector = None
+        self._detector_key = None
+        self._intrinsics = None
+        self._intrinsics_key = None
+        self._depth_encoding = None
+        self._depth_encoding_key = None
+        self._lift_index: Optional[int] = None
+        self._lift_msg = None
+        self._lift_depth = None
+        self._warned: set = set()
 
         triggers = getattr(self, "trig_callbacks", {})
         if any(name in triggers for name in self._aux_inputs):
@@ -823,6 +838,183 @@ class Vision(ModelComponent):
 
         cv2.destroyAllWindows()
 
+    def _depth_snapshot(self) -> Optional[Any]:
+        """Depth as it stands the instant its picture is taken.
+
+        Read alongside the picture rather than at publish time.
+        Not needed for RGBD msgs
+        """
+        if self.depth_topic and (callback := self.callbacks.get(self.depth_topic.name)):
+            return callback.msg
+        return None
+
+    def _depth_for(self) -> Optional[Any]:
+        """The depth image registered to the lifted picture, or None"""
+        # For RGBD
+        if (depth := getattr(self._lift_msg, "depth", None)) is not None and depth.data:
+            return depth
+
+        if (depth := self._lift_depth) is None:
+            self._warn_once(
+                "no_depth",
+                f"Nothing has been received on depth topic "
+                f"'{self.depth_topic.name if self.depth_topic else '<unknown>'}', so no detection "
+                "can be placed in space.",
+                error=True,
+            )
+            return None
+
+        # For Image. Captured at the same instant, check for age nonetheless
+        age = abs(get_stamp_secs(self._lift_msg) - get_stamp_secs(depth))
+        if age > self.config.max_depth_age:
+            self._warn_once(
+                "depth_age",
+                f"Depth on '{self.depth_topic.name}' is {age:.2f}s away from the "
+                f"picture it would be paired with, more than max_depth_age "
+                f"({self.config.max_depth_age}s), so these detections are not "
+                "being published.",
+            )
+            return None
+        return depth
+
+    def _camera_intrinsics(self) -> Optional[Any]:
+        """Calibration of the stream the depth was measured on.
+        A camera_info topic wins when one was given.
+        """
+
+        from ..ros import read_camera_info
+
+        if self.camera_info_topic and (
+            info := self.callbacks.get(self.camera_info_topic.name)
+        ):
+            if (parsed := info.get_output()) is not None:
+                return parsed
+
+        info = getattr(self._lift_msg, "depth_camera_info", None)
+        if info is None:
+            return None
+        key = (
+            info.header.frame_id,
+            info.width,
+            info.height,
+            tuple(info.k),
+            tuple(info.p),
+        )
+        # Update key if it changed
+        if key != self._intrinsics_key:
+            self._intrinsics = read_camera_info(info)
+            self._intrinsics_key = key
+        return self._intrinsics
+
+    def _depth_detector(self):
+        """The 3D detector for the lifted camera, and the depth to run it on.
+
+        :returns: (detector, depth in millimeters), both None when this tick
+            cannot be lifted
+        """
+        from ..callbacks import image_pre_processing, process_encoding
+
+        from ..utils.perception3d import make_detector, prepare_depth
+
+        depth_msg = self._depth_for()
+        if depth_msg is None:
+            return None, None
+
+        intrinsics = self._camera_intrinsics()
+        if intrinsics is None:
+            self._warn_once(
+                "no_intrinsics",
+                "No camera calibration has been received, so depth cannot be "
+                "turned into distances. Pass the camera's `camera_info` topic, "
+                "or use an RGBD input, which carries its own.",
+                error=True,
+            )
+            return None, None
+
+        # The intrinsics need to describe the depth image
+        if (intrinsics.width, intrinsics.height) != (depth_msg.width, depth_msg.height):
+            self._warn_once(
+                "intrinsics_resolution",
+                f"The camera reports intrinsics for {intrinsics.width}x"
+                f"{intrinsics.height} images but publishes depth at "
+                f"{depth_msg.width}x{depth_msg.height}. Detections cannot be "
+                "placed in metric space until the two agree.",
+                error=True,
+            )
+            return None, None
+
+        # Check if the streams encoding changed (unlikely)
+        if depth_msg.encoding != self._depth_encoding_key:
+            self._depth_encoding = process_encoding(depth_msg.encoding)
+            self._depth_encoding_key = depth_msg.encoding
+
+        depth_mm = prepare_depth(
+            image_pre_processing(depth_msg, *self._depth_encoding),
+            encoding=depth_msg.encoding,
+            scale=self.config.depth_scale,
+        )
+
+        # Registered depth shares the color image's pixel grid preferrably
+        color_frame = get_frame_id(getattr(self._lift_msg, "rgb", self._lift_msg))
+        depth_frame = get_frame_id(depth_msg)
+        if color_frame and depth_frame and color_frame != depth_frame:
+            self._warn_once(
+                "frame_mismatch",
+                f"The depth stream reports frame '{depth_frame}' while the "
+                f"pictures are in '{color_frame}'. Depth registered to the "
+                "color image lives in the color camera's frame, so that is "
+                "the one used. If this depth stream is not the registered "
+                "one, every 3D box will be misplaced.",
+            )
+        camera_frame = color_frame or depth_frame
+        target = self.config.detections_frame
+        translation = rotation = None
+        if target != camera_frame:
+            listener = self.get_transform_listener(
+                camera_frame, target, self.config.static_camera_tf
+            )
+            if not listener.got_transform:
+                self._warn_once(
+                    "camera_transform",
+                    f"The transform from camera frame '{camera_frame}' to "
+                    f"'{target}' has not been resolved yet, so detections are "
+                    "not being published in 3D.",
+                )
+                return None, None
+            translation, rotation = listener.translation, listener.rotation
+
+        # Rebuilding is cheap, so the detector is kept only until something it
+        # was built from moves
+        key = (
+            camera_frame,
+            intrinsics.fx,
+            intrinsics.fy,
+            intrinsics.cx,
+            intrinsics.cy,
+            None if translation is None else tuple(translation),
+            None if rotation is None else tuple(rotation),
+        )
+        if key != self._detector_key:
+            self._detector = make_detector(
+                intrinsics,
+                translation=translation,
+                rotation=rotation,
+                depth_range=(self.config.min_depth, self.config.max_depth),
+            )
+            self._detector_key = key
+        return self._detector, depth_mm
+
+    # TODO: Upstream to sugarcoat component
+    def _warn_once(self, key: str, message: str, error: bool = False) -> None:
+        """Report a lasting misconfiguration the first time it is noticed"""
+        if key in self._warned:
+            return
+        self._warned.add(key)
+        if error:
+            self.get_logger().error(message)
+        else:
+            self.get_logger().warning(message)
+
     def _create_input(self, *_, **kwargs) -> Optional[Dict[str, Any]]:
         """Create inference input for ObjectDetection models
         :param args:
@@ -830,10 +1022,18 @@ class Vision(ModelComponent):
         :rtype: dict[str, Any]
         """
         self._images = []
+        # Where the lifted camera's picture sits in this tick's results
+        self._lift_index: Optional[int] = None
+        self._lift_msg = None
+        self._lift_depth = None
+
         # set one image topic as query for event based trigger
         if trigger := kwargs.get("topic"):
             if msg := self.trig_callbacks[trigger.name].msg:
                 self._images.append(msg)
+                if trigger.name == self._lift_camera:
+                    self._lift_index, self._lift_msg = 0, msg
+                    self._lift_depth = self._depth_snapshot()
             images = [self.trig_callbacks[trigger.name].get_output(clear_last=True)]
         else:
             images = []
@@ -844,6 +1044,9 @@ class Vision(ModelComponent):
                     continue
                 msg = i.msg
                 if (item := i.get_output(clear_last=True)) is not None:
+                    if name == self._lift_camera and msg is not None:
+                        self._lift_index, self._lift_msg = len(images), msg
+                        self._lift_depth = self._depth_snapshot()
                     images.append(item)
                     if msg is not None:
                         self._images.append(msg)
@@ -862,8 +1065,22 @@ class Vision(ModelComponent):
         """
         output = result.pop("output")
         images = kwargs.pop("images", None)
+        boxes = self._lift(output) if self._lift_to_3d else None
+
         for publisher in self.publishers_dict.values():
-            if issubclass(publisher.output_topic.msg_type, (Detections, Trackings)):
+            msg_type = publisher.output_topic.msg_type
+            if issubclass(msg_type, Detections3D):
+                # NOTE: None means the camera could not be used this tick
+                # (3D lifting didn't work), and nothing goes out. A scene the camera
+                # did see as empty comes through as empty fields and is published
+                if boxes is not None:
+                    publisher.publish(
+                        boxes["output"],
+                        **{k: v for k, v in boxes.items() if k != "output"},
+                        frame_id=self.config.detections_frame,
+                        time_stamp=kwargs.get("time_stamp"),
+                    )
+            elif issubclass(msg_type, (Detections, Trackings)):
                 publisher.publish(
                     output[0],
                     images=images[0] if images else None,
@@ -873,12 +1090,66 @@ class Vision(ModelComponent):
             else:
                 publisher.publish(output, images=images, **result, **kwargs)
 
+    def _lift(self, output: List[Dict]) -> Optional[Dict[str, Any]]:
+        """Turn the lifted camera's detections into metric boxes.
+
+        :returns: Fields for the Detections3D converter, or None when the
+            camera could not be used this tick
+        """
+        from ..utils.perception3d import (
+            boxes_from_detections,
+            detections_to_message_fields,
+        )
+
+        if self._lift_index is None or self._lift_index >= len(output):
+            self._warn_once(
+                "no_lift_frame",
+                f"No picture arrived on '{self._lift_camera}', so nothing can "
+                "be placed in space this tick.",
+            )
+            return None
+
+        detections = output[self._lift_index] or {}
+        pixels = detections.get("bboxes") or []
+        if not pixels:
+            # NOTE: The camera worked and saw nothing; unlike the None returns on
+            # this path, this is an observation, published as an empty message
+            # so consumers let go of objects that are no longer there
+            return detections_to_message_fields([])
+
+        # the color image, which an RGBD frame carries nested
+        color = getattr(self._lift_msg, "rgb", self._lift_msg)
+
+        detector, depth_mm = self._depth_detector()
+        if detector is None:
+            return None
+
+        lifted = [
+            box
+            for box in boxes_from_detections(
+                detector,
+                depth_mm,
+                pixels,
+                image_size=(color.width, color.height),
+                depth_range=(self.config.min_depth, self.config.max_depth),
+            )
+            # A box built from a handful of depth pixels is not trustworthy
+            if box.validity >= self.config.min_depth_validity
+        ]
+        return detections_to_message_fields(
+            lifted,
+            labels=detections.get("labels"),
+            scores=detections.get("scores"),
+            boxes_2d=pixels,
+        )
+
     def _source_frame(self) -> Optional[str]:
-        """Frame of the camera the detections were made in"""
+        """Frame of the camera the detections were made in, None unless
+        exactly one camera contributed.
+        """
         if len(self._images) != 1:
             return None
-        source = getattr(self._images[0], "rgb", self._images[0])
-        return getattr(getattr(source, "header", None), "frame_id", None) or None
+        return get_frame_id(getattr(self._images[0], "rgb", self._images[0])) or None
 
     def _execution_step(self, *args, **kwargs):
         """_execution_step.

--- a/agents/config.py
+++ b/agents/config.py
@@ -568,6 +568,8 @@ class MoveItConfig(BaseComponentConfig):
     :type arm_group_name: str
     :param gripper_group_name: Name of the SRDF planning group of the gripper (e.g. "hand"). Required for gripper control when `gripper_mode` is "move_group". Default is None.
     :type gripper_group_name: Optional[str]
+    :param cartesian_group_name: Planning group used for Cartesian path requests (straight-line motions, including the descend/retreat steps of pick and place). Default is None, which uses `arm_group_name`. Setting a separate group lets an underactuated (e.g. 5-DOF) arm pair a position-only IK configuration on the arm group (for pose goals) with an orientation-tracking IK configuration on a twin group over the same chain. MoveIt's Cartesian interpolator validates the achieved orientation of every step against a fixed precision the request cannot override, which a position-only solver cannot meet.
+    :type cartesian_group_name: Optional[str]
     :param end_effector_link: End-effector link that pose targets and Cartesian waypoints refer to. Empty (default) uses the planning group's default tip link.
     :type end_effector_link: str
     :param pose_reference_frame: Default reference frame for pose targets that carry an empty `header.frame_id`. Empty (default) uses move_group's planning frame.
@@ -649,6 +651,7 @@ class MoveItConfig(BaseComponentConfig):
 
     arm_group_name: str = field()
     gripper_group_name: Optional[str] = field(default=None)
+    cartesian_group_name: Optional[str] = field(default=None)
     end_effector_link: str = field(default="")
     pose_reference_frame: str = field(default="")
     planning_pipeline: str = field(default="")

--- a/agents/config.py
+++ b/agents/config.py
@@ -112,7 +112,9 @@ class LLMConfig(ModelComponentConfig):
 
     enable_rag: bool = field(default=False)
     collection_name: Optional[str] = field(default=None)
-    distance_func: Literal["l2", "ip", "cosine"] = field(default="l2")
+    distance_func: Literal["l2", "ip", "cosine"] = field(
+        default="l2", validator=base_validators.in_(["l2", "ip", "cosine"])
+    )
     n_results: int = field(default=1)
     add_metadata: bool = field(default=False)
     chat_history: bool = field(default=False)
@@ -127,7 +129,9 @@ class LLMConfig(ModelComponentConfig):
     response_terminator: str = field(default="<<Response Ended>>")
     strip_think_tokens: bool = field(default=True)
     enable_local_model: bool = field(default=False)
-    device_local_model: Literal["cpu", "cuda"] = field(default="cuda")
+    device_local_model: Literal["cpu", "cuda"] = field(
+        default="cuda", validator=base_validators.in_(["cpu", "cuda"])
+    )
     ncpu_local_model: int = field(default=1)
     local_model_path: Optional[str] = field(default="Qwen/Qwen3-0.6B-GGUF")
     local_model_options: Dict = field(default=Factory(dict))
@@ -329,7 +333,14 @@ class MLLMConfig(LLMConfig):
 
     task: Optional[
         Literal["general", "pointing", "affordance", "trajectory", "grounding"]
-    ] = field(default=None)
+    ] = field(
+        default=None,
+        validator=validators.optional(
+            base_validators.in_(
+                ["general", "pointing", "affordance", "trajectory", "grounding"]
+            )
+        ),
+    )
     local_model_path: Optional[str] = field(
         default="ggml-org/Qwen3-VL-2B-Instruct-GGUF"
     )
@@ -447,13 +458,23 @@ class VLAConfig(ModelComponentConfig):
     # TODO: One can make models that take multiple state input types.
     # This parameter would have to be revised in that case
     state_input_type: Literal["positions", "velocities", "accelerations", "efforts"] = (
-        field(default="positions")
+        field(
+            default="positions",
+            validator=base_validators.in_(
+                ["positions", "velocities", "accelerations", "efforts"]
+            ),
+        )
     )
     # TODO: One can make models that produce multiple action output types.
     # This parameter would have to be revised in that case
     action_output_type: Literal[
         "positions", "velocities", "accelerations", "efforts"
-    ] = field(default="positions")
+    ] = field(
+        default="positions",
+        validator=base_validators.in_(
+            ["positions", "velocities", "accelerations", "efforts"]
+        ),
+    )
     observation_sending_rate: float = field(
         default=10.0, validator=base_validators.in_range(min_value=1e-6, max_value=1e6)
     )
@@ -466,11 +487,17 @@ class VLAConfig(ModelComponentConfig):
     robot_urdf_file: Optional[str] = field(default=None)
     joint_limits: Optional[Dict] = field(default=None)
     policy_action_units: Literal["radians", "degrees", "normalized"] = field(
-        default="radians"
+        default="radians",
+        validator=base_validators.in_(["radians", "degrees", "normalized"]),
     )
     aggregate_fn_name: Literal[
         "latest_only", "weighted_average", "average", "conservative"
-    ] = field(default="latest_only")
+    ] = field(
+        default="latest_only",
+        validator=base_validators.in_(
+            ["latest_only", "weighted_average", "average", "conservative"]
+        ),
+    )
     _termination_mode: Literal["timesteps", "keyboard", "event"] = field(
         default="timesteps", alias="_termination_mode"
     )
@@ -558,6 +585,18 @@ class MoveItConfig(BaseComponentConfig):
     :type server_timeout: float
     :param execution_timeout: Maximum wall time in seconds for a single plan+execute goal. Default is 120.0.
     :type execution_timeout: float
+    :param scene_update_mode: WHEN detected objects are pushed into the planning scene: "manual" (default) only on the `update_planning_scene` component action, "on_goal" additionally refreshes the scene right before each motion goal is planned, "continuous" keeps refreshing at `scene_update_rate` while detections arrive. Only effective when the component is given a Detections3D input topic.
+    :type scene_update_mode: Literal["manual", "on_goal", "continuous"]
+    :param scene_update_rate: Scene refreshes per second in "continuous" mode. Default is 1.0.
+    :type scene_update_rate: float
+    :param scene_object_ttl: Seconds a detection-sourced object stays in the scene after the detector stops reporting it, before a refresh removes it. Bridges detection dropouts without keeping ghost obstacles around. Default is 5.0.
+    :type scene_object_ttl: float
+    :param object_padding: Margin in meters added on every side of detected objects, for planning clearance around imperfectly measured geometry. Default is 0.0.
+    :type object_padding: float
+    :param min_object_thickness: Floor in meters for each extent of a detected object. Surfaces seen head-on are lifted with no measurable extent along the view axis, and a zero-thickness box is invisible to collision checking. Default is 0.01.
+    :type min_object_thickness: float
+    :param touch_links: Links allowed to stay in contact with an attached object, e.g. the gripper's links. Default is None, which resolves them from the robot SRDF at attach time.
+    :type touch_links: Optional[List[str]]
 
     Example of usage:
     ```python
@@ -593,7 +632,8 @@ class MoveItConfig(BaseComponentConfig):
         default=0.95, validator=base_validators.in_range(min_value=0.0, max_value=1.0)
     )
     gripper_mode: Literal["move_group", "gripper_command"] = field(
-        default="move_group"
+        default="move_group",
+        validator=base_validators.in_(["move_group", "gripper_command"]),
     )
     gripper_command_action: str = field(default="")
     gripper_open_target: str = field(default="open")
@@ -607,6 +647,17 @@ class MoveItConfig(BaseComponentConfig):
     srdf_file: Optional[str] = field(default=None)
     server_timeout: float = field(default=30.0, validator=base_validators.gt(0.0))
     execution_timeout: float = field(default=120.0, validator=base_validators.gt(0.0))
+    scene_update_mode: Literal["manual", "on_goal", "continuous"] = field(
+        default="manual",
+        validator=base_validators.in_(["manual", "on_goal", "continuous"]),
+    )
+    scene_update_rate: float = field(default=1.0, validator=base_validators.gt(0.0))
+    scene_object_ttl: float = field(default=5.0, validator=base_validators.gt(0.0))
+    object_padding: float = field(
+        default=0.0, validator=base_validators.in_range(min_value=0.0, max_value=1.0)
+    )
+    min_object_thickness: float = field(default=0.01, validator=base_validators.gt(0.0))
+    touch_links: Optional[List[str]] = field(default=None)
 
     @goal_orientation_tolerance.validator
     def _check_orientation_tolerance(self, _, value):
@@ -692,7 +743,9 @@ class VisionConfig(ModelComponentConfig):
     input_height: int = field(default=640)
     input_width: int = field(default=640)
     dataset_labels: Optional[Dict] = field(default=None)
-    device_local_classifier: Literal["cpu", "cuda", "tensorrt"] = field(default="cuda")
+    device_local_classifier: Literal["cpu", "cuda", "tensorrt"] = field(
+        default="cuda", validator=base_validators.in_(["cpu", "cuda", "tensorrt"])
+    )
     ncpu_local_classifier: int = field(default=1)
     local_classifier_model_path: str = field(
         default="https://github.com/automatika-robotics/embodied-agents/releases/download/0.3.3/deim_dfine_hgnetv2_n_coco_160e.onnx"
@@ -778,7 +831,9 @@ class TextToSpeechConfig(ModelComponentConfig):
     """
 
     enable_local_model: bool = field(default=False)
-    device_local_model: Literal["cpu", "cuda"] = field(default="cuda")
+    device_local_model: Literal["cpu", "cuda"] = field(
+        default="cuda", validator=base_validators.in_(["cpu", "cuda"])
+    )
     ncpu_local_model: int = field(default=1)
     local_model_path: Optional[str] = field(
         default="csukuangfj2/sherpa-onnx-pocket-tts-int8-2026-01-26"
@@ -986,7 +1041,9 @@ class SpeechToTextConfig(ModelComponentConfig):
     """
 
     enable_local_model: bool = field(default=False)
-    device_local_model: Literal["cpu", "cuda"] = field(default="cuda")
+    device_local_model: Literal["cpu", "cuda"] = field(
+        default="cuda", validator=base_validators.in_(["cpu", "cuda"])
+    )
     ncpu_local_model: int = field(default=1)
     local_model_path: Optional[str] = field(
         default="csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v2-int8"
@@ -1013,8 +1070,12 @@ class SpeechToTextConfig(ModelComponentConfig):
     speech_buffer_max_len: int = field(default=30000)
     stream: bool = field(default=False)
     min_chunk_size: int = field(default=2000, validator=base_validators.gt(500))
-    device_vad: Literal["cpu", "cuda", "tensorrt"] = field(default="cpu")
-    device_wakeword: Literal["cpu", "cuda", "tensorrt"] = field(default="cpu")
+    device_vad: Literal["cpu", "cuda", "tensorrt"] = field(
+        default="cpu", validator=base_validators.in_(["cpu", "cuda", "tensorrt"])
+    )
+    device_wakeword: Literal["cpu", "cuda", "tensorrt"] = field(
+        default="cpu", validator=base_validators.in_(["cpu", "cuda", "tensorrt"])
+    )
     ncpu_vad: int = field(default=1)
     ncpu_wakeword: int = field(default=1)
     vad_model_path: str = field(
@@ -1078,7 +1139,9 @@ class MapConfig(BaseComponentConfig):
     """
 
     map_name: str = field()
-    distance_func: Literal["l2", "ip", "cosine"] = field(default="l2")
+    distance_func: Literal["l2", "ip", "cosine"] = field(
+        default="l2", validator=base_validators.in_(["l2", "ip", "cosine"])
+    )
     _position: Optional[Topic] = field(
         default=None, converter=_get_optional_topic, alias="_position"
     )
@@ -1202,7 +1265,9 @@ class SemanticRouterConfig(ModelComponentConfig):
     """
 
     router_name: str = field()
-    distance_func: Literal["l2", "ip", "cosine"] = field(default="l2")
+    distance_func: Literal["l2", "ip", "cosine"] = field(
+        default="l2", validator=base_validators.in_(["l2", "ip", "cosine"])
+    )
     maximum_distance: float = field(
         default=0.4, validator=base_validators.in_range(min_value=0.1, max_value=1.0)
     )
@@ -1285,12 +1350,19 @@ class MotionDetectorConfig(BaseComponentConfig):
     )
     publish_bool_on_change_only: bool = field(default=False)
     process_rate: Optional[float] = field(default=None)
-    device: Literal["cpu", "cuda"] = field(default="cpu")
+    device: Literal["cpu", "cuda"] = field(
+        default="cpu", validator=base_validators.in_(["cpu", "cuda"])
+    )
 
     min_video_frames: int = field(default=15)  # assuming 0.5 second video at 30 fps
     max_video_frames: int = field(default=600)  # assuming 20 second video at 30 fps
     motion_estimation_func: Optional[Literal["frame_difference", "optical_flow"]] = (
-        field(default=None)
+        field(
+            default=None,
+            validator=validators.optional(
+                base_validators.in_(["frame_difference", "optical_flow"])
+            ),
+        )
     )
     threshold: float = field(
         default=0.3, validator=base_validators.in_range(min_value=0.1, max_value=5.0)

--- a/agents/config.py
+++ b/agents/config.py
@@ -12,6 +12,7 @@ __all__ = [
     "VLMConfig",
     "CortexConfig",
     "VLAConfig",
+    "MoveItConfig",
     "SpeechToTextConfig",
     "TextToSpeechConfig",
     "SemanticRouterConfig",
@@ -486,6 +487,150 @@ class VLAConfig(ModelComponentConfig):
 
     def _get_inference_params(self) -> Dict:
         return {}
+
+
+@define(kw_only=True)
+class MoveItConfig(BaseComponentConfig):
+    """
+    Configuration for the MoveIt manipulation component.
+
+    It defines which planning groups to command on a running MoveIt 2 `move_group`
+    node, how to plan (planner selection, effort, tolerances) and how the gripper
+    is controlled.
+
+    :param arm_group_name: Name of the SRDF planning group of the arm (e.g. "panda_arm"). Group names are defined in the robot's MoveIt (SRDF) configuration.
+    :type arm_group_name: str
+    :param gripper_group_name: Name of the SRDF planning group of the gripper (e.g. "hand"). Required for gripper control when `gripper_mode` is "move_group". Default is None.
+    :type gripper_group_name: Optional[str]
+    :param end_effector_link: End-effector link that pose targets and Cartesian waypoints refer to. Empty (default) uses the planning group's default tip link.
+    :type end_effector_link: str
+    :param pose_reference_frame: Default reference frame for pose targets that carry an empty `header.frame_id`. Empty (default) uses move_group's planning frame.
+    :type pose_reference_frame: str
+    :param planning_pipeline: Planning pipeline to use (e.g. "ompl", "pilz_industrial_motion_planner"). Empty (default) uses move_group's default pipeline. Validated against the pipelines advertised by move_group at activation.
+    :type planning_pipeline: str
+    :param planner_id: Planner algorithm within the pipeline (e.g. "RRTConnect", "RRTstar" for OMPL). Empty (default) uses the pipeline's default planner. Validated against the planners advertised by move_group at activation.
+    :type planner_id: str
+    :param num_planning_attempts: Number of planning attempts before the best solution is returned. Default is 5.
+    :type num_planning_attempts: int
+    :param allowed_planning_time: Maximum planning time in seconds. Default is 5.0.
+    :type allowed_planning_time: float
+    :param max_velocity_scaling: Fraction of the joint velocity limits used when timing trajectories, in (0, 1]. Default is 0.1 — deliberately slow; increase once a setup is trusted.
+    :type max_velocity_scaling: float
+    :param max_acceleration_scaling: Fraction of the joint acceleration limits used when timing trajectories, in (0, 1]. Default is 0.1.
+    :type max_acceleration_scaling: float
+    :param goal_position_tolerance: Position tolerance in meters for pose targets. Default is 1e-3.
+    :type goal_position_tolerance: float
+    :param goal_orientation_tolerance: Orientation tolerance in radians for pose targets — a single value applied to all axes, or a list of 3 per-axis values (x, y, z). Relaxing a single axis (e.g. z to ~3.14) makes many poses reachable for underactuated (e.g. 5-DOF) arms. Default is 1e-2.
+    :type goal_orientation_tolerance: Union[float, List[float]]
+    :param goal_joint_tolerance: Position tolerance in radians for joint targets. Default is 1e-3.
+    :type goal_joint_tolerance: float
+    :param cartesian_max_step: End-effector interpolation step in meters for Cartesian paths. Default is 0.0025.
+    :type cartesian_max_step: float
+    :param cartesian_jump_threshold: Maximum allowed joint-space jump between consecutive Cartesian points (0.0 disables the check). Default is 0.0.
+    :type cartesian_jump_threshold: float
+    :param cartesian_avoid_collisions: Whether Cartesian paths must avoid collisions. Default is True.
+    :type cartesian_avoid_collisions: bool
+    :param cartesian_fraction_threshold: Minimum fraction of the requested Cartesian path that must be achievable for the goal to be executed, in [0, 1]. Default is 0.95.
+    :type cartesian_fraction_threshold: float
+    :param gripper_mode: How the gripper is controlled: "move_group" (default) sends named targets on `gripper_group_name`; "gripper_command" sends a control_msgs GripperCommand to `gripper_command_action`.
+    :type gripper_mode: Literal["move_group", "gripper_command"]
+    :param gripper_command_action: Action name of the gripper controller (e.g. "/gripper_controller/gripper_cmd"). Required when `gripper_mode` is "gripper_command".
+    :type gripper_command_action: str
+    :param gripper_open_target: SRDF named target used by `open_gripper` in "move_group" mode. Default is "open".
+    :type gripper_open_target: str
+    :param gripper_close_target: SRDF named target used by `close_gripper` in "move_group" mode. Default is "close".
+    :type gripper_close_target: str
+    :param gripper_open_position: Gripper position used by `open_gripper` in "gripper_command" mode. Default is 0.04.
+    :type gripper_open_position: float
+    :param gripper_close_position: Gripper position used by `close_gripper` in "gripper_command" mode. Default is 0.0.
+    :type gripper_close_position: float
+    :param gripper_max_effort: Maximum effort for GripperCommand goals (0.0 lets the controller decide). Default is 0.0.
+    :type gripper_max_effort: float
+    :param move_group_namespace: Namespace prefix of the move_group interfaces (e.g. "/my_robot" if the actions are at "/my_robot/move_action"). Default is "".
+    :type move_group_namespace: str
+    :param move_group_node_name: Name of the move_group node, used to fetch the SRDF (named targets) from its parameters. Default is "move_group".
+    :type move_group_node_name: str
+    :param named_targets: Manual named-target definitions per group, overriding the SRDF: {group: {target_name: {joint: position}}}. Default is None.
+    :type named_targets: Optional[Dict]
+    :param srdf_file: Path or URL of a local SRDF file used as fallback for named targets when the SRDF cannot be fetched from move_group. Default is None.
+    :type srdf_file: Optional[str]
+    :param server_timeout: Time in seconds to wait for move_group's servers to become available. Default is 30.0.
+    :type server_timeout: float
+    :param execution_timeout: Maximum wall time in seconds for a single plan+execute goal. Default is 120.0.
+    :type execution_timeout: float
+
+    Example of usage:
+    ```python
+    config = MoveItConfig(arm_group_name="panda_arm", gripper_group_name="hand")
+    ```
+    """
+
+    arm_group_name: str = field()
+    gripper_group_name: Optional[str] = field(default=None)
+    end_effector_link: str = field(default="")
+    pose_reference_frame: str = field(default="")
+    planning_pipeline: str = field(default="")
+    planner_id: str = field(default="")
+    num_planning_attempts: int = field(default=5, validator=base_validators.gt(0))
+    allowed_planning_time: float = field(
+        default=5.0, validator=base_validators.gt(0.0)
+    )
+    max_velocity_scaling: float = field(
+        default=0.1, validator=base_validators.in_range(min_value=1e-3, max_value=1.0)
+    )
+    max_acceleration_scaling: float = field(
+        default=0.1, validator=base_validators.in_range(min_value=1e-3, max_value=1.0)
+    )
+    goal_position_tolerance: float = field(
+        default=1e-3, validator=base_validators.gt(0.0)
+    )
+    goal_orientation_tolerance: Union[float, List[float]] = field(default=1e-2)
+    goal_joint_tolerance: float = field(default=1e-3, validator=base_validators.gt(0.0))
+    cartesian_max_step: float = field(default=0.0025, validator=base_validators.gt(0.0))
+    cartesian_jump_threshold: float = field(default=0.0)
+    cartesian_avoid_collisions: bool = field(default=True)
+    cartesian_fraction_threshold: float = field(
+        default=0.95, validator=base_validators.in_range(min_value=0.0, max_value=1.0)
+    )
+    gripper_mode: Literal["move_group", "gripper_command"] = field(
+        default="move_group"
+    )
+    gripper_command_action: str = field(default="")
+    gripper_open_target: str = field(default="open")
+    gripper_close_target: str = field(default="close")
+    gripper_open_position: float = field(default=0.04)
+    gripper_close_position: float = field(default=0.0)
+    gripper_max_effort: float = field(default=0.0)
+    move_group_namespace: str = field(default="")
+    move_group_node_name: str = field(default="move_group")
+    named_targets: Optional[Dict] = field(default=None)
+    srdf_file: Optional[str] = field(default=None)
+    server_timeout: float = field(default=30.0, validator=base_validators.gt(0.0))
+    execution_timeout: float = field(default=120.0, validator=base_validators.gt(0.0))
+
+    @goal_orientation_tolerance.validator
+    def _check_orientation_tolerance(self, _, value):
+        """Orientation tolerance validator"""
+        if isinstance(value, (int, float)):
+            if value <= 0:
+                raise ValueError("goal_orientation_tolerance must be greater than 0")
+            return
+        if len(value) != 3 or any(v <= 0 for v in value):
+            raise ValueError(
+                "goal_orientation_tolerance must be a single positive value or "
+                "a list of 3 positive per-axis (x, y, z) values"
+            )
+
+    @gripper_command_action.validator
+    def _check_gripper_command_action(self, _, value):
+        """Gripper command action validator.
+
+        Defined on gripper_command_action (declared after gripper_mode)."""
+        if self.gripper_mode == "gripper_command" and not value:
+            raise ValueError(
+                "gripper_command_action must be set when gripper_mode is "
+                "'gripper_command' (e.g. '/gripper_controller/gripper_cmd')"
+            )
 
 
 @define(kw_only=True)

--- a/agents/config.py
+++ b/agents/config.py
@@ -319,6 +319,20 @@ class MLLMConfig(LLMConfig):
     :type ncpu_local_model: int
     :param local_model_path: HuggingFace repository ID for a GGUF VLM model (default: ``ggml-org/Qwen3-VL-2B-Instruct-GGUF``), a local directory with the GGUF and mmproj files, or a local path to a ``.gguf`` file. The VLM family (qwen_vl, gemma, moondream, minicpm, llava, llava16, nanollava) is detected from the model name. This parameter is only effective when ``enable_local_model`` is True.
     :type local_model_path: Optional[str]
+    :param detections_frame: Frame that 3D detections are published in, usually the frame the consumer plans in, e.g. "base_link". Boxes are axis aligned in this frame and it is chosen before they are measured, so it cannot be changed after the fact. Required when a Detections3D output topic is given. Only meaningful with the "grounding" or "affordance" task.
+    :type detections_frame: str
+    :param static_camera_tf: Whether the transform from the camera to `detections_frame` is fixed, which it is for a camera bolted to the robot. Set False for a camera that moves with a moving joint, so the transform keeps being looked up. Default is True.
+    :type static_camera_tf: bool
+    :param depth_scale: Multiplier from the depth image's units to millimeters, overriding what its encoding implies. Default is None, which derives it from the encoding.
+    :type depth_scale: Optional[float]
+    :param min_depth: Closest depth reading to treat as usable, in meters. Default is 0.05.
+    :type min_depth: float
+    :param max_depth: Furthest depth reading to treat as usable, in meters. Default is 5.0.
+    :type max_depth: float
+    :param max_depth_age: How far apart in time the color and depth frames may be before the pair is treated as mismatched, in seconds. Default is 0.2.
+    :type max_depth_age: float
+    :param min_depth_validity: Minimum fraction of usable depth pixels inside a detection's 2D box for its 3D box to be published, in [0, 1]. A box built from a handful of readings is not a shape, and a planner would take it for one. Default is 0.1.
+    :type min_depth_validity: float
 
     Example of usage:
     ```python
@@ -344,6 +358,31 @@ class MLLMConfig(LLMConfig):
     local_model_path: Optional[str] = field(
         default="ggml-org/Qwen3-VL-2B-Instruct-GGUF"
     )
+    # NOTE: 3D lift fields, kept identical to VisionConfig
+    detections_frame: str = field(default="")
+    static_camera_tf: bool = field(default=True)
+    depth_scale: Optional[float] = field(default=None)
+    min_depth: float = field(default=0.05, validator=base_validators.gt(0.0))
+    max_depth: float = field(default=5.0, validator=base_validators.gt(0.0))
+    max_depth_age: float = field(default=0.2, validator=base_validators.gt(0.0))
+    min_depth_validity: float = field(
+        default=0.1, validator=base_validators.in_range(min_value=0.0, max_value=1.0)
+    )
+    # serialized topics
+    _depth_topic: Optional[Topic] = field(
+        default=None, converter=_get_optional_topic, alias="_depth_topic"
+    )
+    _camera_info_topic: Optional[Topic] = field(
+        default=None, converter=_get_optional_topic, alias="_camera_info_topic"
+    )
+
+    @max_depth.validator
+    def _check_depth_range(self, _, value):
+        """A sensor cannot see further than it can see"""
+        if value <= self.min_depth:
+            raise ValueError(
+                f"max_depth ({value}) must be greater than min_depth ({self.min_depth})"
+            )
 
     @task.validator
     def _check_task(self, _, value):
@@ -756,6 +795,7 @@ class VisionConfig(ModelComponentConfig):
     local_classifier_model_path: str = field(
         default="https://github.com/automatika-robotics/embodied-agents/releases/download/0.3.3/deim_dfine_hgnetv2_n_coco_160e.onnx"
     )
+    # NOTE: 3D lift fields, kept identical to MLLMConfig
     detections_frame: str = field(default="")
     static_camera_tf: bool = field(default=True)
     depth_scale: Optional[float] = field(default=None)

--- a/agents/config.py
+++ b/agents/config.py
@@ -599,6 +599,8 @@ class MoveItConfig(BaseComponentConfig):
     :type touch_links: Optional[List[str]]
     :param approach_clearance: Height in meters above a pick or place target at which the collision-aware approach motion ends and the straight-line descent begins; also the height objects are lifted or retreated to. Default is 0.1.
     :type approach_clearance: float
+    :param target_match_radius: How far in meters a scene object may be from a pick goal's target_pose and still be taken as the intended target. Tighten for dense scenes, loosen for coarse target coordinates such as language-model guesses. Default is 0.2.
+    :type target_match_radius: float
 
     Example of usage:
     ```python
@@ -661,6 +663,7 @@ class MoveItConfig(BaseComponentConfig):
     min_object_thickness: float = field(default=0.01, validator=base_validators.gt(0.0))
     touch_links: Optional[List[str]] = field(default=None)
     approach_clearance: float = field(default=0.1, validator=base_validators.gt(0.0))
+    target_match_radius: float = field(default=0.2, validator=base_validators.gt(0.0))
 
     @goal_orientation_tolerance.validator
     def _check_orientation_tolerance(self, _, value):

--- a/agents/config.py
+++ b/agents/config.py
@@ -759,6 +759,13 @@ class VisionConfig(ModelComponentConfig):
     min_depth_validity: float = field(
         default=0.1, validator=base_validators.in_range(min_value=0.0, max_value=1.0)
     )
+    # serialized topics
+    _depth_topic: Optional[Topic] = field(
+        default=None, converter=_get_optional_topic, alias="_depth_topic"
+    )
+    _camera_info_topic: Optional[Topic] = field(
+        default=None, converter=_get_optional_topic, alias="_camera_info_topic"
+    )
 
     @max_depth.validator
     def _check_depth_range(self, _, value):

--- a/agents/config.py
+++ b/agents/config.py
@@ -624,7 +624,7 @@ class MoveItConfig(BaseComponentConfig):
     :type server_timeout: float
     :param execution_timeout: Maximum wall time in seconds for a single plan+execute goal. Default is 120.0.
     :type execution_timeout: float
-    :param scene_update_mode: WHEN detected objects are pushed into the planning scene: "manual" (default) only on the `update_planning_scene` component action, "on_goal" additionally refreshes the scene right before each motion goal is planned, "continuous" keeps refreshing at `scene_update_rate` while detections arrive. Only effective when the component is given a Detections3D input topic.
+    :param scene_update_mode: WHEN detected objects are pushed into the planning scene: "manual" (default) only on the `update_planning_scene` component action, "on_goal" additionally refreshes the scene right before each motion goal is planned, "continuous" keeps refreshing at `scene_update_rate` while detections arrive. Only effective when the component is given a Detections3D input topic. In every mode the scene freezes while an object is held. The first refresh after release reconciles the scene.
     :type scene_update_mode: Literal["manual", "on_goal", "continuous"]
     :param scene_update_rate: Scene refreshes per second in "continuous" mode. Default is 1.0.
     :type scene_update_rate: float

--- a/agents/config.py
+++ b/agents/config.py
@@ -597,6 +597,8 @@ class MoveItConfig(BaseComponentConfig):
     :type min_object_thickness: float
     :param touch_links: Links allowed to stay in contact with an attached object, e.g. the gripper's links. Default is None, which resolves them from the robot SRDF at attach time.
     :type touch_links: Optional[List[str]]
+    :param approach_clearance: Height in meters above a pick or place target at which the collision-aware approach motion ends and the straight-line descent begins; also the height objects are lifted or retreated to. Default is 0.1.
+    :type approach_clearance: float
 
     Example of usage:
     ```python
@@ -658,6 +660,7 @@ class MoveItConfig(BaseComponentConfig):
     )
     min_object_thickness: float = field(default=0.01, validator=base_validators.gt(0.0))
     touch_links: Optional[List[str]] = field(default=None)
+    approach_clearance: float = field(default=0.1, validator=base_validators.gt(0.0))
 
     @goal_orientation_tolerance.validator
     def _check_orientation_tolerance(self, _, value):

--- a/agents/config.py
+++ b/agents/config.py
@@ -661,6 +661,20 @@ class VisionConfig(ModelComponentConfig):
        :type ncpu_local_classifier: int
        :param local_classifier_model_path: Path or URL to the ONNX model used by the local classifier (default: DEIM, Huang et al. CVPR 2025). Other models based on [DEIM](https://github.com/ShihuaHuang95/DEIM?tab=readme-ov-file#deim-d-fine) can be checked [here](https://github.com/automatika-robotics/embodied-agents/releases/tag/0.3.3). This parameter is only effective when enable_local_classifier is set to True.
        :type local_classifier_model_path: str
+       :param detections_frame: Frame that 3D detections are published in, usually the frame the consumer plans in, e.g. "base_link". Boxes are axis aligned in this frame and it is chosen before they are measured, so it cannot be changed after the fact. Required when a Detections3D output topic is given.
+       :type detections_frame: str
+       :param static_camera_tf: Whether the transform from the camera to `detections_frame` is fixed, which it is for a camera bolted to the robot. Set False for a camera that moves with a moving joint, so the transform keeps being looked up. Default is True.
+       :type static_camera_tf: bool
+       :param depth_scale: Multiplier from the depth image's units to millimeters, overriding what its encoding implies. Default is None, which derives it from the encoding.
+       :type depth_scale: Optional[float]
+       :param min_depth: Closest depth reading to treat as usable, in meters. Default is 0.05.
+       :type min_depth: float
+       :param max_depth: Furthest depth reading to treat as usable, in meters. Default is 5.0.
+       :type max_depth: float
+       :param max_depth_age: How far apart in time the color and depth frames may be before the pair is treated as mismatched, in seconds. Only applies to depth arriving on its own topic, since an RGBD frame carries both halves together. Default is 0.2.
+       :type max_depth_age: float
+       :param min_depth_validity: Minimum fraction of usable depth pixels inside a detection's 2D box for its 3D box to be published, in [0, 1]. A box built from a handful of readings is not a shape, and a planner would take it for one. Default is 0.1.
+       :type min_depth_validity: float
 
        Example of usage:
        ```python
@@ -683,6 +697,23 @@ class VisionConfig(ModelComponentConfig):
     local_classifier_model_path: str = field(
         default="https://github.com/automatika-robotics/embodied-agents/releases/download/0.3.3/deim_dfine_hgnetv2_n_coco_160e.onnx"
     )
+    detections_frame: str = field(default="")
+    static_camera_tf: bool = field(default=True)
+    depth_scale: Optional[float] = field(default=None)
+    min_depth: float = field(default=0.05, validator=base_validators.gt(0.0))
+    max_depth: float = field(default=5.0, validator=base_validators.gt(0.0))
+    max_depth_age: float = field(default=0.2, validator=base_validators.gt(0.0))
+    min_depth_validity: float = field(
+        default=0.1, validator=base_validators.in_range(min_value=0.0, max_value=1.0)
+    )
+
+    @max_depth.validator
+    def _check_depth_range(self, _, value):
+        """A sensor cannot see further than it can see"""
+        if value <= self.min_depth:
+            raise ValueError(
+                f"max_depth ({value}) must be greater than min_depth ({self.min_depth})"
+            )
 
     def _get_inference_params(self) -> Dict:
         """get_inference_params.

--- a/agents/config.py
+++ b/agents/config.py
@@ -630,6 +630,8 @@ class MoveItConfig(BaseComponentConfig):
     :type scene_update_mode: Literal["manual", "on_goal", "continuous"]
     :param scene_update_rate: Scene refreshes per second in "continuous" mode. Default is 1.0.
     :type scene_update_rate: float
+    :param scene_detection_labels: Detection labels allowed into the planning scene. Default is None, which admits every label.
+    :type scene_detection_labels: Optional[List[str]]
     :param scene_object_ttl: Seconds a detection-sourced object stays in the scene after the detector stops reporting it, before a refresh removes it. Bridges detection dropouts without keeping ghost obstacles around. Default is 5.0.
     :type scene_object_ttl: float
     :param object_padding: Margin in meters added on every side of detected objects, for planning clearance around imperfectly measured geometry. Default is 0.0.
@@ -698,6 +700,7 @@ class MoveItConfig(BaseComponentConfig):
         validator=base_validators.in_(["manual", "on_goal", "continuous"]),
     )
     scene_update_rate: float = field(default=1.0, validator=base_validators.gt(0.0))
+    scene_detection_labels: Optional[List[str]] = field(default=None)
     scene_object_ttl: float = field(default=5.0, validator=base_validators.gt(0.0))
     object_padding: float = field(
         default=0.0, validator=base_validators.in_range(min_value=0.0, max_value=1.0)

--- a/agents/models.py
+++ b/agents/models.py
@@ -609,9 +609,16 @@ class LeRobotPolicy(Model):
     checkpoint: str = field(default="lerobot/smolvla_base")
     policy_type: Literal[
         "smolvla", "diffusion", "act", "pi0", "pi05", "groot", "tdmpc", "vqbet"
-    ] = field(default="smolvla")
+    ] = field(
+        default="smolvla",
+        validator=base_validators.in_(
+            ["smolvla", "diffusion", "act", "pi0", "pi05", "groot", "tdmpc", "vqbet"]
+        ),
+    )
     actions_per_chunk: int = field(default=50)
-    policy_device: Literal["cpu", "cuda"] = field(default="cuda")
+    policy_device: Literal["cpu", "cuda"] = field(
+        default="cuda", validator=base_validators.in_(["cpu", "cuda"])
+    )
     dataset_info_file: Optional[str] = field(default=None)
     rename_map: Dict[str, str] = field(default=Factory(dict))
     _features: Dict = field(

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -9,6 +9,7 @@ from rclpy.logging import get_logger
 
 from sensor_msgs.msg import JointState as JointStateROS
 from geometry_msgs.msg import Pose as ROSPose
+from geometry_msgs.msg import PoseStamped as ROSPoseStamped
 from shape_msgs.msg import SolidPrimitive
 
 # FROM SUGARCOAT
@@ -149,6 +150,7 @@ __all__ = [
     "read_camera_info",
     "Empty",
     "ROSPose",
+    "ROSPoseStamped",
     "SolidPrimitive",
     "ServiceClientConfig",
     "ServiceClientHandler",

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -55,6 +55,7 @@ from ros_sugar.base_clients import (
     ServiceClientConfig,
     ServiceClientHandler,
 )
+from ros_sugar.io.datatypes import read_camera_info
 
 from .launcher import Launcher
 
@@ -142,6 +143,7 @@ __all__ = [
     "MoveManipulator",
     "GetParameters",
     "run_external_processor",
+    "read_camera_info",
     "ServiceClientConfig",
     "ServiceClientHandler",
     "ActionClientConfig",

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -14,6 +14,7 @@ from ros_sugar.supported_types import (
     SupportedType,
     Audio,
     Bool,
+    CameraInfo,
     Image,
     CompressedImage,
     OccupancyGrid,
@@ -65,8 +66,10 @@ from rcl_interfaces.srv import GetParameters
 from automatika_embodied_agents.msg import (
     Point2D,
     Bbox2D,
+    Bbox3D as ROSBbox3D,
     Detections2D,
     Detections2DMultiSource,
+    Detections3D as ROSDetections3D,
 )
 from automatika_embodied_agents.msg import (
     StreamingString as ROSStreamingString,
@@ -78,6 +81,7 @@ from automatika_embodied_agents.msg import (
 from automatika_embodied_agents.action import MoveManipulator, VisionLanguageAction
 from .callbacks import (
     DetectionsCallback,
+    Detections3DCallback,
     DetectionsMultiSourceCallback,
     PointsOfInterestCallback,
     RGBDCallback,
@@ -94,6 +98,7 @@ __all__ = [
     "Video",
     "Audio",
     "Bool",
+    "CameraInfo",
     "Image",
     "CompressedImage",
     "OccupancyGrid",
@@ -103,6 +108,7 @@ __all__ = [
     "PoseArray",
     "PoseStamped",
     "Detections",
+    "Detections3D",
     "DetectionsMultiSource",
     "PointsOfInterest",
     "Trackings",
@@ -399,6 +405,60 @@ class DetectionsMultiSource(SupportedType):
         for img, detection in zip(images, output):
             detections.append(Detections.convert(detection, img))
         msg.detections = detections
+        return msg
+
+
+class Detections3D(SupportedType):
+    """
+    Wraps the `automatika_embodied_agents.msg.Detections3D` message type.
+
+    This type represents detected objects in metric space, each with a
+    labelled 3D bounding box in a named frame rather than in image space.
+
+    **ROS2 Message Type**: `automatika_embodied_agents/msg/Detections3D`
+    """
+
+    _ros_type = ROSDetections3D
+    callback = Detections3DCallback
+
+    @classmethod
+    def convert(
+        cls,
+        output: List,
+        labels: Optional[List[str]] = None,
+        scores: Optional[List[float]] = None,
+        depth_validity: Optional[List[float]] = None,
+        boxes_2d: Optional[List] = None,
+        source_frame: str = "",
+        **_,
+    ) -> ROSDetections3D:
+        """
+        Takes 3D object detections and converts them into a ROS message
+        of type Detections3D
+
+        :param output: Boxes as (center, size) pairs, each in meters
+        :return: Detections3D
+        """
+        msg = ROSDetections3D()
+        boxes = []
+        for center, size in output:
+            box = ROSBbox3D()
+            box.center.position.x = float(center[0])
+            box.center.position.y = float(center[1])
+            box.center.position.z = float(center[2])
+            # Boxes are axis aligned in the frame they are given in
+            box.center.orientation.w = 1.0
+            box.size.x = float(size[0])
+            box.size.y = float(size[1])
+            box.size.z = float(size[2])
+            boxes.append(box)
+
+        msg.boxes = boxes
+        msg.labels = labels or []
+        msg.scores = [float(score) for score in scores or []]
+        msg.depth_validity = [float(value) for value in depth_validity or []]
+        msg.boxes_2d = boxes_2d or []
+        msg.source_frame = source_frame
         return msg
 
 
@@ -758,6 +818,7 @@ agent_types = [
     StreamingString,
     Video,
     Detections,
+    Detections3D,
     DetectionsMultiSource,
     Trackings,
     TrackingsMultiSource,

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -352,25 +352,24 @@ class Detections(SupportedType):
     @classmethod
     def convert(
         cls,
-        output: Union[Dict, List[Dict]],
-        images: Union[
-            ROSImage,
-            ROSCompressedImage,
-            np.ndarray,
-            List[ROSImage],
-            List[ROSCompressedImage],
-            List[np.ndarray],
-        ],
+        output: Dict,
+        images: Union[ROSImage, ROSCompressedImage, np.ndarray, None] = None,
         **_,
     ) -> Detections2D:
         """
-        Takes object detection data and converts it into a ROS message
-        of type Detection2D
+        Takes one camera's object detection data and converts it into a ROS
+        message of type Detection2D
+
+        :param output: Detections found in a single image
+        :param images: The image they were found in
         :return: Detection2D
         """
         if isinstance(output, List):
-            output = output[0]
-            images = images[0] if images else []
+            raise TypeError(
+                "Detections2D describes a single camera and cannot carry "
+                "detections from several. Use a Detections2DMultiSource output "
+                "topic for a component that detects on more than one image."
+            )
         msg = Detections2D()
         msg.scores = output.get("scores") or []
         msg.labels = output.get("labels") or []
@@ -526,26 +525,24 @@ class Trackings(SupportedType):
     @classmethod
     def convert(
         cls,
-        output: Union[Dict, List[Dict]],
-        images: Union[
-            ROSImage,
-            ROSCompressedImage,
-            np.ndarray,
-            List[ROSImage],
-            List[ROSCompressedImage],
-            List[np.ndarray],
-        ],
+        output: Dict,
+        images: Union[ROSImage, ROSCompressedImage, np.ndarray, None] = None,
         **_,
     ) -> ROSTrackings:
         """
-        Takes tracking data and converts it into a ROS message
+        Takes one camera's tracking data and converts it into a ROS message
         of type Tracking
+
+        :param output: Tracks found in a single image
+        :param images: The image they were found in
         :return: ROSTracking
         """
-        # Only consider the first datapoint if a list is sent
         if isinstance(output, List):
-            output = output[0]
-            images = images[0]
+            raise TypeError(
+                "Trackings describes a single camera and cannot carry tracks "
+                "from several. Use a TrackingsMultiSource output topic for a "
+                "component that tracks in more than one image."
+            )
         msg = ROSTrackings()
         msg.ids = output.get("ids") or []
         msg.labels = output.get("tracked_labels") or []

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -64,6 +64,7 @@ from .launcher import Launcher
 # SUGATCOAT INTERFACES
 from automatika_ros_sugar.srv import ExecuteMethod
 from rcl_interfaces.srv import GetParameters
+from std_srvs.srv import Empty
 
 # AGENTS TYPES
 from automatika_embodied_agents.msg import (
@@ -146,6 +147,7 @@ __all__ = [
     "GetParameters",
     "run_external_processor",
     "read_camera_info",
+    "Empty",
     "ROSPose",
     "SolidPrimitive",
     "ServiceClientConfig",

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -293,6 +293,32 @@ class Video(SupportedType):
         return msg
 
 
+def _attach_source_image(msg: Any, image: Any) -> None:
+    """Attach a source image (and its depth, if any) to a perception message.
+    Also copies the image's header onto the message, so the detections carry
+    the frame they were made in.
+
+    :param msg: Perception message with image/compressed_image/depth fields
+    :param image: Source ROS image message (Image, CompressedImage or RGBD)
+    """
+    if image is None:
+        return
+    if isinstance(image, ROSCompressedImage):
+        msg.compressed_image = CompressedImage.convert(image)
+        source = image
+    # Handle RealSense RGBD msgs
+    elif hasattr(image, "depth"):
+        msg.image = Image.convert(image.rgb)
+        msg.depth = Image.convert(image.depth)
+        source = image.rgb
+    else:
+        msg.image = Image.convert(image)
+        source = image
+
+    if hasattr(source, "header") and hasattr(msg, "header"):
+        msg.header = source.header
+
+
 class Detections(SupportedType):
     """
     Wraps the `automatika_embodied_agents.msg.Detections2D` message type.
@@ -343,14 +369,7 @@ class Detections(SupportedType):
 
         msg.boxes = boxes
         if images:
-            if isinstance(images, ROSCompressedImage):
-                msg.compressed_image = CompressedImage.convert(images)
-            # Handle RealSense RGBD msgs
-            elif hasattr(images, "depth"):
-                msg.image = Image.convert(images.rgb)
-                msg.depth = Image.convert(images.depth)
-            else:
-                msg.image = Image.convert(images)
+            _attach_source_image(msg, images)
         return msg
 
 
@@ -418,14 +437,7 @@ class PointsOfInterest(SupportedType):
             points.append(point)
         msg.points = points
 
-        if isinstance(image, ROSCompressedImage):
-            msg.compressed_image = CompressedImage.convert(image)
-        # Handle RealSense RGBD msgs
-        elif hasattr(image, "depth"):
-            msg.image = Image.convert(image.rgb)
-            msg.depth = Image.convert(image.depth)
-        else:
-            msg.image = Image.convert(image)
+        _attach_source_image(msg, image)
         return msg
 
 
@@ -500,14 +512,7 @@ class Trackings(SupportedType):
         msg.boxes = tracked_boxes
         msg.centroids = centroids
         msg.estimated_velocities = estimated_velocities
-        if isinstance(images, ROSCompressedImage):
-            msg.compressed_image = CompressedImage.convert(images)
-        # Handle RealSense RGBD msgs
-        elif hasattr(images, "depth"):
-            msg.image = Image.convert(images.rgb)
-            msg.depth = Image.convert(images.depth)
-        else:
-            msg.image = Image.convert(images)
+        _attach_source_image(msg, images)
         return msg
 
 

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -19,7 +19,9 @@ from ros_sugar.supported_types import (
     OccupancyGrid,
     Odometry,
     PointCloud2,
+    Pose,
     PoseArray,
+    PoseStamped,
     String,
     ROSImage,
     ROSCompressedImage,
@@ -46,12 +48,18 @@ from ros_sugar.utils import (
 from ros_sugar.io.utils import run_external_processor
 from ros_sugar.core import Event, Action
 from ros_sugar import actions
-from ros_sugar.base_clients import ServiceClientHandler, ActionClientHandler
+from ros_sugar.base_clients import (
+    ActionClientConfig,
+    ActionClientHandler,
+    ServiceClientConfig,
+    ServiceClientHandler,
+)
 
 from .launcher import Launcher
 
 # SUGATCOAT INTERFACES
 from automatika_ros_sugar.srv import ExecuteMethod
+from rcl_interfaces.srv import GetParameters
 
 # AGENTS TYPES
 from automatika_embodied_agents.msg import (
@@ -67,7 +75,7 @@ from automatika_embodied_agents.msg import (
     TrackingsMultiSource as ROSTrackingsMultiSource,
     PointsOfInterest as ROSPointsOfInterest,
 )
-from automatika_embodied_agents.action import VisionLanguageAction
+from automatika_embodied_agents.action import MoveManipulator, VisionLanguageAction
 from .callbacks import (
     DetectionsCallback,
     DetectionsMultiSourceCallback,
@@ -91,7 +99,9 @@ __all__ = [
     "OccupancyGrid",
     "Odometry",
     "PointCloud2",
+    "Pose",
     "PoseArray",
+    "PoseStamped",
     "Detections",
     "DetectionsMultiSource",
     "PointsOfInterest",
@@ -123,8 +133,12 @@ __all__ = [
     "component_fallback",
     "component_action",
     "VisionLanguageAction",
+    "MoveManipulator",
+    "GetParameters",
     "run_external_processor",
+    "ServiceClientConfig",
     "ServiceClientHandler",
+    "ActionClientConfig",
     "ActionClientHandler",
     "get_ros_msg_fields_dict",
     "ros_msg_to_str",

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -8,6 +8,8 @@ from importlib.util import find_spec
 from rclpy.logging import get_logger
 
 from sensor_msgs.msg import JointState as JointStateROS
+from geometry_msgs.msg import Pose as ROSPose
+from shape_msgs.msg import SolidPrimitive
 
 # FROM SUGARCOAT
 from ros_sugar.supported_types import (
@@ -144,6 +146,8 @@ __all__ = [
     "GetParameters",
     "run_external_processor",
     "read_camera_info",
+    "ROSPose",
+    "SolidPrimitive",
     "ServiceClientConfig",
     "ServiceClientHandler",
     "ActionClientConfig",

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -378,8 +378,7 @@ class Detections(SupportedType):
             boxes.append(_to_bbox_2d(bbox))
 
         msg.boxes = boxes
-        if images:
-            _attach_source_image(msg, images)
+        _attach_source_image(msg, images)
         return msg
 
 

--- a/agents/ros.py
+++ b/agents/ros.py
@@ -299,6 +299,16 @@ class Video(SupportedType):
         return msg
 
 
+def _to_bbox_2d(bbox: Any) -> Bbox2D:
+    """Build a Bbox2D message from an (x1, y1, x2, y2) box in pixels"""
+    box = Bbox2D()
+    box.top_left_x = float(bbox[0])
+    box.top_left_y = float(bbox[1])
+    box.bottom_right_x = float(bbox[2])
+    box.bottom_right_y = float(bbox[3])
+    return box
+
+
 def _attach_source_image(msg: Any, image: Any) -> None:
     """Attach a source image (and its depth, if any) to a perception message.
     Also copies the image's header onto the message, so the detections carry
@@ -366,12 +376,7 @@ class Detections(SupportedType):
         msg.labels = output.get("labels") or []
         boxes = []
         for bbox in output.get("bboxes") or []:
-            box = Bbox2D()
-            box.top_left_x = float(bbox[0])
-            box.top_left_y = float(bbox[1])
-            box.bottom_right_x = float(bbox[2])
-            box.bottom_right_y = float(bbox[3])
-            boxes.append(box)
+            boxes.append(_to_bbox_2d(bbox))
 
         msg.boxes = boxes
         if images:
@@ -457,7 +462,11 @@ class Detections3D(SupportedType):
         msg.labels = labels or []
         msg.scores = [float(score) for score in scores or []]
         msg.depth_validity = [float(value) for value in depth_validity or []]
-        msg.boxes_2d = boxes_2d or []
+        # The 2D boxes come through as plain pixel tuples from the detector
+        msg.boxes_2d = [
+            box if isinstance(box, Bbox2D) else _to_bbox_2d(box)
+            for box in boxes_2d or []
+        ]
         msg.source_frame = source_frame
         return msg
 
@@ -562,12 +571,7 @@ class Trackings(SupportedType):
         # tracked_bboxes: list of [x1, y1, x2, y2] bounding boxes
         if o_tracked_bboxes := output.get("tracked_bboxes"):
             for bbox in o_tracked_bboxes:
-                box = Bbox2D()
-                box.top_left_x = float(bbox[0])
-                box.top_left_y = float(bbox[1])
-                box.bottom_right_x = float(bbox[2])
-                box.bottom_right_y = float(bbox[3])
-                tracked_boxes.append(box)
+                tracked_boxes.append(_to_bbox_2d(bbox))
 
         msg.boxes = tracked_boxes
         msg.centroids = centroids

--- a/agents/ui_elements.py
+++ b/agents/ui_elements.py
@@ -1,5 +1,6 @@
 from .ros import (
     Detections,
+    Detections3D,
     DetectionsMultiSource,
     PointsOfInterest,
     RGBD,
@@ -32,6 +33,8 @@ OUTPUT_ELEMENTS = {
     DetectionsMultiSource: _out_image_element,
     PointsOfInterest: _out_image_element,
     RGBD: _out_image_element,
+    # 3D detections dont have an image; displayed as text
+    Detections3D: _log_text_element,
 }
 
 INPUT_ELEMENTS = {}

--- a/agents/utils/__init__.py
+++ b/agents/utils/__init__.py
@@ -17,6 +17,8 @@ from .utils import (
     build_url,
     build_lerobot_features_from_dataset_info,
     find_missing_values,
+    get_frame_id,
+    get_stamp_secs,
     _LANGUAGE_CODES,
 )
 
@@ -26,6 +28,8 @@ __all__ = [
     "build_url",
     "find_missing_values",
     "flatten",
+    "get_frame_id",
+    "get_stamp_secs",
     "create_detection_context",
     "draw_detection_bounding_boxes",
     "draw_points_2d",

--- a/agents/utils/moveit.py
+++ b/agents/utils/moveit.py
@@ -24,6 +24,10 @@ _MOVEIT_INSTALL_HINT = (
 # Parameter of the move_group node that carries the robot SRDF
 SRDF_PARAMETER = "robot_description_semantic"
 
+# =========================================================================
+# General Utils
+# =========================================================================
+
 
 class MoveMode(str, Enum):
     """Kinds of motion target accepted in a manipulation goal.
@@ -124,7 +128,8 @@ def pose_to_constraints(
         OrientationConstraint,
         PositionConstraint,
     )
-    from shape_msgs.msg import SolidPrimitive
+
+    from ..ros import SolidPrimitive
 
     constraints = Constraints()
 
@@ -353,3 +358,308 @@ def moveit_error_string(code: int) -> str:
         if name.isupper() and isinstance(value, int)
     }
     return names.get(code, f"UNKNOWN_ERROR({code})")
+
+
+# =========================================================================
+# Planning scene
+# =========================================================================
+
+# Prefix namespacing collision objects that came from detections, so clearing
+# them leaves manually added objects alone
+DETECTION_ID_PREFIX = "det__"
+
+
+def object_id_for(label: str, rank: int, prefix: str = DETECTION_ID_PREFIX) -> str:
+    """Scene id of a detected object, e.g. ``det__orange_0``.
+
+    :param label: Detection label
+    :param rank: Position among same-labelled objects, by descending score
+    :param prefix: Namespace marking the object as detection-sourced
+    """
+    clean = (label or "object").strip().replace(" ", "_")
+    return f"{prefix}{clean}_{rank}"
+
+
+def build_collision_object(
+    object_id: str,
+    frame_id: str,
+    center: Any,
+    size: Sequence[float],
+    min_thickness: float = 0.01,
+) -> Any:
+    """A box-shaped collision object MoveIt can plan around.
+
+    The object is expressed directly in ``frame_id`` with a zero timestamp,
+    which move_group takes as-is without a TF lookup, so objects should be built
+    objects in the planning frame. Re-adding an existing id moves the object.
+
+    :param object_id: Scene-wide identifier
+    :param frame_id: Frame the center is given in, normally the planning frame
+    :param center: geometry_msgs Pose, or an (x, y, z) position for an
+        axis-aligned box
+    :param size: Full extents of the box in meters
+    :param min_thickness: Floor for each extent. A fronto-parallel surface is
+        lifted with no measurable extent along the view axis, and a zero
+        thickness box is invisible to collision checking
+    :returns: moveit_msgs CollisionObject with operation ADD
+    """
+    ensure_moveit_msgs()
+    from moveit_msgs.msg import CollisionObject
+
+    from ..ros import ROSPose, SolidPrimitive
+
+    pose = ROSPose()
+    if hasattr(center, "position"):
+        pose.position.x = center.position.x
+        pose.position.y = center.position.y
+        pose.position.z = center.position.z
+        source = center.orientation
+        if any((source.x, source.y, source.z, source.w)):
+            pose.orientation.x = source.x
+            pose.orientation.y = source.y
+            pose.orientation.z = source.z
+            pose.orientation.w = source.w
+        else:
+            # All zeros is not a rotation and MoveIt rejects it
+            pose.orientation.w = 1.0
+    else:
+        pose.position.x, pose.position.y, pose.position.z = (
+            float(value) for value in center
+        )
+        # A bare Pose carries the same all-zero quaternion
+        pose.orientation.w = 1.0
+
+    obj = CollisionObject()
+    obj.id = object_id
+    obj.header.frame_id = frame_id  # stamp stays zero to avoid TF lookup in move_group
+    obj.primitives.append(
+        SolidPrimitive(
+            type=SolidPrimitive.BOX,
+            dimensions=[max(float(extent), min_thickness) for extent in size],
+        )
+    )
+    obj.primitive_poses.append(pose)
+    obj.operation = CollisionObject.ADD  # an octet field: use the constants
+    return obj
+
+
+def build_remove_object(object_id: str) -> Any:
+    """An instruction taking one object out of the planning scene.
+
+    :param object_id: Id the object was added under
+    :returns: moveit_msgs CollisionObject with operation REMOVE
+    """
+    ensure_moveit_msgs()
+    from moveit_msgs.msg import CollisionObject
+
+    obj = CollisionObject()
+    obj.id = object_id
+    obj.operation = CollisionObject.REMOVE
+    return obj
+
+
+def build_scene_diff(
+    collision_objects: Sequence[Any] = (),
+    attached_objects: Sequence[Any] = (),
+) -> Any:
+    """Wrap scene changes as one diff against move_group's current scene.
+
+    A diff only touches what it carries. The robot state is marked as a diff too.
+    Without that, applying the scene would overwrite the state move_group is monitoring.
+
+    :param collision_objects: World objects to add, move or remove
+    :param attached_objects: Objects to attach to or detach from the robot
+    :returns: moveit_msgs PlanningScene diff
+    """
+    ensure_moveit_msgs()
+    from moveit_msgs.msg import PlanningScene
+
+    scene = PlanningScene()
+    scene.is_diff = True
+    scene.robot_state.is_diff = True
+    scene.world.collision_objects.extend(collision_objects)
+    scene.robot_state.attached_collision_objects.extend(attached_objects)
+    return scene
+
+
+def collision_objects_from_detections(
+    detections: Any,
+    *,
+    min_thickness: float = 0.01,
+    padding: float = 0.0,
+    id_prefix: str = DETECTION_ID_PREFIX,
+) -> List[Any]:
+    """Turn a Detections3D message into collision objects.
+
+    Ranks in IDs counted per label by descending score, so on a static scene
+    the same object keeps the same id from one refresh to the next without needing
+    a tracker.
+
+    Boxes are used in the planning frame (already transformed).
+
+    :param detections: Detections3D message
+    :param min_thickness: Floor for each box extent in meters
+    :param padding: Margin added on every side of every box in meters, for
+        planning clearance around imperfectly measured objects
+    :returns: moveit_msgs CollisionObjects with operation ADD
+    """
+    frame = detections.header.frame_id
+    labels = list(detections.labels)
+    scores = list(detections.scores)
+    entries = []
+    for index, box in enumerate(detections.boxes):
+        entries.append((
+            labels[index] if index < len(labels) else "",
+            scores[index] if index < len(scores) else 0.0,
+            box,
+        ))
+
+    objects = []
+    ranks: Dict[str, int] = {}
+    for label, _, box in sorted(entries, key=lambda entry: -entry[1]):
+        rank = ranks.get(label, 0)
+        ranks[label] = rank + 1
+        objects.append(
+            build_collision_object(
+                object_id_for(label, rank, prefix=id_prefix),
+                frame,
+                box.center,
+                (
+                    box.size.x + 2 * padding,
+                    box.size.y + 2 * padding,
+                    box.size.z + 2 * padding,
+                ),
+                min_thickness=min_thickness,
+            )
+        )
+    return objects
+
+
+def build_attached_object(
+    object_id: str, link_name: str, touch_links: Sequence[str] = ()
+) -> Any:
+    """Attach a scene object to a robot link, as on a grasp.
+
+    NOTE: Attaching by id moves an object already in the scene: move_group removes
+    it from the world and carries it with the link, excluding contact with
+    the ``touch_links`` from collision checking. With the wrong touch links
+    the first motion after a grasp fails on a collision between gripper and
+    held object.
+
+    :param object_id: Id of an object already in the planning scene
+    :param link_name: Link the object is rigidly attached to
+    :param touch_links: Links allowed to stay in contact with the object
+    :returns: moveit_msgs AttachedCollisionObject
+    """
+    ensure_moveit_msgs()
+    from moveit_msgs.msg import AttachedCollisionObject, CollisionObject
+
+    attached = AttachedCollisionObject()
+    attached.link_name = link_name
+    attached.object.id = object_id
+    attached.object.operation = CollisionObject.ADD
+    attached.touch_links = list(touch_links)
+    return attached
+
+
+def build_detach_object(object_id: str, link_name: str = "") -> Any:
+    """Detach an attached object, returning it to the world.
+
+    :param object_id: Id the object was attached under
+    :param link_name: Link holding the object; empty searches every link
+    :returns: moveit_msgs AttachedCollisionObject with operation REMOVE
+    """
+    ensure_moveit_msgs()
+    from moveit_msgs.msg import AttachedCollisionObject, CollisionObject
+
+    attached = AttachedCollisionObject()
+    attached.link_name = link_name
+    attached.object.id = object_id
+    attached.object.operation = CollisionObject.REMOVE
+    return attached
+
+
+def derive_touch_links(
+    srdf: Optional[Union[str, ET.Element]],
+    end_effector_link: str,
+    gripper_group: str = "",
+    explicit: Optional[Sequence[str]] = None,
+    logger_name: str = "moveit",
+) -> List[str]:
+    """Resolve the links allowed to stay in contact with a grasped object.
+
+    CAUTION: Once an object is attached it is in permanent contact with the gripper, and
+    any gripper link missing from this list makes every subsequent motion start in
+    collision.
+
+    Resolution order:
+
+    1. An explicitly configured list is used as given.
+    2. ``<link>`` entries of the SRDF gripper group, the declarative source.
+    3. The SRDF end effector's parent link plus its ``Adjacent``
+       ``disable_collisions`` partners. This is a heuristic: it finds jaws
+       attached directly to the parent link but misses links one joint
+       further out, so a joint-only gripper group is better served by adding
+       its links to the SRDF or to the config.
+    4. The end effector link alone, with a warning.
+
+    :param srdf: SRDF document content, or an already parsed XML root
+    :param end_effector_link: Configured end-effector link, the last resort
+    :param gripper_group: SRDF group of the gripper, used to pick its links
+        and its end effector entry
+    :param explicit: Configured touch links, trusted as given
+    :param logger_name: Name of the logger to report the fallback on
+    :returns: Link names, deduplicated, order preserved
+    """
+    if explicit:
+        return list(dict.fromkeys(explicit))
+
+    root = None
+    if srdf is not None:
+        try:
+            root = ET.fromstring(srdf) if isinstance(srdf, str) else srdf
+        except ET.ParseError as e:
+            get_logger(logger_name).warning(f"Could not parse the robot SRDF: {e}")
+
+    if root is not None:
+        if gripper_group:
+            links = [
+                link.get("name")
+                for group in root.iter("group")
+                if group.get("name") == gripper_group
+                for link in group.iter("link")
+                if link.get("name")
+            ]
+            if links:
+                return list(dict.fromkeys(links))
+
+        parent = next(
+            (
+                eef.get("parent_link")
+                for eef in root.iter("end_effector")
+                if not gripper_group or eef.get("group") == gripper_group
+            ),
+            None,
+        )
+        if parent:
+            # NOTE:Only pairs disabled for being physically connected say anything
+            # about the gripper's shape; "Never" pairs span the whole robot
+            partners = []
+            for pair in root.iter("disable_collisions"):
+                if (pair.get("reason") or "").lower() != "adjacent":
+                    continue
+                link1, link2 = pair.get("link1"), pair.get("link2")
+                if parent == link1 and link2:
+                    partners.append(link2)
+                elif parent == link2 and link1:
+                    partners.append(link1)
+            if partners:
+                return list(dict.fromkeys([parent, *partners]))
+
+    get_logger(logger_name).warning(
+        "Could not resolve the gripper's links from the SRDF, so only "
+        f"'{end_effector_link}' may touch an attached object. If grasping "
+        "fails on a collision between gripper and object, list the gripper "
+        "links in the SRDF gripper group or in the component config."
+    )
+    return [end_effector_link]

--- a/agents/utils/moveit.py
+++ b/agents/utils/moveit.py
@@ -1,0 +1,252 @@
+"""Utilities for building MoveIt 2 requests from plain targets.
+
+MoveIt's move_group node accepts motion targets only as constraint sets
+(``moveit_msgs/Constraints``). These helpers do the same message
+construction that MoveIt's C++ MoveGroupInterface performs client side, so
+no MoveIt python bindings are required. MoveIt message definitions are imported
+lazily.
+"""
+
+import xml.etree.ElementTree as ET
+from importlib.util import find_spec
+from typing import Any, Dict, Iterable, List, Sequence, Union
+
+_MOVEIT_INSTALL_HINT = (
+    "'moveit_msgs' module is required to use the MoveIt component but it is "
+    "not installed. Please install the 'ros-<distro>-moveit-msgs' package."
+)
+
+
+def ensure_moveit_msgs() -> None:
+    """Raise an actionable error when moveit_msgs is unavailable."""
+    if find_spec("moveit_msgs") is None:
+        raise ModuleNotFoundError(_MOVEIT_INSTALL_HINT)
+
+
+def pose_to_constraints(
+    target_pose: Any,
+    link_name: str,
+    position_tolerance: float,
+    orientation_tolerance: Union[float, Sequence[float]],
+) -> Any:
+    """Express an end-effector pose target as a MoveIt constraint set.
+
+    The position target becomes a spherical constraint region of radius
+    ``position_tolerance`` centered at the target point; the orientation
+    target is constrained per axis by ``orientation_tolerance``.
+
+    :param target_pose: geometry_msgs PoseStamped target
+    :param link_name: End-effector link the constraints apply to
+    :param position_tolerance: Position tolerance in meters
+    :param orientation_tolerance: Orientation tolerance in radians — a single
+        value applied to all axes, or a sequence of 3 per-axis values
+        (x, y, z). Relaxing a single axis (e.g. z to ~pi) makes many poses
+        reachable for underactuated (e.g. 5-DOF) arms and rotationally
+        symmetric tools
+    :returns: moveit_msgs Constraints
+    """
+    if isinstance(orientation_tolerance, (int, float)):
+        axis_tolerances = (float(orientation_tolerance),) * 3
+    else:
+        axis_tolerances = tuple(float(value) for value in orientation_tolerance)
+        if len(axis_tolerances) != 3:
+            raise ValueError(
+                "orientation_tolerance must be a single value or a sequence "
+                f"of 3 per-axis (x, y, z) values, got {len(axis_tolerances)}"
+            )
+    ensure_moveit_msgs()
+    from moveit_msgs.msg import (
+        BoundingVolume,
+        Constraints,
+        OrientationConstraint,
+        PositionConstraint,
+    )
+    from shape_msgs.msg import SolidPrimitive
+
+    constraints = Constraints()
+
+    position = PositionConstraint()
+    position.header = target_pose.header
+    position.link_name = link_name
+    region = BoundingVolume()
+    region.primitives.append(
+        SolidPrimitive(type=SolidPrimitive.SPHERE, dimensions=[position_tolerance])
+    )
+    region.primitive_poses.append(target_pose.pose)
+    position.constraint_region = region
+    position.weight = 1.0  # hard constraint
+    constraints.position_constraints.append(position)
+
+    orientation = OrientationConstraint()
+    orientation.header = target_pose.header
+    orientation.link_name = link_name
+    orientation.orientation = target_pose.pose.orientation
+    orientation.absolute_x_axis_tolerance = axis_tolerances[0]
+    orientation.absolute_y_axis_tolerance = axis_tolerances[1]
+    orientation.absolute_z_axis_tolerance = axis_tolerances[2]
+    orientation.weight = 1.0  # hard constraint
+    constraints.orientation_constraints.append(orientation)
+
+    return constraints
+
+
+def joints_to_constraints(joint_positions: Dict[str, float], tolerance: float) -> Any:
+    """Express a joint-space target as a MoveIt constraint set.
+
+    :param joint_positions: Mapping of joint name to target position
+    :param tolerance: Position tolerance applied above and below the target
+    :returns: moveit_msgs Constraints
+    """
+    ensure_moveit_msgs()
+    from moveit_msgs.msg import Constraints, JointConstraint
+
+    constraints = Constraints()
+    for name, position in joint_positions.items():
+        constraints.joint_constraints.append(
+            JointConstraint(
+                joint_name=name,
+                position=float(position),
+                tolerance_above=tolerance,
+                tolerance_below=tolerance,
+                weight=1.0,  # hard constraint
+            )
+        )
+    return constraints
+
+
+def build_move_group_goal(
+    constraints: Any,
+    group_name: str,
+    *,
+    pipeline_id: str = "",
+    planner_id: str = "",
+    num_attempts: int = 5,
+    allowed_time: float = 5.0,
+    velocity_scaling: float = 0.1,
+    acceleration_scaling: float = 0.1,
+    plan_only: bool = False,
+) -> Any:
+    """Build a MoveGroup action goal around a constraint set.
+
+    The start state is marked as a diff so move_group plans from the robot
+    state it is currently monitoring.
+
+    :param constraints: moveit_msgs Constraints (from pose_to_constraints or
+        joints_to_constraints)
+    :param group_name: SRDF planning group to plan for
+    :returns: moveit_msgs MoveGroup.Goal
+    """
+    ensure_moveit_msgs()
+    from moveit_msgs.action import MoveGroup
+
+    goal = MoveGroup.Goal()
+    request = goal.request
+    request.group_name = group_name
+    request.goal_constraints = [constraints]
+    request.pipeline_id = pipeline_id
+    request.planner_id = planner_id
+    request.num_planning_attempts = num_attempts
+    request.allowed_planning_time = allowed_time
+    request.max_velocity_scaling_factor = velocity_scaling
+    request.max_acceleration_scaling_factor = acceleration_scaling
+    request.start_state.is_diff = True
+    goal.planning_options.plan_only = plan_only
+    return goal
+
+
+def build_cartesian_request(
+    waypoints: Iterable[Any],
+    frame_id: str,
+    group_name: str,
+    link_name: str,
+    *,
+    max_step: float = 0.0025,
+    jump_threshold: float = 0.0,
+    avoid_collisions: bool = True,
+    velocity_scaling: float = 0.1,
+    acceleration_scaling: float = 0.1,
+) -> Any:
+    """Build a GetCartesianPath service request for a straight-line path.
+
+    :param waypoints: geometry_msgs Pose waypoints for the end effector
+    :param frame_id: Reference frame of the waypoints
+    :param group_name: SRDF planning group
+    :param link_name: End-effector link that follows the waypoints
+    :returns: moveit_msgs GetCartesianPath.Request
+    """
+    ensure_moveit_msgs()
+    from moveit_msgs.srv import GetCartesianPath
+
+    request = GetCartesianPath.Request()
+    request.header.frame_id = frame_id
+    request.group_name = group_name
+    request.link_name = link_name
+    request.waypoints = list(waypoints)
+    request.max_step = max_step
+    request.avoid_collisions = avoid_collisions
+    request.start_state.is_diff = True
+    # NOTE: These fields vary across MoveIt versions (humble..rolling), set only
+    # when present
+    for field_name, value in (
+        ("jump_threshold", jump_threshold),
+        ("max_velocity_scaling_factor", velocity_scaling),
+        ("max_acceleration_scaling_factor", acceleration_scaling),
+    ):
+        if hasattr(request, field_name):
+            setattr(request, field_name, value)
+    return request
+
+
+def parse_srdf_group_states(srdf_xml: str) -> Dict[str, Dict[str, Dict[str, float]]]:
+    """Extract named states per planning group from an SRDF document.
+
+    :param srdf_xml: SRDF document content
+    :returns: Mapping of group name to {state name: {joint name: position}}
+    """
+    root = ET.fromstring(srdf_xml)
+    states: Dict[str, Dict[str, Dict[str, float]]] = {}
+    for group_state in root.iter("group_state"):
+        group = group_state.get("group")
+        name = group_state.get("name")
+        if not group or not name:
+            continue
+        joints = {}
+        for joint in group_state.iter("joint"):
+            joint_name = joint.get("name")
+            value = joint.get("value")
+            if joint_name and value is not None:
+                # multi-dof joint values are space separated; keep the first
+                joints[joint_name] = float(value.split()[0])
+        states.setdefault(group, {})[name] = joints
+    return states
+
+
+def parse_planner_interfaces(response: Any) -> Dict[str, List[str]]:
+    """Map available planning pipelines to their planner ids.
+
+    :param response: moveit_msgs QueryPlannerInterfaces.Response
+    :returns: Mapping of pipeline id to the planner ids it provides
+    """
+    pipelines: Dict[str, List[str]] = {}
+    for interface in response.planner_interfaces:
+        pipelines.setdefault(interface.pipeline_id, []).extend(interface.planner_ids)
+    return pipelines
+
+
+def moveit_error_string(code: int) -> str:
+    """Translate a raw MoveItErrorCodes value to its constant name.
+
+    Built dynamically from the installed message definition.
+
+    :param code: MoveItErrorCodes value
+    :returns: Constant name, e.g. 'SUCCESS' or 'PLANNING_FAILED'
+    """
+    ensure_moveit_msgs()
+    from moveit_msgs.msg import MoveItErrorCodes
+
+    names = {
+        value: name
+        for name, value in vars(MoveItErrorCodes).items()
+        if name.isupper() and isinstance(value, int)
+    }
+    return names.get(code, f"UNKNOWN_ERROR({code})")

--- a/agents/utils/moveit.py
+++ b/agents/utils/moveit.py
@@ -496,6 +496,7 @@ def collision_objects_from_detections(
     min_thickness: float = 0.01,
     padding: float = 0.0,
     id_prefix: str = DETECTION_ID_PREFIX,
+    include_labels: Optional[Sequence[str]] = None,
 ) -> List[Any]:
     """Turn a Detections3D message into collision objects.
 
@@ -509,15 +510,24 @@ def collision_objects_from_detections(
     :param min_thickness: Floor for each box extent in meters
     :param padding: Margin added on every side of every box in meters, for
         planning clearance around imperfectly measured objects
+    :param include_labels: Labels allowed into the scene. None admits all.
+        A filtered-out object is invisible to planning even when it physically
+        sits inside the workspace, so fixed surroundings should be modelled in
+        the robot description or as manual objects
     :returns: moveit_msgs CollisionObjects with operation ADD
     """
     frame = detections.header.frame_id
     labels = list(detections.labels)
     scores = list(detections.scores)
+    allowed = set(include_labels) if include_labels is not None else None
     entries = []
     for index, box in enumerate(detections.boxes):
+        label = labels[index] if index < len(labels) else ""
+        # Filtered before ranking, so admitted ids stay contiguous
+        if allowed is not None and label not in allowed:
+            continue
         entries.append((
-            labels[index] if index < len(labels) else "",
+            label,
             scores[index] if index < len(scores) else 0.0,
             box,
         ))

--- a/agents/utils/moveit.py
+++ b/agents/utils/moveit.py
@@ -36,12 +36,17 @@ class MoveMode(str, Enum):
     - ``JOINTS``: explicit joint positions.
     - ``NAMED``: a named target defined in the robot's SRDF (e.g. "home").
     - ``CARTESIAN``: a straight-line end-effector path through waypoints.
+    - ``PICK``: grasp a planning scene object, named by ``target_object`` or
+      located by ``target_pose``, and lift it.
+    - ``PLACE``: set the held object down at ``target_pose`` and release it.
     """
 
     POSE = "pose"
     JOINTS = "joints"
     NAMED = "named"
     CARTESIAN = "cartesian"
+    PICK = "pick"
+    PLACE = "place"
 
     @classmethod
     def values(cls) -> List[str]:
@@ -72,6 +77,9 @@ class MoveMode(str, Enum):
             return cls.CARTESIAN
         if len(goal.joint_names):
             return cls.JOINTS
+        # Pick can name a scene object. Place cannot be inferred from bare pose.
+        if goal.target_object:
+            return cls.PICK
         if goal.target_pose.header.frame_id or any([
             goal.target_pose.pose.position.x,
             goal.target_pose.pose.position.y,

--- a/agents/utils/moveit.py
+++ b/agents/utils/moveit.py
@@ -8,13 +8,76 @@ lazily.
 """
 
 import xml.etree.ElementTree as ET
+from enum import Enum
 from importlib.util import find_spec
-from typing import Any, Dict, Iterable, List, Sequence, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
+
+from rclpy.logging import get_logger
+
+from .utils import _read_spec_file
 
 _MOVEIT_INSTALL_HINT = (
     "'moveit_msgs' module is required to use the MoveIt component but it is "
     "not installed. Please install the 'ros-<distro>-moveit-msgs' package."
 )
+
+# Parameter of the move_group node that carries the robot SRDF
+SRDF_PARAMETER = "robot_description_semantic"
+
+
+class MoveMode(str, Enum):
+    """Kinds of motion target accepted in a manipulation goal.
+
+    - ``POSE``: an end-effector pose.
+    - ``JOINTS``: explicit joint positions.
+    - ``NAMED``: a named target defined in the robot's SRDF (e.g. "home").
+    - ``CARTESIAN``: a straight-line end-effector path through waypoints.
+    """
+
+    POSE = "pose"
+    JOINTS = "joints"
+    NAMED = "named"
+    CARTESIAN = "cartesian"
+
+    @classmethod
+    def values(cls) -> List[str]:
+        """List the valid mode strings"""
+        return [mode.value for mode in cls]
+
+    @classmethod
+    def from_goal(cls, goal: Any) -> "MoveMode":
+        """Get the mode of a manipulation goal, inferring it when not set.
+
+        When the goal's ``mode`` field is empty the mode is inferred from
+        whichever target field carries a value.
+
+        :param goal: MoveManipulator goal
+        :raises ValueError: If the mode is unknown or no target is given
+        """
+        mode = (goal.mode or "").strip().lower()
+        if mode:
+            try:
+                return cls(mode)
+            except ValueError:
+                raise ValueError(
+                    f"Unknown mode '{mode}'. Valid modes: {cls.values()}"
+                ) from None
+        if goal.named_target:
+            return cls.NAMED
+        if len(goal.cartesian_waypoints):
+            return cls.CARTESIAN
+        if len(goal.joint_names):
+            return cls.JOINTS
+        if goal.target_pose.header.frame_id or any([
+            goal.target_pose.pose.position.x,
+            goal.target_pose.pose.position.y,
+            goal.target_pose.pose.position.z,
+        ]):
+            return cls.POSE
+        raise ValueError(
+            "No motion target given. Set 'mode' and the matching target field: "
+            f"{cls.values()}"
+        )
 
 
 def ensure_moveit_msgs() -> None:
@@ -197,13 +260,53 @@ def build_cartesian_request(
     return request
 
 
-def parse_srdf_group_states(srdf_xml: str) -> Dict[str, Dict[str, Dict[str, float]]]:
-    """Extract named states per planning group from an SRDF document.
+def load_named_targets(
+    srdf: Optional[Union[str, ET.Element]] = None,
+    srdf_file: Optional[str] = None,
+    overrides: Optional[Dict] = None,
+    logger_name: str = "moveit",
+) -> Dict[str, Dict[str, Dict[str, float]]]:
+    """Collect the named targets available per planning group.
 
-    :param srdf_xml: SRDF document content
+    Named targets are read from the robot SRDF, either from already
+    retrieved content or from a file when no content is given. Manually
+    provided targets take precedence over the ones defined in the SRDF.
+
+    :param srdf: SRDF document content, e.g. as read from the move_group node
+    :param srdf_file: Path or URL of an SRDF file, used when no content is given
+    :param overrides: Manually defined targets, {group: {name: {joint: position}}}
+    :param logger_name: Name of the logger to report failures on
     :returns: Mapping of group name to {state name: {joint name: position}}
     """
-    root = ET.fromstring(srdf_xml)
+    states: Dict[str, Dict[str, Dict[str, float]]] = {}
+    if srdf is None and srdf_file:
+        try:
+            srdf = _read_spec_file(srdf_file, spec_type="xml")
+        except Exception as e:
+            get_logger(logger_name).warning(
+                f"Could not read SRDF file '{srdf_file}': {e}"
+            )
+    if srdf is not None:
+        try:
+            states = parse_srdf_group_states(srdf)
+        except Exception as e:
+            get_logger(logger_name).warning(f"Could not parse the robot SRDF: {e}")
+
+    for group, group_states in (overrides or {}).items():
+        states.setdefault(group, {}).update(group_states)
+    return states
+
+
+def parse_srdf_group_states(
+    srdf_xml: Union[str, ET.Element],
+) -> Dict[str, Dict[str, Dict[str, float]]]:
+    """Extract named states per planning group from an SRDF document.
+
+    :param srdf_xml: SRDF document content, or an already parsed XML root
+        (as returned by ``_read_spec_file`` for local files)
+    :returns: Mapping of group name to {state name: {joint name: position}}
+    """
+    root = ET.fromstring(srdf_xml) if isinstance(srdf_xml, str) else srdf_xml
     states: Dict[str, Dict[str, Dict[str, float]]] = {}
     for group_state in root.iter("group_state"):
         group = group_state.get("group")

--- a/agents/utils/perception3d.py
+++ b/agents/utils/perception3d.py
@@ -59,6 +59,85 @@ def ensure_kompass_core() -> None:
         raise ModuleNotFoundError(_KOMPASS_INSTALL_HINT)
 
 
+def resolve_lift_camera(
+    inputs: Sequence[Any],
+    depth: Optional[Any],
+    camera_info: Optional[Any],
+    *,
+    frame: str,
+    component: str,
+) -> str:
+    """Validate a component's 3D lifting contract and name its lift camera.
+
+    A component asked for Detections3D output needs a frame to report boxes
+    in, and depth registered to the picture stream the detections are made
+    on: either an RGBD input, or a plain depth topic with the calibration of
+    the stream it was measured on. Raises TypeError describing whichever
+    part of the contract is missing.
+
+    :param inputs: The component's input topics
+    :param depth: Topic given as the ``depth`` keyword, if any
+    :param camera_info: Topic given as the ``camera_info`` keyword, if any
+    :param frame: The configured ``detections_frame``
+    :param component: Component name for the error messages
+    :return: Name of the picture topic the lift applies to
+    """
+    from ..ros import CameraInfo, CompressedImage, Image, RGBD
+
+    # Check if detection frame has been set. 3D Boxes are axis aligned in it.
+    if not frame:
+        raise TypeError(
+            f"{component} was given a Detections3D output, which needs a frame "
+            "to report boxes in. Set `detections_frame` on the config to the "
+            "frame the consumer works in, such as a robotic arm's planning "
+            "frame."
+        )
+
+    pictures = [
+        t
+        for t in inputs
+        if issubclass(t.msg_type, (Image, RGBD))
+        and (not depth or t.name != depth.name)
+    ]
+    if camera_info and not issubclass(camera_info.msg_type, CameraInfo):
+        raise TypeError(
+            f"{component} camera_info topic must be of type CameraInfo, got "
+            f"{camera_info.msg_type.__name__}."
+        )
+
+    # Prefer RGBD over plain image. Return first RGBD if multiple.
+    # Otherwise the first Image topic is taken at the end.
+    rgbd = [t for t in pictures if issubclass(t.msg_type, RGBD)]
+    if rgbd:
+        return rgbd[0].name
+
+    if not depth:
+        raise TypeError(
+            f"{component} was given a Detections3D output, which requires "
+            "depth to place detections in space. Either give it an RGBD "
+            "input, which carries depth registered to its picture, or pass "
+            "the camera's registered depth topic as `depth=Topic(...)` along "
+            f"with its `camera_info=Topic(...)`. Inputs given: "
+            f"{[t.name for t in inputs]}"
+        )
+    if issubclass(depth.msg_type, CompressedImage) or not issubclass(
+        depth.msg_type, Image
+    ):
+        raise TypeError(
+            f"{component} depth topic must be an uncompressed Image, got "
+            f"{depth.msg_type.__name__}."
+        )
+    if not camera_info:
+        raise TypeError(
+            f"{component} was given a depth topic but no camera_info topic. "
+            "Depth pixels cannot be turned into distances without the "
+            "calibration of the stream they were measured on: pass it as "
+            "`camera_info=Topic(...)`."
+        )
+    # Take first image topic by default
+    return pictures[0].name
+
+
 @define
 class Box3D:
     """An object detected in metric space.

--- a/agents/utils/perception3d.py
+++ b/agents/utils/perception3d.py
@@ -8,6 +8,9 @@ optional dependency.
 
 Being a median, the reported distance is that of whatever fills most of the
 box, so detections should be tight around their objects.
+
+Boxes come back in the frame the camera's pose was given in, or in the
+camera's own optical frame when no pose is given.
 """
 
 # TODO: See if any of these utilities need to be upstreamed
@@ -24,10 +27,30 @@ _KOMPASS_INSTALL_HINT = (
 )
 
 # Depth encodings carrying integer millimeters rather than float meters
-_MILLIMETER_ENCODINGS = {"16uc1", "mono16", "16sc1"}
+_MILLIMETER_ENCODINGS = {"16uc1", "mono16"}
 
 # kompass-core works in millimeters
 _METERS_TO_MM = 1000.0
+
+# NOTE: Rotation taking a camera's optical axes (x right, y down, z forward) to the
+# body aligned axes (x forward, y left, z up) the detector reports in, as
+# (x, y, z, w). This is the fixed quarter turn ROS puts between a camera's link
+# frame and its optical frame.
+_OPTICAL_TO_BODY = (-0.5, 0.5, -0.5, 0.5)
+
+
+def _quaternion_multiply(
+    first: Sequence[float], second: Sequence[float]
+) -> Tuple[float, float, float, float]:
+    """Compose two rotations given as (x, y, z, w), applying `second` first."""
+    x1, y1, z1, w1 = first
+    x2, y2, z2, w2 = second
+    return (
+        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+    )
 
 
 def ensure_kompass_core() -> None:
@@ -132,8 +155,10 @@ def make_detector(
 ) -> Any:
     """Build a depth detector for one camera.
 
-    Building one is not free, so callers should keep it and rebuild only when
-    the camera's intrinsics or pose change.
+    The pose is that of the camera's **optical** frame, which is the one an
+    image names in its header and the one TF can resolve. Boxes come back in
+    the frame that pose is given in, or in the camera's own optical frame when
+    no pose is given.
 
     :param intrinsics: Camera intrinsics (ros_sugar.io.CameraIntrinsics)
     :param translation: Camera position in the target frame, identity if unset
@@ -145,10 +170,22 @@ def make_detector(
     ensure_kompass_core()
     from kompass_core.vision import DepthDetector
 
+    # NOTE: The detector turns the camera's optical axes into body aligned ones
+    # itself before applying the pose it is built with, so that fixed turn has
+    # to be taken back out of the pose given here. Drop this once the detector
+    # can be told which convention the pose is in, and pass the pose straight
+    # through: https://github.com/automatika-robotics/kompass-core/issues/49
+    rotation = rotation if rotation is not None else (0.0, 0.0, 0.0, 1.0)
+    x, y, z, w = _OPTICAL_TO_BODY
+    body_in_target = _quaternion_multiply(rotation, (-x, -y, -z, w))
+
     return DepthDetector(
         np.asarray(depth_range, dtype=np.float32),
-        np.asarray(translation if translation is not None else (0.0, 0.0, 0.0), dtype=np.float32),
-        np.asarray(rotation if rotation is not None else (0.0, 0.0, 0.0, 1.0), dtype=np.float32),
+        np.asarray(
+            translation if translation is not None else (0.0, 0.0, 0.0),
+            dtype=np.float32,
+        ),
+        np.asarray(body_in_target, dtype=np.float32),
         np.asarray([intrinsics.fx, intrinsics.fy], dtype=np.float32),
         np.asarray([intrinsics.cx, intrinsics.cy], dtype=np.float32),
         1e-3,  # the depth images handed over are in millimeters
@@ -174,7 +211,8 @@ def boxes_from_detections(
     :param image_size: Size of the image the boxes were found in as
         (width, height), taken from the depth image if unset
     :param depth_range: Usable range of the sensor in meters
-    :returns: The boxes that could be placed, in the detector's frame
+    :returns: The boxes that could be placed, in the frame the detector's
+        camera pose was given in
     """
     ensure_kompass_core()
     from kompass_cpp.types import Bbox2D

--- a/agents/utils/perception3d.py
+++ b/agents/utils/perception3d.py
@@ -1,0 +1,257 @@
+"""Turn 2D detections into metric 3D boxes given a depth image registered to the
+frame the detections were made in and the camera's intrinsics.
+
+The geometry itself is done by kompass-core's depth detector, which takes the
+median of the depth pixels inside a box, keeps the pixels within a median
+absolute deviation of it, and derives the object's extents from those. It is an
+optional dependency.
+
+Being a median, the reported distance is that of whatever fills most of the
+box, so detections should be tight around their objects.
+"""
+
+# TODO: See if any of these utilities need to be upstreamed
+
+from importlib.util import find_spec
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+from attrs import define, field
+
+_KOMPASS_INSTALL_HINT = (
+    "'kompass-core' is required to lift 2D detections into 3D but it is not "
+    "installed. Install it with: pip install kompass-core"
+)
+
+# Depth encodings carrying integer millimeters rather than float meters
+_MILLIMETER_ENCODINGS = {"16uc1", "mono16", "16sc1"}
+
+# kompass-core works in millimeters
+_METERS_TO_MM = 1000.0
+
+
+def ensure_kompass_core() -> None:
+    """Raise an actionable error when kompass_core is unavailable."""
+    if find_spec("kompass_core") is None:
+        raise ModuleNotFoundError(_KOMPASS_INSTALL_HINT)
+
+
+@define
+class Box3D:
+    """An object detected in metric space.
+
+    :param index: Index of the 2D detection this box was lifted from, so the
+        label and score of that detection can be carried over. Boxes without
+        usable depth are dropped, so this is not the position in the output
+    :param center: Center of the box in meters
+    :param size: Full extents of the box in meters
+    :param validity: Fraction of the depth pixels inside the 2D box that were
+        usable, in [0, 1]
+    """
+
+    index: int = field()
+    center: Tuple[float, float, float] = field()
+    size: Tuple[float, float, float] = field()
+    validity: float = field(default=0.0)
+
+
+def prepare_depth(
+    depth: np.ndarray,
+    encoding: Optional[str] = None,
+    scale: Optional[float] = None,
+) -> np.ndarray:
+    """Put a depth image in the layout kompass-core reads.
+
+    Depth arrives either as float meters or as integer millimeters depending
+    on the camera, and invalid pixels are marked as 0, NaN or infinity
+    depending on the driver. All of them become a plain 0, which is what
+    kompass-core treats as no reading.
+
+    :param depth: Depth image as (H, W) or (H, W, 1)
+    :param encoding: ROS encoding of the depth image, used to tell integer
+        millimeters from float meters when the dtype alone is ambiguous
+    :param scale: Multiplier from the image's units to millimeters,
+        overriding what the encoding and dtype imply
+    :returns: Depth in millimeters as a column major uint16 array
+    """
+    depth = np.asarray(depth)
+    if depth.ndim == 3 and depth.shape[2] == 1:
+        depth = depth[:, :, 0]
+    if depth.ndim != 2:
+        raise ValueError(f"Depth image must be 2D, got shape {depth.shape}")
+
+    if scale is None:
+        if encoding and encoding.lower() in _MILLIMETER_ENCODINGS:
+            scale = 1.0
+        elif np.issubdtype(depth.dtype, np.floating):
+            scale = _METERS_TO_MM
+        else:
+            scale = 1.0
+
+    if np.issubdtype(depth.dtype, np.floating):
+        # NaN for no return, infinity for out of range: both mean no reading
+        depth = np.nan_to_num(depth, nan=0.0, posinf=0.0, neginf=0.0)
+
+    depth = np.clip(depth * scale, 0, np.iinfo(np.uint16).max)
+    return np.require(depth, dtype=np.uint16, requirements=["F"])
+
+
+def depth_validity(
+    depth_mm: np.ndarray,
+    box: Sequence[float],
+    depth_range: Tuple[float, float] = (0.1, 5.0),
+) -> float:
+    """Fraction of a 2D box's depth pixels that carry a usable reading.
+
+    A box built from a handful of pixels is geometrically meaningless, so
+    consumers use this to decide whether to trust the 3D box built from it.
+
+    :param depth_mm: Depth image in millimeters
+    :param box: 2D box as (x1, y1, x2, y2) in pixels
+    :param depth_range: Usable range of the sensor in meters
+    :returns: Fraction in [0, 1], 0 when the box is empty or off the image
+    """
+    height, width = depth_mm.shape[:2]
+    x1, y1, x2, y2 = (int(round(value)) for value in box)
+    x1, x2 = max(0, min(x1, x2)), min(width, max(x1, x2))
+    y1, y2 = max(0, min(y1, y2)), min(height, max(y1, y2))
+    if x2 <= x1 or y2 <= y1:
+        return 0.0
+
+    patch = depth_mm[y1:y2, x1:x2]
+    low, high = (limit * _METERS_TO_MM for limit in depth_range)
+    usable = np.count_nonzero((patch >= low) & (patch <= high))
+    return float(usable) / float(patch.size)
+
+
+def make_detector(
+    intrinsics: Any,
+    translation: Optional[Sequence[float]] = None,
+    rotation: Optional[Sequence[float]] = None,
+    depth_range: Tuple[float, float] = (0.1, 5.0),
+) -> Any:
+    """Build a depth detector for one camera.
+
+    Building one is not free, so callers should keep it and rebuild only when
+    the camera's intrinsics or pose change.
+
+    :param intrinsics: Camera intrinsics (ros_sugar.io.CameraIntrinsics)
+    :param translation: Camera position in the target frame, identity if unset
+    :param rotation: Camera orientation in the target frame as (x, y, z, w),
+        identity if unset
+    :param depth_range: Usable range of the sensor in meters
+    :returns: kompass_core DepthDetector
+    """
+    ensure_kompass_core()
+    from kompass_core.vision import DepthDetector
+
+    return DepthDetector(
+        np.asarray(depth_range, dtype=np.float32),
+        np.asarray(translation if translation is not None else (0.0, 0.0, 0.0), dtype=np.float32),
+        np.asarray(rotation if rotation is not None else (0.0, 0.0, 0.0, 1.0), dtype=np.float32),
+        np.asarray([intrinsics.fx, intrinsics.fy], dtype=np.float32),
+        np.asarray([intrinsics.cx, intrinsics.cy], dtype=np.float32),
+        1e-3,  # the depth images handed over are in millimeters
+    )
+
+
+def boxes_from_detections(
+    detector: Any,
+    depth_mm: np.ndarray,
+    boxes_2d: Sequence[Sequence[float]],
+    image_size: Optional[Tuple[int, int]] = None,
+    depth_range: Tuple[float, float] = (0.1, 5.0),
+) -> List[Box3D]:
+    """Lift 2D detections into metric boxes.
+
+    Detections whose pixels carry no usable depth cannot be placed in space
+    and are left out, so each returned box records which detection it came
+    from rather than relying on position.
+
+    :param detector: Detector from :func:`make_detector`
+    :param depth_mm: Depth image from :func:`prepare_depth`
+    :param boxes_2d: 2D boxes as (x1, y1, x2, y2) in pixels
+    :param image_size: Size of the image the boxes were found in as
+        (width, height), taken from the depth image if unset
+    :param depth_range: Usable range of the sensor in meters
+    :returns: The boxes that could be placed, in the detector's frame
+    """
+    ensure_kompass_core()
+    from kompass_cpp.types import Bbox2D
+
+    if not len(boxes_2d):
+        return []
+
+    height, width = depth_mm.shape[:2]
+    if image_size is None:
+        image_size = (width, height)
+
+    inputs = []
+    for index, box in enumerate(boxes_2d):
+        x1, y1, x2, y2 = (float(value) for value in box)
+        corner = np.array([min(x1, x2), min(y1, y2)], dtype=np.int32)
+        extent = np.array([abs(x2 - x1), abs(y2 - y1)], dtype=np.int32)
+        # The detector carries the label through untouched
+        detection = Bbox2D(
+            top_left_corner=corner,
+            size=extent,
+            timestamp=0.0,
+            label=str(index),
+        )
+        detection.set_img_size(np.array(image_size, dtype=np.int32))
+        inputs.append(detection)
+
+    detected = detector.compute_3d_detections(depth_mm, inputs, 0.0, 0.0, 0.0, 0.0)
+    if not detected:
+        return []
+
+    boxes = []
+    for box in detected:
+        try:
+            index = int(box.label)
+        except (TypeError, ValueError):
+            continue
+        if not 0 <= index < len(boxes_2d):
+            continue
+        center = np.asarray(box.center, dtype=np.float64)
+        size = np.asarray(box.size, dtype=np.float64)
+        boxes.append(
+            Box3D(
+                index=index,
+                center=(float(center[0]), float(center[1]), float(center[2])),
+                size=(float(size[0]), float(size[1]), float(size[2])),
+                validity=depth_validity(depth_mm, boxes_2d[index], depth_range),
+            )
+        )
+    return boxes
+
+
+def detections_to_message_fields(
+    boxes: Sequence[Box3D],
+    labels: Optional[Sequence[str]] = None,
+    scores: Optional[Sequence[float]] = None,
+    boxes_2d: Optional[Sequence[Sequence[float]]] = None,
+) -> Dict[str, List]:
+    """Line metric boxes up with the 2D detections they came from.
+
+    :param boxes: Boxes from :func:`boxes_from_detections`
+    :param labels: Labels of the 2D detections
+    :param scores: Scores of the 2D detections
+    :param boxes_2d: The 2D boxes themselves, to carry into the message
+    :returns: Keyword arguments for the Detections3D converter
+    """
+    fields: Dict[str, List] = {
+        "output": [(box.center, box.size) for box in boxes],
+        "labels": [],
+        "scores": [],
+        "depth_validity": [box.validity for box in boxes],
+        "boxes_2d": [],
+    }
+    for box in boxes:
+        if labels is not None and box.index < len(labels):
+            fields["labels"].append(labels[box.index])
+        if scores is not None and box.index < len(scores):
+            fields["scores"].append(float(scores[box.index]))
+        if boxes_2d is not None and box.index < len(boxes_2d):
+            fields["boxes_2d"].append(boxes_2d[box.index])
+    return fields

--- a/agents/utils/utils.py
+++ b/agents/utils/utils.py
@@ -8,6 +8,7 @@ from enum import Enum
 from io import BytesIO
 from pathlib import Path
 from typing import (
+    Any,
     List,
     Dict,
     Literal,
@@ -555,6 +556,27 @@ def load_model_repo(
         raise
 
     return str(model_dir)
+
+
+def get_frame_id(msg: Any) -> str:
+    """Frame a ROS message was captured in, empty when it does not say.
+
+    :param msg: Any ROS message, with or without a header
+    :rtype: str
+    """
+    return getattr(getattr(msg, "header", None), "frame_id", "") or ""
+
+
+def get_stamp_secs(msg: Any) -> float:
+    """Capture time of a ROS message in seconds, 0 when it does not say.
+
+    :param msg: Any ROS message, with or without a header
+    :rtype: float
+    """
+    stamp = getattr(getattr(msg, "header", None), "stamp", None)
+    if stamp is None:
+        return 0.0
+    return stamp.sec + stamp.nanosec * 1e-9
 
 
 def flatten(xs):

--- a/docs/development/messages.md
+++ b/docs/development/messages.md
@@ -25,6 +25,7 @@ The following custom messages are defined in the `automatika_embodied_agents` pa
 | Action | File | Description |
 |---|---|---|
 | `VisionLanguageAction` | `VisionLanguageAction.action` | ROS2 action for VLA inference. Defines goal, feedback, and result for vision-language-action loops. |
+| `MoveManipulator` | `MoveManipulator.action` | ROS2 action served by the MoveIt component. The goal carries a motion `mode` (pose, joints, named, cartesian, pick, place) with its target fields; feedback reports the current step; the result carries success, a message and the MoveIt error code. |
 
 ## The `SupportedType` System
 

--- a/docs/development/messages.md
+++ b/docs/development/messages.md
@@ -12,6 +12,8 @@ The following custom messages are defined in the `automatika_embodied_agents` pa
 | `Bbox2D` | `Bbox2D.msg` | A 2D bounding box with `top_left_x`, `top_left_y`, `bottom_right_x`, `bottom_right_y`. |
 | `Detections2D` | `Detections2D.msg` | Object detection results: arrays of `scores`, `labels`, `boxes` (Bbox2D[]), plus optional `image` and `depth`. |
 | `Detections2DMultiSource` | `Detections2DMultiSource.msg` | An array of `Detections2D` for multi-camera setups. |
+| `Bbox3D` | `Bbox3D.msg` | A 3D bounding box: `center` (Pose) and `size` (Vector3, full extents in meters). Assignable to `vision_msgs/BoundingBox3D` and usable as a MoveIt BOX primitive. |
+| `Detections3D` | `Detections3D.msg` | Detected objects in metric space: `scores`, `labels`, `boxes` (Bbox3D[]) in `header.frame_id`, plus `depth_validity` per box and the `boxes_2d`/`source_frame` they were lifted from. |
 | `Trackings` | `Trackings.msg` | Tracked object data: `ids`, `labels`, `boxes`, `centroids`, `estimated_velocities`, plus source image. |
 | `TrackingsMultiSource` | `TrackingsMultiSource.msg` | An array of `Trackings` for multi-camera tracking. |
 | `StreamingString` | `StreamingString.msg` | A string with `stream` (bool) and `done` (bool) flags for token-by-token LLM output. |

--- a/msg/Bbox2D.msg
+++ b/msg/Bbox2D.msg
@@ -1,3 +1,6 @@
+# A 2D bounding box around an object, in image space.
+
+# Corners in pixels, with the origin at the top left of the image.
 float64 top_left_x
 float64 top_left_y
 float64 bottom_right_x

--- a/msg/Bbox3D.msg
+++ b/msg/Bbox3D.msg
@@ -1,0 +1,7 @@
+# A 3D bounding box around an object, in metric space.
+
+# Center of the box, in the frame given by the parent message header.
+geometry_msgs/Pose center
+
+# Full extents of the box along its own axes, in meters.
+geometry_msgs/Vector3 size

--- a/msg/Detections2D.msg
+++ b/msg/Detections2D.msg
@@ -1,12 +1,19 @@
+# Detected objects in image space.
+
+# Frame of the camera the detections were made in.
 std_msgs/Header header
 
+# Detector confidence per object, parallel to `boxes`.
 float64[] scores
+# Object labels, parallel to `boxes`.
 string[] labels
+# The objects, in pixels.
 Bbox2D[]  boxes
 
-# Either an image or compressed image
+# The frame the objects were found in. Either an image or compressed image
 sensor_msgs/Image image
 sensor_msgs/CompressedImage compressed_image
 
-# Depth image if available
+# Registered depth for the same frame, when the camera provides it. This is
+# what lets a consumer lift these detections into metric space.
 sensor_msgs/Image depth

--- a/msg/Detections3D.msg
+++ b/msg/Detections3D.msg
@@ -1,0 +1,28 @@
+# Detected objects in metric space.
+#
+# Produced by lifting 2D detections with a registered depth image and the
+# camera intrinsics.
+
+# The frame every box in this message is given in. Unlike 2D detections, which
+# stay in the pixels of the camera that saw them and so cannot share a frame,
+# metric boxes from several cameras can be transformed into one common frame.
+std_msgs/Header header
+
+# Detector confidence per object, parallel to `boxes`.
+float64[] scores
+# Object labels, parallel to `boxes`.
+string[] labels
+# The objects.
+Bbox3D[] boxes
+
+# Fraction of the depth pixels inside each object's 2D box that were valid
+# and used to build its 3D box, in [0, 1] and parallel to `boxes`. A box built
+# from a handful of pixels is geometrically meaningless, so consumers should
+# check this before trusting one.
+float64[] depth_validity
+
+# The 2D detections these boxes were lifted from, parallel to `boxes`, and the
+# frame of the image they were found in. Empty when the boxes did not come
+# from an image.
+Bbox2D[] boxes_2d
+string source_frame

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <depend>builtin_interfaces</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
   <depend>python3-tqdm</depend>
   <depend>python3-httpx</depend>
   <depend>python3-websockets</depend>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,10 +76,12 @@ def mock_component_internals(component):
         return_value=MagicMock(sec=0, nanosec=0)
     )
 
-    # Setup publishers_dict
+    # Setup publishers_dict. Components route on what a publisher publishes,
+    # so it carries the component's real output topic rather than a mock one
     mock_pub = MagicMock()
     mock_pub.publish = MagicMock()
-    mock_pub.output_topic = MagicMock()
+    out_topics = getattr(component, "out_topics", None)
+    mock_pub.output_topic = out_topics[0] if out_topics else MagicMock()
     component.publishers_dict = {"out": mock_pub}
 
     return component

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -292,3 +292,55 @@ class TestVLMLocalModelDefaults:
         c = MLLMConfig()
         assert c.local_model_path == "ggml-org/Qwen3-VL-2B-Instruct-GGUF"
         assert c.local_model_options == {}
+
+
+class TestMoveItConfig:
+    def test_defaults(self):
+        from agents.config import MoveItConfig
+
+        c = MoveItConfig(arm_group_name="panda_arm")
+        assert c.arm_group_name == "panda_arm"
+        assert c.gripper_group_name is None
+        assert c.planning_pipeline == "" and c.planner_id == ""
+        assert c.gripper_mode == "move_group"
+        assert c.max_velocity_scaling == 0.1
+        assert c.cartesian_fraction_threshold == 0.95
+        assert c.server_timeout == 30.0 and c.execution_timeout == 120.0
+
+    def test_arm_group_required(self):
+        from agents.config import MoveItConfig
+
+        with pytest.raises(TypeError):
+            MoveItConfig()
+
+    def test_gripper_command_mode_requires_action_name(self):
+        from agents.config import MoveItConfig
+
+        with pytest.raises(ValueError, match="gripper_command_action"):
+            MoveItConfig(arm_group_name="arm", gripper_mode="gripper_command")
+        c = MoveItConfig(
+            arm_group_name="arm",
+            gripper_mode="gripper_command",
+            gripper_command_action="/gripper_controller/gripper_cmd",
+        )
+        assert c.gripper_command_action == "/gripper_controller/gripper_cmd"
+
+    def test_orientation_tolerance_scalar_or_triple(self):
+        from agents.config import MoveItConfig
+
+        c = MoveItConfig(
+            arm_group_name="arm", goal_orientation_tolerance=[0.01, 0.01, 3.14]
+        )
+        assert c.goal_orientation_tolerance == [0.01, 0.01, 3.14]
+        with pytest.raises(ValueError, match="3 positive"):
+            MoveItConfig(arm_group_name="arm", goal_orientation_tolerance=[0.01, 0.01])
+        with pytest.raises(ValueError):
+            MoveItConfig(arm_group_name="arm", goal_orientation_tolerance=-1.0)
+
+    def test_scaling_range_enforced(self):
+        from agents.config import MoveItConfig
+
+        with pytest.raises(ValueError):
+            MoveItConfig(arm_group_name="arm", max_velocity_scaling=1.5)
+        with pytest.raises(ValueError):
+            MoveItConfig(arm_group_name="arm", max_velocity_scaling=0.0)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -83,6 +83,50 @@ class TestMLLMConfig:
         assert "task" not in params
 
 
+class TestShared3DFields:
+    """The 3D lift fields are duplicated flat in VisionConfig and MLLMConfig
+    (a shared attrs base would need slots=False, costing both configs their
+    slot enforcement). This class is what keeps the copies in sync."""
+
+    FIELDS = (
+        "detections_frame",
+        "static_camera_tf",
+        "depth_scale",
+        "min_depth",
+        "max_depth",
+        "max_depth_age",
+        "min_depth_validity",
+        "_depth_topic",
+        "_camera_info_topic",
+    )
+
+    def test_both_configs_carry_the_same_fields_and_defaults(self):
+        from agents.config import VisionConfig
+
+        vision, mllm = VisionConfig(), MLLMConfig()
+        for name in self.FIELDS:
+            assert getattr(mllm, name) == getattr(vision, name)
+
+    def test_depth_range_validated_on_both(self):
+        from agents.config import VisionConfig
+
+        for config_class in (VisionConfig, MLLMConfig):
+            with pytest.raises(ValueError, match="max_depth"):
+                config_class(min_depth=2.0, max_depth=1.0)
+
+    def test_aux_topics_serialize_on_mllm(self):
+        """The stash fields must survive to_dict/from_dict for the
+        serialized multiprocess relaunch, exactly as on VisionConfig."""
+        from agents.ros import Topic
+
+        config = MLLMConfig()
+        config._depth_topic = Topic(name="depth", msg_type="Image")
+        restored = MLLMConfig()
+        restored.from_dict(config.to_dict())
+        assert restored._depth_topic.name == "depth"
+        assert restored._camera_info_topic is None
+
+
 class TestSTTConfig:
     def test_construction(self):
         """SpeechToTextConfig can be constructed with defaults."""

--- a/tests/test_mllm.py
+++ b/tests/test_mllm.py
@@ -66,6 +66,148 @@ class TestMLLMConstruction:
             )
 
 
+class TestMLLM3DConstruction:
+    """Aux depth/camera_info inputs and the Detections3D contract."""
+
+    @staticmethod
+    def _make(mock_model_client, config=None, inputs=None, **kwargs):
+        return MLLM(
+            inputs=inputs
+            or [
+                Topic(name="text_in", msg_type="String"),
+                Topic(name="img_in", msg_type="Image"),
+            ],
+            outputs=[Topic(name="d3", msg_type="Detections3D")],
+            model_client=mock_model_client,
+            config=config
+            or MLLMConfig(task="grounding", detections_frame="base_link"),
+            component_name="test_mllm_3d",
+            **kwargs,
+        )
+
+    def test_valid_3d_construction(self, rclpy_init, mock_model_client):
+        comp = self._make(
+            mock_model_client,
+            depth=Topic(name="depth", msg_type="Image"),
+            camera_info=Topic(name="cam_info", msg_type="CameraInfo"),
+        )
+        assert comp._lift_to_3d
+        assert comp._lift_camera == "img_in"
+        assert comp._aux_inputs == {"depth", "cam_info"}
+        assert comp.depth_topic.name == "depth"
+        # the aux topics ride the config for the serialized relaunch
+        assert comp.config._depth_topic.name == "depth"
+        assert comp.config._camera_info_topic.name == "cam_info"
+
+    def test_3d_output_requires_a_box_task(self, rclpy_init, mock_model_client):
+        with pytest.raises(TypeError, match="grounding"):
+            self._make(
+                mock_model_client,
+                config=MLLMConfig(detections_frame="base_link"),
+                depth=Topic(name="depth", msg_type="Image"),
+                camera_info=Topic(name="cam_info", msg_type="CameraInfo"),
+            )
+
+    def test_3d_output_requires_a_frame(self, rclpy_init, mock_model_client):
+        with pytest.raises(TypeError, match="detections_frame"):
+            self._make(
+                mock_model_client,
+                config=MLLMConfig(task="grounding"),
+                depth=Topic(name="depth", msg_type="Image"),
+                camera_info=Topic(name="cam_info", msg_type="CameraInfo"),
+            )
+
+    def test_3d_output_requires_depth(self, rclpy_init, mock_model_client):
+        with pytest.raises(TypeError, match="requires\\s+depth"):
+            self._make(mock_model_client)
+
+    def test_depth_requires_camera_info(self, rclpy_init, mock_model_client):
+        with pytest.raises(TypeError, match="camera_info"):
+            self._make(
+                mock_model_client, depth=Topic(name="depth", msg_type="Image")
+            )
+
+    def test_stray_camera_info_input_rejected(self, rclpy_init, mock_model_client):
+        with pytest.raises(TypeError, match="camera_info=Topic"):
+            self._make(
+                mock_model_client,
+                inputs=[
+                    Topic(name="text_in", msg_type="String"),
+                    Topic(name="img_in", msg_type="Image"),
+                    Topic(name="stray_info", msg_type="CameraInfo"),
+                ],
+                depth=Topic(name="depth", msg_type="Image"),
+                camera_info=Topic(name="cam_info", msg_type="CameraInfo"),
+            )
+
+    def test_aux_topics_never_reach_the_model(self, rclpy_init, mock_model_client):
+        comp = self._make(
+            mock_model_client,
+            depth=Topic(name="depth", msg_type="Image"),
+            camera_info=Topic(name="cam_info", msg_type="CameraInfo"),
+        )
+        mock_component_internals(comp)
+
+        trigger = Topic(name="text_in", msg_type="String")
+        trig_cb = MagicMock()
+        trig_cb.get_output.return_value = "ground the mug"
+        comp.trig_callbacks = {"text_in": trig_cb}
+
+        img_cb = MagicMock()
+        img_cb.get_output.return_value = np.zeros((10, 10, 3))
+        img_cb.msg = MagicMock()
+        img_cb.input_topic = Topic(name="img_in", msg_type="Image")
+        depth_cb = MagicMock()
+        depth_cb.get_output.return_value = np.zeros((10, 10))
+        depth_cb.msg = MagicMock()
+        depth_cb.input_topic = Topic(name="depth", msg_type="Image")
+        comp.callbacks = {"img_in": img_cb, "depth": depth_cb}
+
+        result = comp._create_input(topic=trigger)
+
+        assert result is not None
+        assert len(result["images"]) == 1
+
+    def test_3d_mllm_survives_the_executable_reconstruction(
+        self, rclpy_init, mock_model_client
+    ):
+        """The launch executable rebuilds the component from serialized
+        config, inputs and outputs — it knows nothing of the `depth` and
+        `camera_info` parameters. They ride the config instead."""
+        import json
+
+        from agents.ros import QoSConfig
+
+        original = self._make(
+            mock_model_client,
+            depth=Topic(name="depth", msg_type="Image"),
+            camera_info=Topic(name="cam_info", msg_type="CameraInfo"),
+        )
+
+        def _topics(serialized):
+            topics = []
+            for entry in json.loads(serialized):
+                data = json.loads(entry)
+                data["qos_profile"] = QoSConfig(**data.get("qos_profile", {}))
+                data["additional_types"] = []
+                topics.append(Topic(**data))
+            return topics
+
+        rebuilt = MLLM(
+            inputs=_topics(original._inputs_json),
+            outputs=_topics(original._outputs_json),
+            model_client=mock_model_client,
+            trigger=1.0,
+            config=MLLMConfig(**json.loads(original.config.to_json())),
+            component_name="test_mllm_3d",
+        )
+
+        assert rebuilt._aux_inputs == original._aux_inputs
+        assert rebuilt._lift_camera == original._lift_camera == "img_in"
+        assert rebuilt.depth_topic.name == "depth"
+        assert rebuilt.camera_info_topic.name == "cam_info"
+
+
 class TestMLLMCreateInput:
     def test_requires_images(self, mllm):
         """Only text, no images → None."""

--- a/tests/test_mllm.py
+++ b/tests/test_mllm.py
@@ -8,6 +8,7 @@ from agents.config import MLLMConfig
 from agents.ros import Topic, Image
 from agents.components.mllm import MLLM
 from tests.conftest import mock_component_internals
+from tests.test_vision import _SyntheticCamera, _callback, _image, _warnings
 
 
 @pytest.fixture
@@ -276,3 +277,122 @@ class TestMLLMSetTask:
         mllm._task = None
         with pytest.raises((ValueError, TypeError)):
             mllm.set_task("invalid_task")
+
+
+class TestGroundedLift(_SyntheticCamera):
+    """Grounded 2D boxes are lifted onto the depth latched with the picture
+    the model saw, and published as Detections3D named by the query."""
+
+    @pytest.fixture
+    def grounder(self, rclpy_init, mock_model_client):
+        comp = MLLM(
+            inputs=[
+                Topic(name="text_in", msg_type="String"),
+                Topic(name="img_in", msg_type="Image"),
+            ],
+            outputs=[
+                Topic(name="d2", msg_type="Detections"),
+                Topic(name="d3", msg_type="Detections3D"),
+            ],
+            depth=Topic(name="depth", msg_type="Image"),
+            camera_info=Topic(name="cam_info", msg_type="CameraInfo"),
+            model_client=mock_model_client,
+            config=MLLMConfig(task="grounding", detections_frame="cam"),
+            component_name="test_grounder",
+        )
+        mock_component_internals(comp)
+        # one mock publisher per output topic, keyed by name
+        comp.publishers_dict = {
+            topic.name: MagicMock(output_topic=topic) for topic in comp.out_topics
+        }
+        # what custom_on_configure derives from config and outputs
+        comp._task = "grounding"
+        comp._string_publishers = []
+        comp._poi_publishers = []
+        comp._detections_publishers = ["d2"]
+        comp._detections3d_publishers = ["d3"]
+        return comp
+
+    def _wire(self, comp, stamp=0.0, depth_stamp=0.0):
+        trig = MagicMock()
+        trig.get_output.return_value = "the orange"
+        comp.trig_callbacks = {"text_in": trig}
+        comp.callbacks = {
+            "img_in": _callback(
+                _image("cam", width=self.WIDTH, height=self.HEIGHT, stamp=stamp),
+                output=np.zeros((self.HEIGHT, self.WIDTH, 3)),
+                name="img_in",
+            ),
+            "depth": _callback(self._depth_scene("cam", depth_stamp), name="depth"),
+            "cam_info": _callback(
+                msg_type="CameraInfo", output=self._intrinsics(), name="cam_info"
+            ),
+        }
+
+    @staticmethod
+    def _published(comp, topic="d3"):
+        args, kwargs = comp.publishers_dict[topic].publish.call_args
+        return args[0], kwargs
+
+    def _trigger(self, comp):
+        comp._execution_step(topic=Topic(name="text_in", msg_type="String"))
+
+    def test_grounded_boxes_are_published_in_metric_space(
+        self, grounder, mock_model_client
+    ):
+        mock_model_client.inference.return_value = {"output": [list(self.PATCH)]}
+        self._wire(grounder)
+
+        self._trigger(grounder)
+
+        boxes, published = self._published(grounder)
+        # the query names the objects: it is all the scene consumer gets
+        assert published["labels"] == ["the orange"]
+        assert published["frame_id"] == "cam"
+        assert published["boxes_2d"] == [list(self.PATCH)]
+        (center, _), = boxes
+        assert center[2] == pytest.approx(self.PATCH_DEPTH_M, abs=0.02)
+        # the 2D output still goes out alongside
+        pixels, _ = self._published(grounder, "d2")
+        assert pixels["bboxes"] == [list(self.PATCH)]
+
+    def test_nothing_grounded_is_an_empty_message(
+        self, grounder, mock_model_client
+    ):
+        """The model looked and found nothing: an observation, published so
+        consumers let go of objects that are no longer there."""
+        mock_model_client.inference.return_value = {"output": []}
+        self._wire(grounder)
+
+        self._trigger(grounder)
+
+        boxes, _ = self._published(grounder)
+        assert boxes == []
+
+    def test_depth_is_the_instant_of_capture_not_of_publishing(
+        self, grounder, mock_model_client
+    ):
+        """The VLM takes seconds; the boxes must measure the scene it saw."""
+        self._wire(grounder)
+
+        def _slow_inference(*_, **__):
+            # a much later depth frame lands while the model is busy
+            grounder.callbacks["depth"].msg = self._depth_scene("cam", stamp=99.0)
+            return {"output": [list(self.PATCH)]}
+
+        mock_model_client.inference.side_effect = _slow_inference
+
+        self._trigger(grounder)
+
+        # had the late frame been read, max_depth_age would have refused it
+        boxes, _ = self._published(grounder)
+        assert boxes[0][0][2] == pytest.approx(self.PATCH_DEPTH_M, abs=0.02)
+
+    def test_stale_depth_publishes_nothing(self, grounder, mock_model_client):
+        mock_model_client.inference.return_value = {"output": [list(self.PATCH)]}
+        self._wire(grounder, stamp=10.0, depth_stamp=9.0)
+
+        self._trigger(grounder)
+
+        assert grounder.publishers_dict["d3"].publish.call_count == 0
+        assert "max_depth_age" in _warnings(grounder)

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1940,3 +1940,180 @@ class TestSceneGeometryCache:
         entry = comp._scene_objects["det__mug_0"]
         assert entry["center"] == (0.5, 0.1, 0.05)
         assert entry["size"] == (0.06, 0.06, 0.1)
+
+
+class TestPickSequence:
+    """The pick mode: approach, open, descend, grasp, attach, lift."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_moveit_msgs(self):
+        pytest.importorskip("moveit_msgs.msg")
+
+    @pytest.fixture
+    def component(self, rclpy_init):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(
+                arm_group_name="arm",
+                gripper_group_name="gripper",
+                end_effector_link="hand",
+                pose_reference_frame="base",
+                approach_clearance=0.1,
+                touch_links=["hand", "jaw"],
+            ),
+            component_name="m_pick",
+        )
+        comp.get_logger = MagicMock()
+        comp.health_status = MagicMock()
+        comp._named_targets = {
+            "gripper": {"open": {"jaw": 1.0}, "close": {"jaw": 0.0}}
+        }
+        comp._move_client = TestGoalExecution._client()
+        comp._exec_client = TestGoalExecution._client()
+        comp._gripper_client = TestGoalExecution._client()
+        comp._cartesian_client = MagicMock()
+        comp._cartesian_client.send_request.return_value = SimpleNamespace(
+            fraction=1.0, solution=MagicMock(), error_code=SimpleNamespace(val=1)
+        )
+        comp._apply_scene_client = MagicMock()
+        comp._apply_scene_client.send_request.return_value = SimpleNamespace(
+            success=True
+        )
+        comp._scene_objects["det__mug_0"] = {
+            "source": "detection",
+            "last_seen": 0.0,
+            "center": (0.4, 0.0, 0.05),
+            "size": (0.06, 0.06, 0.1),
+        }
+        return comp
+
+    @staticmethod
+    def _pick_goal(**fields):
+        from automatika_embodied_agents.action import MoveManipulator
+
+        goal = MoveManipulator.Goal()
+        goal.mode = "pick"
+        for key, value in fields.items():
+            setattr(goal, key, value)
+        return goal
+
+    @staticmethod
+    def _states(handle):
+        return [call[0][0].state for call in handle.publish_feedback.call_args_list]
+
+    def test_pick_runs_the_whole_sequence(self, component):
+        handle = TestGoalExecution._goal_handle(self._pick_goal(target_object="mug"))
+
+        result = component.main_action_callback(handle)
+
+        assert result.success and "det__mug_0" in result.message
+        handle.succeed.assert_called_once()
+        assert self._states(handle) == [
+            "PRE_GRASP", "OPEN_GRIPPER", "DESCEND", "GRASP", "ATTACH", "LIFT",
+        ]
+        # approach and lift both go to the clearance height above the box top:
+        # center z 0.05 + half height 0.05 + clearance 0.1
+        move_goals = [
+            call[0][0]
+            for call in component._move_client.send_request.call_args_list
+        ]
+        heights = [
+            g.request.goal_constraints[0]
+            .position_constraints[0].constraint_region.primitive_poses[0].position.z
+            for g in move_goals
+        ]
+        assert heights == [pytest.approx(0.2), pytest.approx(0.2)]
+        # the descent is the one contact-permitted segment, down to the center
+        request = component._cartesian_client.send_request.call_args[0][0]
+        assert request.avoid_collisions is False
+        assert request.waypoints[0].position.z == pytest.approx(0.05)
+        # the object now travels with the arm
+        assert component._scene_objects["det__mug_0"]["attached"] == "hand"
+
+    def test_pick_resolves_labels_to_the_best_rank(self, component):
+        component._scene_objects["det__mug_1"] = {
+            "source": "detection", "last_seen": 0.0,
+            "center": (0.9, 0.0, 0.05), "size": (0.06, 0.06, 0.1),
+        }
+        object_id, center, _ = component._resolve_pick_target(
+            self._pick_goal(target_object="mug")
+        )
+        assert object_id == "det__mug_0" and center == (0.4, 0.0, 0.05)
+
+    def test_pick_resolves_by_nearest_pose(self, component):
+        goal = self._pick_goal()
+        goal.target_pose.header.frame_id = "base"
+        goal.target_pose.pose.position.x = 0.45
+        object_id, _, _ = component._resolve_pick_target(goal)
+        assert object_id == "det__mug_0"
+
+    def test_a_far_pose_matches_nothing(self, component):
+        goal = self._pick_goal()
+        goal.target_pose.pose.position.x = 2.0
+        with pytest.raises(ValueError, match="No scene object within"):
+            component._resolve_pick_target(goal)
+
+    def test_a_failed_resolution_aborts_the_goal_without_crashing(self, component):
+        handle = TestGoalExecution._goal_handle(
+            self._pick_goal(target_object="bottle")
+        )
+
+        result = component.main_action_callback(handle)
+
+        assert not result.success and "det__mug_0" in result.message
+        handle.abort.assert_called_once()
+        component._move_client.send_request.assert_not_called()
+
+    def test_the_match_radius_comes_from_config(self, component):
+        component.config.target_match_radius = 0.01
+        goal = self._pick_goal()
+        goal.target_pose.pose.position.x = 0.45
+        with pytest.raises(ValueError, match="within 0.01 m"):
+            component._resolve_pick_target(goal)
+
+    def test_an_attached_object_is_not_a_candidate(self, component):
+        component._scene_objects["det__mug_0"]["attached"] = "hand"
+        with pytest.raises(ValueError, match="No scene object matches"):
+            component._resolve_pick_target(self._pick_goal(target_object="mug"))
+
+    def test_an_unknown_object_lists_the_scene(self, component):
+        with pytest.raises(ValueError, match="det__mug_0"):
+            component._resolve_pick_target(self._pick_goal(target_object="bottle"))
+
+    def test_a_failed_approach_aborts_with_the_step_named(self, component):
+        from moveit_msgs.msg import MoveItErrorCodes
+
+        component._move_client = TestGoalExecution._client(
+            error_code=MoveItErrorCodes.PLANNING_FAILED
+        )
+        handle = TestGoalExecution._goal_handle(self._pick_goal(target_object="mug"))
+
+        result = component.main_action_callback(handle)
+
+        assert not result.success
+        assert result.message.startswith("Pre-grasp:")
+        handle.abort.assert_called_once()
+        # the sequence stopped before touching anything
+        assert "attached" not in component._scene_objects["det__mug_0"]
+
+    def test_a_partial_descent_aborts(self, component):
+        component._cartesian_client.send_request.return_value = SimpleNamespace(
+            fraction=0.4, solution=MagicMock(), error_code=SimpleNamespace(val=1)
+        )
+        handle = TestGoalExecution._goal_handle(self._pick_goal(target_object="mug"))
+
+        result = component.main_action_callback(handle)
+
+        assert not result.success and result.message.startswith("Descent:")
+
+    def test_cancellation_cancels_the_goal(self, component):
+        handle = TestGoalExecution._goal_handle(
+            self._pick_goal(target_object="mug"), cancel_requested=True
+        )
+        component._move_client.action_returned = False
+
+        component.main_action_callback(handle)
+
+        handle.canceled.assert_called_once()

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1,10 +1,12 @@
 """Tests for MoveIt request-building utilities — no ROS node needed."""
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 from agents.utils.moveit import (
+    MoveMode,
     ensure_moveit_msgs,
     parse_planner_interfaces,
     parse_srdf_group_states,
@@ -55,6 +57,155 @@ class TestSrdfParsing:
         assert parse_srdf_group_states("<robot/>") == {}
 
 
+class TestInterfaceNames:
+    """Interface naming on the component — requires rclpy and moveit_msgs."""
+
+    @pytest.fixture
+    def component(self, rclpy_init):
+        pytest.importorskip("moveit_msgs.msg")
+        from agents.components.moveit import MoveIt
+        from agents.config import MoveItConfig
+
+        return MoveIt(
+            config=MoveItConfig(arm_group_name="panda_arm"),
+            component_name="test_moveit_names",
+        )
+
+    def test_no_namespace(self, component):
+        assert component._resolve_name("move_action") == "/move_action"
+
+    def test_namespace_forms_normalized(self, component):
+        for namespace in ("robot_a", "/robot_a", "/robot_a/", " robot_a "):
+            component.config.move_group_namespace = namespace
+            assert component._resolve_name("move_action") == "/robot_a/move_action"
+
+    def test_nested_name_keeps_namespace(self, component):
+        component.config.move_group_namespace = "/robot_a"
+        assert (
+            component._resolve_name("move_group/get_parameters")
+            == "/robot_a/move_group/get_parameters"
+        )
+
+
+class TestComponentNamedTargets:
+    """The SRDF is read from the running move_group node by the component."""
+
+    @pytest.fixture
+    def component(self, rclpy_init):
+        pytest.importorskip("moveit_msgs.msg")
+        from agents.components.moveit import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(arm_group_name="panda_arm", gripper_group_name="hand"),
+            component_name="test_moveit_targets",
+        )
+        comp.get_logger = MagicMock()
+        return comp
+
+    @staticmethod
+    def _param_client(response):
+        client = MagicMock()
+        client.send_request_from_dict.return_value = response
+        return client
+
+    def test_targets_read_from_move_group(self, component):
+        from agents.utils.moveit import SRDF_PARAMETER
+
+        component._param_client = self._param_client(
+            SimpleNamespace(values=[SimpleNamespace(string_value=SAMPLE_SRDF)])
+        )
+        states = component._named_target_states()
+        # parsed into targets, not returned as raw SRDF
+        assert states["panda_arm"]["ready"]["panda_joint2"] == -0.785
+        assert states["hand"]["open"] == {"panda_finger_joint1": 0.035}
+        component._param_client.send_request_from_dict.assert_called_once_with({
+            "names": [SRDF_PARAMETER]
+        })
+
+    def test_targets_cached_after_first_read(self, component):
+        component._param_client = self._param_client(
+            SimpleNamespace(values=[SimpleNamespace(string_value=SAMPLE_SRDF)])
+        )
+        first = component._named_target_states()
+        assert component._named_target_states() is first
+        assert component._param_client.send_request_from_dict.call_count == 1
+
+    def test_falls_back_to_srdf_file(self, component, tmp_path):
+        srdf_file = tmp_path / "robot.srdf"
+        srdf_file.write_text(SAMPLE_SRDF)
+        component.config.srdf_file = str(srdf_file)
+        component._param_client = self._param_client(None)
+        assert component._named_target_states()["panda_arm"]["ready"]
+
+    def test_no_sources_returns_empty_dict(self, component):
+        component._param_client = self._param_client(None)
+        # must be a dict, callers index into it
+        assert component._named_target_states() == {}
+        assert component.get_named_targets.__wrapped__(component) == (
+            "No named targets are defined for this robot"
+        )
+
+
+class TestNamedTargets:
+    def test_targets_read_from_srdf_content(self):
+        from agents.utils.moveit import load_named_targets
+
+        states = load_named_targets(srdf=SAMPLE_SRDF)
+        assert states["panda_arm"]["ready"]["panda_joint2"] == -0.785
+        assert states["hand"]["open"] == {"panda_finger_joint1": 0.035}
+
+    def test_overrides_take_precedence(self):
+        from agents.utils.moveit import load_named_targets
+
+        states = load_named_targets(
+            srdf=SAMPLE_SRDF,
+            overrides={
+                "panda_arm": {"ready": {"panda_joint1": 1.57}},
+                "extra": {"parked": {"j": 0.0}},
+            },
+        )
+        # overridden target replaces the SRDF one, others are kept
+        assert states["panda_arm"]["ready"] == {"panda_joint1": 1.57}
+        assert "extended" in states["panda_arm"]
+        assert states["extra"]["parked"] == {"j": 0.0}
+
+    def test_file_used_when_no_content_given(self, tmp_path):
+        from agents.utils.moveit import load_named_targets
+
+        srdf_file = tmp_path / "robot.srdf"
+        srdf_file.write_text(SAMPLE_SRDF)
+        states = load_named_targets(srdf_file=str(srdf_file))
+        assert states["panda_arm"]["ready"]["panda_joint2"] == -0.785
+
+    def test_content_preferred_over_file(self, tmp_path):
+        from agents.utils.moveit import load_named_targets
+
+        srdf_file = tmp_path / "robot.srdf"
+        srdf_file.write_text(SAMPLE_SRDF)
+        states = load_named_targets(
+            srdf='<robot><group_state name="parked" group="arm">'
+            '<joint name="j" value="1.0"/></group_state></robot>',
+            srdf_file=str(srdf_file),
+        )
+        assert states == {"arm": {"parked": {"j": 1.0}}}
+
+    def test_no_sources_returns_empty(self):
+        from agents.utils.moveit import load_named_targets
+
+        assert load_named_targets() == {}
+
+    def test_unreadable_file_returns_empty(self):
+        from agents.utils.moveit import load_named_targets
+
+        assert load_named_targets(srdf_file="/nonexistent/robot.srdf") == {}
+
+    def test_malformed_srdf_does_not_raise(self):
+        from agents.utils.moveit import load_named_targets
+
+        assert load_named_targets(srdf="<robot><not-xml") == {}
+
+
 class TestPlannerInterfaces:
     def test_pipelines_mapped_to_planner_ids(self):
         response = SimpleNamespace(
@@ -73,6 +224,64 @@ class TestPlannerInterfaces:
             "ompl": ["RRTConnect", "RRTstar"],
             "pilz": ["PTP", "LIN"],
         }
+
+
+class TestMoveMode:
+    """Mode resolution is pure goal logic — no component needed."""
+
+    @staticmethod
+    def _goal(**fields):
+        """Minimal stand-in for a MoveManipulator goal."""
+        goal = SimpleNamespace(
+            mode="",
+            named_target="",
+            cartesian_waypoints=[],
+            joint_names=[],
+            joint_positions=[],
+            target_pose=SimpleNamespace(
+                header=SimpleNamespace(frame_id=""),
+                pose=SimpleNamespace(position=SimpleNamespace(x=0.0, y=0.0, z=0.0)),
+            ),
+        )
+        for key, value in fields.items():
+            setattr(goal, key, value)
+        return goal
+
+    def test_values(self):
+        assert MoveMode.values() == ["pose", "joints", "named", "cartesian"]
+
+    def test_is_a_string_enum(self):
+        assert MoveMode.POSE == "pose"
+
+    def test_explicit_mode_normalized(self):
+        assert MoveMode.from_goal(self._goal(mode=" CARTESIAN ")) is MoveMode.CARTESIAN
+
+    def test_unknown_mode_lists_valid_modes(self):
+        with pytest.raises(ValueError, match="Valid modes"):
+            MoveMode.from_goal(self._goal(mode="teleport"))
+
+    def test_inferred_from_named_target(self):
+        assert MoveMode.from_goal(self._goal(named_target="home")) is MoveMode.NAMED
+
+    def test_inferred_from_waypoints(self):
+        goal = self._goal(cartesian_waypoints=[object()])
+        assert MoveMode.from_goal(goal) is MoveMode.CARTESIAN
+
+    def test_inferred_from_joints(self):
+        goal = self._goal(joint_names=["j1"], joint_positions=[0.5])
+        assert MoveMode.from_goal(goal) is MoveMode.JOINTS
+
+    def test_inferred_from_pose_frame_or_position(self):
+        goal = self._goal()
+        goal.target_pose.header.frame_id = "base_link"
+        assert MoveMode.from_goal(goal) is MoveMode.POSE
+        origin_goal = self._goal()
+        origin_goal.target_pose.pose.position.z = 0.5
+        assert MoveMode.from_goal(origin_goal) is MoveMode.POSE
+
+    def test_empty_goal_raises(self):
+        with pytest.raises(ValueError, match="No motion target"):
+            MoveMode.from_goal(self._goal())
 
 
 class TestMoveItMsgsGuard:

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1852,3 +1852,70 @@ class TestSceneUpdateModes:
         component._scene_refresh_tick()
 
         component._refresh_scene_from_detections.assert_not_called()
+
+
+class TestSceneGeometryCache:
+    """Scene entries carry the geometry they were applied with, so targets
+    can be resolved by name without asking move_group."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_messages(self):
+        pytest.importorskip("moveit_msgs.msg")
+        pytest.importorskip("automatika_embodied_agents.msg")
+
+    def test_manual_objects_cache_their_applied_geometry(self, rclpy_init):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(arm_group_name="arm", min_object_thickness=0.05),
+            component_name="m_geo_manual",
+        )
+        comp.get_logger = MagicMock()
+        comp._apply_scene_client = MagicMock()
+        comp._apply_scene_client.send_request.return_value = SimpleNamespace(
+            success=True
+        )
+
+        comp.add_collision_object.__wrapped__(
+            comp, "sheet", [0.4, 0.0, 0.1], [0.3, 0.3, 0.0]
+        )
+
+        entry = comp._scene_objects["sheet"]
+        assert entry["center"] == (0.4, 0.0, 0.1)
+        # the cached size is what was applied: thickness floor included
+        assert entry["size"] == (0.3, 0.3, 0.05)
+
+    def test_detection_objects_geometry_follows_the_object(self, rclpy_init):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+        from agents.ros import Topic
+
+        comp = MoveIt(
+            config=MoveItConfig(arm_group_name="arm"),
+            component_name="m_geo_det",
+            inputs=[Topic(name="d3", msg_type="Detections3D")],
+        )
+        comp.get_logger = MagicMock()
+        comp._apply_scene_client = MagicMock()
+        comp._apply_scene_client.send_request.return_value = SimpleNamespace(
+            success=True
+        )
+
+        def wire(center):
+            callback = MagicMock()
+            callback.get_output.return_value = TestDetectionObjects._detections(
+                [("mug", 0.9, center, (0.06, 0.06, 0.1))]
+            )
+            comp.callbacks = {"d3": callback}
+
+        wire((0.3, 0.0, 0.05))
+        comp.update_planning_scene.__wrapped__(comp)
+        assert comp._scene_objects["det__mug_0"]["center"] == (0.3, 0.0, 0.05)
+
+        # the mug moved: a refresh moves the cached geometry with it
+        wire((0.5, 0.1, 0.05))
+        comp.update_planning_scene.__wrapped__(comp)
+        entry = comp._scene_objects["det__mug_0"]
+        assert entry["center"] == (0.5, 0.1, 0.05)
+        assert entry["size"] == (0.06, 0.06, 0.1)

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1669,24 +1669,74 @@ class TestSceneRefresh:
         assert "table" not in ids
         assert "table" in component._scene_objects
 
-    def test_attached_objects_are_neither_evicted_nor_readded(self, component):
-        """A grasped object leaves the camera's view the moment the gripper
-        closes; evicting it or re-adding a world copy would both be wrong."""
+    def test_the_scene_freezes_while_an_object_is_held(self, component):
+        """Detection ids are score ranks, not identities: refreshing while
+        holding could hide a real obstacle behind the held object's id, or
+        re-add the held object as a world box at the gripper. Freeze, and
+        reconcile after release."""
         component._scene_objects["det__orange_0"] = {
             "source": "detection",
             "last_seen": __import__("time").time() - 100.0,
             "attached": "hand",
         }
-        # the detector reports a new orange, which ranks 0 again
+        # three oranges: the held one, seen at the gripper, and two on the
+        # table, the stronger of which ranks 0 and wears the held one's id
         self._wire(
             component,
-            self._detections([("orange", 0.9, (0.4, 0, 0), (0.06, 0.06, 0.06))]),
+            self._detections([
+                ("orange", 0.9, (0.4, 0.0, 0.05), (0.06, 0.06, 0.06)),
+                ("orange", 0.8, (0.5, 0.1, 0.05), (0.06, 0.06, 0.06)),
+                ("orange", 0.7, (0.2, 0.3, 0.2), (0.06, 0.06, 0.06)),
+            ]),
         )
         message = component.update_planning_scene.__wrapped__(component)
 
-        assert "already up to date" in message
+        assert "held" in message
         component._apply_scene_client.send_request.assert_not_called()
         assert component._scene_objects["det__orange_0"]["attached"] == "hand"
+
+    def test_the_first_refresh_after_release_reconciles(self, component):
+        entry = {
+            "source": "detection",
+            "last_seen": __import__("time").time() - 100.0,
+            "attached": "hand",
+        }
+        component._scene_objects["det__orange_0"] = entry
+        self._wire(
+            component,
+            self._detections([
+                ("orange", 0.9, (0.4, 0.0, 0.05), (0.06, 0.06, 0.06)),
+                ("orange", 0.8, (0.5, 0.1, 0.05), (0.06, 0.06, 0.06)),
+            ]),
+        )
+        component.update_planning_scene.__wrapped__(component)
+        component._apply_scene_client.send_request.assert_not_called()
+        entry.pop("attached")
+
+        component.update_planning_scene.__wrapped__(component)
+
+        scene = self._applied_scene(component)
+        ids = {o.id for o in scene.world.collision_objects}
+        assert ids == {"det__orange_0", "det__orange_1"}
+
+    def test_partition_still_exempts_attached_as_a_race_guard(self, component):
+        """The freeze normally keeps attached entries out of a refresh; the
+        partition exemption remains for an attach landing mid-refresh."""
+        from agents.utils.moveit import collision_objects_from_detections
+
+        component._scene_objects["det__orange_0"] = {
+            "source": "detection",
+            "last_seen": __import__("time").time() - 100.0,
+            "attached": "hand",
+        }
+        objects = collision_objects_from_detections(
+            self._detections([("orange", 0.9, (0.4, 0, 0), (0.06, 0.06, 0.06))])
+        )
+        added, stale = component._partition_scene_changes(
+            objects, __import__("time").time()
+        )
+        assert "det__orange_0" not in {o.id for o in added}
+        assert "det__orange_0" not in stale
 
     def test_nothing_seen_and_nothing_stale_is_a_no_op(self, component):
         self._wire(component, self._detections([]))

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1206,3 +1206,158 @@ class TestSceneServiceClients:
         assert component._apply_scene_client is None
         assert component._get_scene_client is None
         assert component._clear_octomap_client is None
+
+
+class TestSceneActions:
+    """The component actions that manage collision objects in the scene."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_moveit_msgs(self):
+        pytest.importorskip("moveit_msgs.msg")
+
+    @pytest.fixture
+    def component(self, rclpy_init):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(
+                arm_group_name="arm", pose_reference_frame="base_link"
+            ),
+            component_name="m_scene_actions",
+        )
+        comp.get_logger = MagicMock()
+        comp._apply_scene_client = MagicMock()
+        comp._apply_scene_client.send_request.return_value = SimpleNamespace(
+            success=True
+        )
+        return comp
+
+    @staticmethod
+    def _applied_scene(component):
+        request = component._apply_scene_client.send_request.call_args[0][0]
+        return request.scene
+
+    def test_add_sends_one_diff_and_tracks_the_object(self, component):
+        from moveit_msgs.msg import CollisionObject
+
+        message = component.add_collision_object.__wrapped__(
+            component, "crate", [0.4, 0.0, 0.1], [0.2, 0.3, 0.2]
+        )
+
+        scene = self._applied_scene(component)
+        assert scene.is_diff and scene.robot_state.is_diff
+        (obj,) = scene.world.collision_objects
+        assert obj.id == "crate" and obj.operation == CollisionObject.ADD
+        # empty frame falls back to the configured reference frame
+        assert obj.header.frame_id == "base_link"
+        assert list(obj.primitives[0].dimensions) == [0.2, 0.3, 0.2]
+        assert component._scene_objects["crate"]["source"] == "manual"
+        assert "Added" in message
+
+    def test_add_applies_the_thickness_floor(self, component):
+        component.config.min_object_thickness = 0.05
+        component.add_collision_object.__wrapped__(
+            component, "sheet", [0, 0, 0], [0.4, 0.4, 0.0]
+        )
+        (obj,) = self._applied_scene(component).world.collision_objects
+        assert list(obj.primitives[0].dimensions) == [0.4, 0.4, 0.05]
+
+    def test_add_reports_failure_and_tracks_nothing(self, component):
+        component._apply_scene_client.send_request.return_value = SimpleNamespace(
+            success=False
+        )
+        message = component.add_collision_object.__wrapped__(
+            component, "crate", [0, 0, 0], [0.1, 0.1, 0.1]
+        )
+        assert "Could not" in message
+        assert "crate" not in component._scene_objects
+
+    def test_add_rejects_malformed_geometry(self, component):
+        with pytest.raises(ValueError, match="3 values"):
+            component.add_collision_object.__wrapped__(
+                component, "crate", [0, 0], [0.1, 0.1, 0.1]
+            )
+
+    def test_remove_sends_remove_and_forgets_the_object(self, component):
+        from moveit_msgs.msg import CollisionObject
+
+        component._scene_objects["crate"] = {"source": "manual", "last_seen": 0.0}
+        message = component.remove_collision_object.__wrapped__(component, "crate")
+
+        (obj,) = self._applied_scene(component).world.collision_objects
+        assert obj.id == "crate" and obj.operation == CollisionObject.REMOVE
+        assert "crate" not in component._scene_objects
+        assert "Removed" in message
+
+    def test_clear_removes_tracked_objects_in_one_diff(self, component):
+        component._scene_objects = {
+            "crate": {"source": "manual", "last_seen": 0.0},
+            "det__orange_0": {"source": "detection", "last_seen": 0.0},
+        }
+        message = component.clear_collision_objects.__wrapped__(component)
+
+        removed = {o.id for o in self._applied_scene(component).world.collision_objects}
+        assert removed == {"crate", "det__orange_0"}
+        assert component._scene_objects == {}
+        assert "2" in message
+
+    def test_clear_detections_only_keeps_manual_objects(self, component):
+        component._scene_objects = {
+            "crate": {"source": "manual", "last_seen": 0.0},
+            "det__orange_0": {"source": "detection", "last_seen": 0.0},
+        }
+        component.clear_collision_objects.__wrapped__(component, detections_only=True)
+
+        removed = {o.id for o in self._applied_scene(component).world.collision_objects}
+        assert removed == {"det__orange_0"}
+        assert set(component._scene_objects) == {"crate"}
+
+    def test_clear_with_nothing_tracked_sends_nothing(self, component):
+        message = component.clear_collision_objects.__wrapped__(component)
+        component._apply_scene_client.send_request.assert_not_called()
+        assert "no objects" in message
+
+    def test_list_reads_the_scene_back_from_move_group(self, component):
+        """move_group is authoritative: it also shows objects other tools
+        placed there."""
+        component._get_scene_client = MagicMock()
+        component._get_scene_client.send_request.return_value = SimpleNamespace(
+            scene=SimpleNamespace(
+                world=SimpleNamespace(
+                    collision_objects=[
+                        SimpleNamespace(id="det__orange_0"),
+                        SimpleNamespace(id="table"),
+                    ]
+                )
+            )
+        )
+        message = component.list_collision_objects.__wrapped__(component)
+        assert "det__orange_0, table" in message
+
+    def test_list_falls_back_to_tracked_objects(self, component):
+        component._get_scene_client = MagicMock()
+        component._get_scene_client.send_request.return_value = None
+        component._scene_objects = {"crate": {"source": "manual", "last_seen": 0.0}}
+        message = component.list_collision_objects.__wrapped__(component)
+        assert "did not answer" in message and "crate" in message
+
+    def test_clear_octomap(self, component):
+        from std_srvs.srv import Empty
+
+        component._clear_octomap_client = MagicMock()
+        component._clear_octomap_client.send_request.return_value = Empty.Response()
+        message = component.clear_octomap.__wrapped__(component)
+        assert isinstance(
+            component._clear_octomap_client.send_request.call_args[0][0],
+            Empty.Request,
+        )
+        assert "Cleared" in message
+
+    def test_scene_failure_degrades_without_raising(self, component):
+        """A scene problem must never take the component down."""
+        component._apply_scene_client = None
+        message = component.add_collision_object.__wrapped__(
+            component, "crate", [0, 0, 0], [0.1, 0.1, 0.1]
+        )
+        assert "Could not" in message

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1,5 +1,6 @@
 """Tests for MoveIt request-building utilities — no ROS node needed."""
 
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -759,6 +760,76 @@ class TestCartesianGoals:
         assert result.success is False
         assert "No response" in result.message
         handle.abort.assert_called_once()
+
+
+class TestCartesianGroupAndOrientation:
+    """The Cartesian planning group override, introduced so underactuated
+    arms can pair position-only IK for pose goals with orientation-tracking
+    IK for Cartesian paths."""
+
+    @staticmethod
+    def _component(rclpy_init, **config_fields):
+        pytest.importorskip("moveit_msgs.msg")
+        from agents.components.moveit import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(
+                arm_group_name="panda_arm",
+                end_effector_link="panda_link8",
+                **config_fields,
+            ),
+            component_name=f"test_moveit_cart_group_{len(config_fields)}",
+        )
+        comp.get_logger = MagicMock()
+        comp.health_status = MagicMock()
+        return comp
+
+    @pytest.fixture
+    def component(self, rclpy_init):
+        return self._component(rclpy_init)
+
+    @pytest.fixture
+    def component_with_group(self, rclpy_init):
+        return self._component(rclpy_init, cartesian_group_name="panda_arm_cartesian")
+
+    def test_cartesian_request_uses_the_arm_group_by_default(self, component):
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = None
+        component.main_action_callback(
+            TestGoalExecution._goal_handle(TestCartesianGoals._cartesian_goal())
+        )
+
+        sent = component._cartesian_client.send_request.call_args[0][0]
+        assert sent.group_name == "panda_arm"
+
+    def test_cartesian_request_uses_the_configured_cartesian_group(
+        self, component_with_group
+    ):
+        component_with_group._cartesian_client = MagicMock()
+        component_with_group._cartesian_client.send_request.return_value = None
+        component_with_group.main_action_callback(
+            TestGoalExecution._goal_handle(TestCartesianGoals._cartesian_goal())
+        )
+
+        sent = component_with_group._cartesian_client.send_request.call_args[0][0]
+        assert sent.group_name == "panda_arm_cartesian"
+
+    def test_descend_uses_the_configured_cartesian_group(self, component_with_group):
+        component_with_group._cartesian_client = MagicMock()
+        component_with_group._cartesian_client.send_request.return_value = (
+            TestCartesianGoals._path_response(1.0)
+        )
+        component_with_group._exec_client = TestGoalExecution._client()
+        handle = TestGoalExecution._goal_handle(MagicMock(), active=True)
+
+        outcome, _ = component_with_group._sequence_descent(
+            0.2, 0.0, 0.05, None, handle, deadline=time.time() + 10
+        )
+
+        assert outcome == "ok"
+        sent = component_with_group._cartesian_client.send_request.call_args[0][0]
+        assert sent.group_name == "panda_arm_cartesian"
 
 
 class TestGripperActions:

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1,0 +1,239 @@
+"""Tests for MoveIt request-building utilities — no ROS node needed."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agents.utils.moveit import (
+    ensure_moveit_msgs,
+    parse_planner_interfaces,
+    parse_srdf_group_states,
+)
+
+SAMPLE_SRDF = """
+<robot name="panda">
+  <group name="panda_arm">
+    <chain base_link="panda_link0" tip_link="panda_link8"/>
+  </group>
+  <group name="hand">
+    <joint name="panda_finger_joint1"/>
+  </group>
+  <group_state name="ready" group="panda_arm">
+    <joint name="panda_joint1" value="0"/>
+    <joint name="panda_joint2" value="-0.785"/>
+  </group_state>
+  <group_state name="extended" group="panda_arm">
+    <joint name="panda_joint1" value="0"/>
+    <joint name="panda_joint2" value="0"/>
+  </group_state>
+  <group_state name="open" group="hand">
+    <joint name="panda_finger_joint1" value="0.035"/>
+  </group_state>
+</robot>
+"""
+
+
+class TestSrdfParsing:
+    def test_group_states_extracted_per_group(self):
+        states = parse_srdf_group_states(SAMPLE_SRDF)
+        assert set(states.keys()) == {"panda_arm", "hand"}
+        assert states["panda_arm"]["ready"] == {
+            "panda_joint1": 0.0,
+            "panda_joint2": -0.785,
+        }
+        assert set(states["panda_arm"].keys()) == {"ready", "extended"}
+        assert states["hand"]["open"] == {"panda_finger_joint1": 0.035}
+
+    def test_multi_dof_value_takes_first(self):
+        srdf = (
+            '<robot><group_state name="s" group="g">'
+            '<joint name="j" value="1.5 0.5"/></group_state></robot>'
+        )
+        assert parse_srdf_group_states(srdf) == {"g": {"s": {"j": 1.5}}}
+
+    def test_no_states_empty(self):
+        assert parse_srdf_group_states("<robot/>") == {}
+
+
+class TestPlannerInterfaces:
+    def test_pipelines_mapped_to_planner_ids(self):
+        response = SimpleNamespace(
+            planner_interfaces=[
+                SimpleNamespace(
+                    name="OMPL",
+                    pipeline_id="ompl",
+                    planner_ids=["RRTConnect", "RRTstar"],
+                ),
+                SimpleNamespace(
+                    name="Pilz", pipeline_id="pilz", planner_ids=["PTP", "LIN"]
+                ),
+            ]
+        )
+        assert parse_planner_interfaces(response) == {
+            "ompl": ["RRTConnect", "RRTstar"],
+            "pilz": ["PTP", "LIN"],
+        }
+
+
+class TestMoveItMsgsGuard:
+    def test_ensure_raises_without_moveit(self, monkeypatch):
+        monkeypatch.setattr(
+            "agents.utils.moveit.find_spec", lambda name: None
+        )
+        with pytest.raises(ModuleNotFoundError, match="moveit-msgs"):
+            ensure_moveit_msgs()
+
+    def test_builders_raise_install_hint_without_moveit(self, monkeypatch):
+        """Every builder must surface the install instructions even when
+        called directly, without going through the component."""
+        from agents.utils import moveit as moveit_utils
+
+        monkeypatch.setattr("agents.utils.moveit.find_spec", lambda name: None)
+        for builder, args in [
+            (moveit_utils.joints_to_constraints, ({"j1": 0.0}, 1e-3)),
+            (moveit_utils.build_move_group_goal, (None, "arm")),
+            (moveit_utils.build_cartesian_request, ([], "base", "arm", "ee")),
+            (moveit_utils.moveit_error_string, (1,)),
+        ]:
+            with pytest.raises(ModuleNotFoundError, match="moveit-msgs"):
+                builder(*args)
+
+
+class TestRequestBuilders:
+    """Builders produce real moveit_msgs — skipped when not installed."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_moveit_msgs(self):
+        pytest.importorskip("moveit_msgs.msg")
+
+    @staticmethod
+    def _pose_stamped(x=0.3, y=0.0, z=0.5, frame="base_link"):
+        from geometry_msgs.msg import PoseStamped
+
+        pose = PoseStamped()
+        pose.header.frame_id = frame
+        pose.pose.position.x = x
+        pose.pose.position.y = y
+        pose.pose.position.z = z
+        pose.pose.orientation.w = 1.0
+        return pose
+
+    def test_pose_constraints(self):
+        from shape_msgs.msg import SolidPrimitive
+
+        from agents.utils.moveit import pose_to_constraints
+
+        constraints = pose_to_constraints(
+            self._pose_stamped(),
+            link_name="ee_link",
+            position_tolerance=1e-3,
+            orientation_tolerance=1e-2,
+        )
+        position = constraints.position_constraints[0]
+        assert position.link_name == "ee_link"
+        assert position.header.frame_id == "base_link"
+        sphere = position.constraint_region.primitives[0]
+        assert sphere.type == SolidPrimitive.SPHERE
+        assert list(sphere.dimensions) == [1e-3]
+        assert position.constraint_region.primitive_poses[0].position.x == 0.3
+        orientation = constraints.orientation_constraints[0]
+        assert orientation.orientation.w == 1.0
+        assert orientation.absolute_x_axis_tolerance == 1e-2
+        assert position.weight == orientation.weight == 1.0
+
+    def test_pose_constraints_per_axis_orientation_tolerance(self):
+        """Per-axis tolerances support underactuated arms (e.g. relax only
+        the tool axis on a 5-DOF arm)."""
+        from agents.utils.moveit import pose_to_constraints
+
+        constraints = pose_to_constraints(
+            self._pose_stamped(),
+            link_name="ee_link",
+            position_tolerance=1e-3,
+            orientation_tolerance=(1e-2, 1e-2, 3.14),
+        )
+        orientation = constraints.orientation_constraints[0]
+        assert orientation.absolute_x_axis_tolerance == pytest.approx(1e-2)
+        assert orientation.absolute_y_axis_tolerance == pytest.approx(1e-2)
+        assert orientation.absolute_z_axis_tolerance == pytest.approx(3.14)
+
+    def test_pose_constraints_bad_tolerance_length_raises(self):
+        from agents.utils.moveit import pose_to_constraints
+
+        with pytest.raises(ValueError, match="3 per-axis"):
+            pose_to_constraints(
+                self._pose_stamped(),
+                link_name="ee_link",
+                position_tolerance=1e-3,
+                orientation_tolerance=(1e-2, 1e-2),
+            )
+
+    def test_joint_constraints(self):
+        from agents.utils.moveit import joints_to_constraints
+
+        constraints = joints_to_constraints({"j1": 0.5, "j2": -0.25}, tolerance=1e-3)
+        assert len(constraints.joint_constraints) == 2
+        first = constraints.joint_constraints[0]
+        assert first.joint_name == "j1"
+        assert first.position == 0.5
+        assert first.tolerance_above == first.tolerance_below == 1e-3
+
+    def test_move_group_goal(self):
+        from agents.utils.moveit import build_move_group_goal, joints_to_constraints
+
+        constraints = joints_to_constraints({"j1": 0.5}, tolerance=1e-3)
+        goal = build_move_group_goal(
+            constraints,
+            "panda_arm",
+            pipeline_id="ompl",
+            planner_id="RRTConnect",
+            num_attempts=3,
+            allowed_time=2.0,
+            velocity_scaling=0.2,
+            acceleration_scaling=0.3,
+            plan_only=True,
+        )
+        request = goal.request
+        assert request.group_name == "panda_arm"
+        assert request.goal_constraints == [constraints]
+        assert request.pipeline_id == "ompl"
+        assert request.planner_id == "RRTConnect"
+        assert request.num_planning_attempts == 3
+        assert request.allowed_planning_time == 2.0
+        assert request.max_velocity_scaling_factor == pytest.approx(0.2)
+        assert request.max_acceleration_scaling_factor == pytest.approx(0.3)
+        # plan from the currently monitored robot state
+        assert request.start_state.is_diff is True
+        assert goal.planning_options.plan_only is True
+
+    def test_cartesian_request(self):
+        from agents.utils.moveit import build_cartesian_request
+
+        waypoints = [self._pose_stamped().pose, self._pose_stamped(z=0.6).pose]
+        request = build_cartesian_request(
+            waypoints,
+            frame_id="base_link",
+            group_name="panda_arm",
+            link_name="ee_link",
+            max_step=0.005,
+            avoid_collisions=False,
+        )
+        assert request.header.frame_id == "base_link"
+        assert request.group_name == "panda_arm"
+        assert request.link_name == "ee_link"
+        assert len(request.waypoints) == 2
+        assert request.max_step == pytest.approx(0.005)
+        assert request.avoid_collisions is False
+        assert request.start_state.is_diff is True
+
+    def test_error_string(self):
+        from moveit_msgs.msg import MoveItErrorCodes
+
+        from agents.utils.moveit import moveit_error_string
+
+        assert moveit_error_string(MoveItErrorCodes.SUCCESS) == "SUCCESS"
+        assert (
+            moveit_error_string(MoveItErrorCodes.PLANNING_FAILED)
+            == "PLANNING_FAILED"
+        )
+        assert moveit_error_string(-987654) == "UNKNOWN_ERROR(-987654)"

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1361,3 +1361,156 @@ class TestSceneActions:
             component, "crate", [0, 0, 0], [0.1, 0.1, 0.1]
         )
         assert "Could not" in message
+
+
+class TestAttachDetach:
+    """Attaching a grasped object to the robot and letting go of it again."""
+
+    GRIPPER_SRDF = """
+    <robot name="bot">
+      <group name="gripper">
+        <joint name="jaw"/>
+        <link name="hand"/><link name="left_finger"/><link name="right_finger"/>
+      </group>
+      <end_effector name="eef" parent_link="hand" group="gripper"/>
+    </robot>
+    """
+
+    @pytest.fixture(autouse=True)
+    def _needs_moveit_msgs(self):
+        pytest.importorskip("moveit_msgs.msg")
+
+    @pytest.fixture
+    def component(self, rclpy_init):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(
+                arm_group_name="arm",
+                gripper_group_name="gripper",
+                end_effector_link="hand",
+            ),
+            component_name="m_attach",
+        )
+        comp.get_logger = MagicMock()
+        comp._apply_scene_client = MagicMock()
+        comp._apply_scene_client.send_request.return_value = SimpleNamespace(
+            success=True
+        )
+        comp._srdf = self.GRIPPER_SRDF
+        return comp
+
+    @staticmethod
+    def _applied_scenes(component):
+        return [
+            call[0][0].scene
+            for call in component._apply_scene_client.send_request.call_args_list
+        ]
+
+    def test_attach_defaults_to_the_end_effector_and_srdf_touch_links(
+        self, component
+    ):
+        from moveit_msgs.msg import CollisionObject
+
+        component._scene_objects["det__orange_0"] = {
+            "source": "detection",
+            "last_seen": 0.0,
+        }
+        message = component.attach_object.__wrapped__(component, "det__orange_0")
+
+        (scene,) = self._applied_scenes(component)
+        (attached,) = scene.robot_state.attached_collision_objects
+        assert attached.link_name == "hand"
+        assert attached.object.id == "det__orange_0"
+        assert attached.object.operation == CollisionObject.ADD
+        assert list(attached.touch_links) == ["hand", "left_finger", "right_finger"]
+        assert component._scene_objects["det__orange_0"]["attached"] == "hand"
+        assert "Attached" in message
+
+    def test_explicit_touch_links_win_over_config_and_srdf(self, component):
+        component.config.touch_links = ["from_config"]
+        component.attach_object.__wrapped__(
+            component, "o", touch_links=["only_this"]
+        )
+        (scene,) = self._applied_scenes(component)
+        assert list(
+            scene.robot_state.attached_collision_objects[0].touch_links
+        ) == ["only_this"]
+
+    def test_configured_touch_links_win_over_the_srdf(self, component):
+        component.config.touch_links = ["from_config"]
+        component.attach_object.__wrapped__(component, "o")
+        (scene,) = self._applied_scenes(component)
+        assert list(
+            scene.robot_state.attached_collision_objects[0].touch_links
+        ) == ["from_config"]
+
+    def test_the_srdf_is_fetched_lazily_when_not_cached(self, component):
+        """Attaching before any named-target use still finds the gripper."""
+        component._srdf = None
+        component._param_client = MagicMock()
+        component._param_client.send_request_from_dict.return_value = SimpleNamespace(
+            values=[SimpleNamespace(string_value=self.GRIPPER_SRDF)]
+        )
+        component.attach_object.__wrapped__(component, "o")
+        (scene,) = self._applied_scenes(component)
+        assert list(
+            scene.robot_state.attached_collision_objects[0].touch_links
+        ) == ["hand", "left_finger", "right_finger"]
+
+    def test_attach_without_any_link_reports_it(self, component):
+        component.config.end_effector_link = ""
+        message = component.attach_object.__wrapped__(component, "o")
+        assert "No link" in message
+        component._apply_scene_client.send_request.assert_not_called()
+
+    def test_attach_failure_marks_nothing(self, component):
+        component._apply_scene_client.send_request.return_value = SimpleNamespace(
+            success=False
+        )
+        component._scene_objects["o"] = {"source": "manual", "last_seen": 0.0}
+        message = component.attach_object.__wrapped__(component, "o")
+        assert "Could not" in message
+        assert "attached" not in component._scene_objects["o"]
+
+    def test_detach_returns_the_object_to_the_scene(self, component):
+        from moveit_msgs.msg import CollisionObject
+
+        component._scene_objects["o"] = {
+            "source": "manual",
+            "last_seen": 0.0,
+            "attached": "hand",
+        }
+        message = component.detach_object.__wrapped__(component, "o")
+
+        (scene,) = self._applied_scenes(component)
+        (attached,) = scene.robot_state.attached_collision_objects
+        assert attached.object.operation == CollisionObject.REMOVE
+        # empty link searches every link for the object
+        assert attached.link_name == ""
+        assert "attached" not in component._scene_objects["o"]
+        assert "remains in the scene" in message
+
+    def test_detach_with_remove_deletes_in_a_second_change(self, component):
+        component._scene_objects["o"] = {
+            "source": "manual",
+            "last_seen": 0.0,
+            "attached": "hand",
+        }
+        message = component.detach_object.__wrapped__(component, "o", remove=True)
+
+        detach_scene, remove_scene = self._applied_scenes(component)
+        assert detach_scene.robot_state.attached_collision_objects
+        (removed,) = remove_scene.world.collision_objects
+        assert removed.id == "o"
+        assert "o" not in component._scene_objects
+        assert "removed" in message
+
+    def test_detach_remove_reports_a_partial_failure(self, component):
+        component._apply_scene_client.send_request.side_effect = [
+            SimpleNamespace(success=True),
+            SimpleNamespace(success=False),
+        ]
+        message = component.detach_object.__wrapped__(component, "o", remove=True)
+        assert "Detached" in message and "could not remove" in message

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1514,3 +1514,341 @@ class TestAttachDetach:
         ]
         message = component.detach_object.__wrapped__(component, "o", remove=True)
         assert "Detached" in message and "could not remove" in message
+
+
+class TestSceneRefresh:
+    """Detections pushed into the planning scene, with TTL bookkeeping."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_messages(self):
+        pytest.importorskip("moveit_msgs.msg")
+        pytest.importorskip("automatika_embodied_agents.msg")
+
+    @pytest.fixture
+    def component(self, rclpy_init):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+        from agents.ros import Topic
+
+        comp = MoveIt(
+            config=MoveItConfig(arm_group_name="arm", scene_object_ttl=5.0),
+            component_name="m_refresh",
+            inputs=[Topic(name="d3", msg_type="Detections3D")],
+        )
+        comp.get_logger = MagicMock()
+        comp._apply_scene_client = MagicMock()
+        comp._apply_scene_client.send_request.return_value = SimpleNamespace(
+            success=True
+        )
+        return comp
+
+    @staticmethod
+    def _wire(component, message):
+        callback = MagicMock()
+        callback.get_output.return_value = message
+        component.callbacks = {"d3": callback}
+        return callback
+
+    @staticmethod
+    def _applied_scene(component):
+        request = component._apply_scene_client.send_request.call_args[0][0]
+        return request.scene
+
+    def _detections(self, entries):
+        return TestDetectionObjects._detections(entries)
+
+    def test_detections_become_tracked_scene_objects(self, component):
+        from moveit_msgs.msg import CollisionObject
+
+        callback = self._wire(
+            component,
+            self._detections([
+                ("orange", 0.9, (0.3, 0.0, 0.05), (0.06, 0.06, 0.06)),
+                ("bowl", 0.7, (0.5, 0.1, 0.05), (0.2, 0.2, 0.1)),
+            ]),
+        )
+        message = component.update_planning_scene.__wrapped__(component)
+
+        # the message is requested, not the callback's prompt-context default
+        assert callback.get_output.call_args.kwargs.get("get_msg") is True
+        scene = self._applied_scene(component)
+        by_id = {o.id: o for o in scene.world.collision_objects}
+        assert set(by_id) == {"det__orange_0", "det__bowl_0"}
+        assert all(
+            o.operation == CollisionObject.ADD for o in by_id.values()
+        )
+        assert component._scene_objects["det__orange_0"]["source"] == "detection"
+        assert "2 detected object(s)" in message
+
+    def test_without_a_detections_input_it_says_so(self, rclpy_init):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(arm_group_name="arm"),
+            component_name="m_refresh_none",
+        )
+        assert "No detections input" in comp.update_planning_scene.__wrapped__(comp)
+
+    def test_before_any_message_it_says_so(self, component):
+        self._wire(component, None)
+        assert "No detections have been received" in (
+            component.update_planning_scene.__wrapped__(component)
+        )
+
+    def test_stale_objects_are_removed_in_the_same_diff(self, component):
+        from moveit_msgs.msg import CollisionObject
+
+        import time as time_module
+
+        component._scene_objects["det__cup_0"] = {
+            "source": "detection",
+            "last_seen": time_module.time() - 10.0,  # past the 5 s TTL
+        }
+        self._wire(
+            component,
+            self._detections([("orange", 0.9, (0.3, 0, 0), (0.06, 0.06, 0.06))]),
+        )
+        message = component.update_planning_scene.__wrapped__(component)
+
+        scene = self._applied_scene(component)
+        ops = {o.id: o.operation for o in scene.world.collision_objects}
+        assert ops["det__orange_0"] == CollisionObject.ADD
+        assert ops["det__cup_0"] == CollisionObject.REMOVE
+        assert "det__cup_0" not in component._scene_objects
+        assert "removed 1 stale" in message
+
+    def test_recently_seen_objects_survive_a_dropout(self, component):
+        component._scene_objects["det__cup_0"] = {
+            "source": "detection",
+            "last_seen": __import__("time").time() - 1.0,  # within the TTL
+        }
+        self._wire(
+            component,
+            self._detections([("orange", 0.9, (0.3, 0, 0), (0.06, 0.06, 0.06))]),
+        )
+        component.update_planning_scene.__wrapped__(component)
+
+        ids = {o.id for o in self._applied_scene(component).world.collision_objects}
+        assert "det__cup_0" not in ids  # no REMOVE sent
+        assert "det__cup_0" in component._scene_objects
+
+    def test_manual_objects_are_never_ttl_evicted(self, component):
+        component._scene_objects["table"] = {
+            "source": "manual",
+            "last_seen": __import__("time").time() - 100.0,
+        }
+        self._wire(
+            component,
+            self._detections([("orange", 0.9, (0.3, 0, 0), (0.06, 0.06, 0.06))]),
+        )
+        component.update_planning_scene.__wrapped__(component)
+
+        ids = {o.id for o in self._applied_scene(component).world.collision_objects}
+        assert "table" not in ids
+        assert "table" in component._scene_objects
+
+    def test_attached_objects_are_neither_evicted_nor_readded(self, component):
+        """A grasped object leaves the camera's view the moment the gripper
+        closes; evicting it or re-adding a world copy would both be wrong."""
+        component._scene_objects["det__orange_0"] = {
+            "source": "detection",
+            "last_seen": __import__("time").time() - 100.0,
+            "attached": "hand",
+        }
+        # the detector reports a new orange, which ranks 0 again
+        self._wire(
+            component,
+            self._detections([("orange", 0.9, (0.4, 0, 0), (0.06, 0.06, 0.06))]),
+        )
+        message = component.update_planning_scene.__wrapped__(component)
+
+        assert "already up to date" in message
+        component._apply_scene_client.send_request.assert_not_called()
+        assert component._scene_objects["det__orange_0"]["attached"] == "hand"
+
+    def test_nothing_seen_and_nothing_stale_is_a_no_op(self, component):
+        self._wire(component, self._detections([]))
+        message = component.update_planning_scene.__wrapped__(component)
+        component._apply_scene_client.send_request.assert_not_called()
+        assert "already up to date" in message
+
+    def test_apply_failure_leaves_bookkeeping_untouched(self, component):
+        component._apply_scene_client.send_request.return_value = SimpleNamespace(
+            success=False
+        )
+        self._wire(
+            component,
+            self._detections([("orange", 0.9, (0.3, 0, 0), (0.06, 0.06, 0.06))]),
+        )
+        message = component.update_planning_scene.__wrapped__(component)
+        assert "Could not" in message
+        assert component._scene_objects == {}
+
+
+class TestSceneUpdateModes:
+    """When detections reach the scene without being asked for explicitly."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_moveit_msgs(self):
+        pytest.importorskip("moveit_msgs.msg")
+
+    @pytest.fixture
+    def component(self, rclpy_init):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+        from agents.ros import Topic
+
+        comp = MoveIt(
+            config=MoveItConfig(arm_group_name="panda_arm"),
+            component_name="m_modes",
+            inputs=[Topic(name="d3", msg_type="Detections3D")],
+        )
+        comp.get_logger = MagicMock()
+        comp.health_status = MagicMock()
+        return comp
+
+    def test_on_goal_refreshes_before_planning(self, component):
+        component.config.scene_update_mode = "on_goal"
+        component._refresh_scene_from_detections = MagicMock(
+            return_value="Planning scene updated with 1 detected object(s)"
+        )
+        component._move_client = TestGoalExecution._client()
+        handle = TestGoalExecution._goal_handle(TestGoalExecution._joint_goal())
+
+        result = component.main_action_callback(handle)
+
+        component._refresh_scene_from_detections.assert_called_once()
+        # the refresh is announced through the goal's feedback
+        feedback = handle.publish_feedback.call_args_list[0][0][0]
+        assert feedback.state == "UPDATING_SCENE"
+        assert result.success
+
+    def test_on_goal_scene_failure_never_aborts_the_motion(self, component):
+        component.config.scene_update_mode = "on_goal"
+        component._refresh_scene_from_detections = MagicMock(
+            return_value="Could not update the planning scene"
+        )
+        component._move_client = TestGoalExecution._client()
+        handle = TestGoalExecution._goal_handle(TestGoalExecution._joint_goal())
+
+        result = component.main_action_callback(handle)
+
+        assert result.success  # planned against the previous scene
+
+    def test_manual_mode_does_not_refresh_on_goals(self, component):
+        component._refresh_scene_from_detections = MagicMock()
+        component._move_client = TestGoalExecution._client()
+        handle = TestGoalExecution._goal_handle(TestGoalExecution._joint_goal())
+
+        component.main_action_callback(handle)
+
+        component._refresh_scene_from_detections.assert_not_called()
+
+    def test_continuous_mode_starts_a_timer_on_activation(
+        self, component, monkeypatch
+    ):
+        component.config.scene_update_mode = "continuous"
+        component.config.scene_update_rate = 2.0
+        component.create_timer = MagicMock()
+        monkeypatch.setattr(
+            "ros_sugar.core.component.BaseComponent.custom_on_activate",
+            lambda _: None,
+        )
+
+        component.custom_on_activate()
+
+        period = component.create_timer.call_args[0][0]
+        assert period == pytest.approx(0.5)
+        assert component._scene_timer is component.create_timer.return_value
+
+    def test_modes_without_a_detections_input_warn_instead(
+        self, rclpy_init, monkeypatch
+    ):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(
+                arm_group_name="arm", scene_update_mode="continuous"
+            ),
+            component_name="m_modes_warn",
+        )
+        comp.get_logger = MagicMock()
+        comp.create_timer = MagicMock()
+        monkeypatch.setattr(
+            "ros_sugar.core.component.BaseComponent.custom_on_activate",
+            lambda _: None,
+        )
+
+        comp.custom_on_activate()
+
+        comp.create_timer.assert_not_called()
+        assert "no Detections3D input" in comp.get_logger().warning.call_args[0][0]
+
+    def test_deactivation_stops_the_timer(self, component, monkeypatch):
+        component._scene_timer = MagicMock()
+        component.destroy_timer = MagicMock()
+        monkeypatch.setattr(
+            "ros_sugar.core.component.BaseComponent.custom_on_deactivate",
+            lambda _: None,
+        )
+
+        component.custom_on_deactivate()
+
+        component.destroy_timer.assert_called_once()
+        assert component._scene_timer is None
+
+    # ------------------------------------------------------------------
+    # The continuous tick's skip guard
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _wire_message(component, message):
+        callback = MagicMock()
+        callback.get_output.return_value = message
+        component.callbacks = {"d3": callback}
+
+    def test_tick_refreshes_on_a_new_message(self, component):
+        component._refresh_scene_from_detections = MagicMock(return_value="ok")
+        self._wire_message(component, object())
+
+        component._scene_refresh_tick()
+
+        component._refresh_scene_from_detections.assert_called_once()
+
+    def test_tick_skips_an_already_applied_message(self, component):
+        component._refresh_scene_from_detections = MagicMock(return_value="ok")
+        message = object()
+        self._wire_message(component, message)
+
+        component._scene_refresh_tick()
+        component._scene_refresh_tick()
+
+        assert component._refresh_scene_from_detections.call_count == 1
+
+    def test_tick_refreshes_a_stale_scene_even_without_a_new_message(
+        self, component
+    ):
+        """Objects due for eviction get their removal without waiting for the
+        detector to publish again."""
+        component._refresh_scene_from_detections = MagicMock(return_value="ok")
+        message = object()
+        self._wire_message(component, message)
+        component._scene_refresh_tick()
+
+        component._scene_objects["det__cup_0"] = {
+            "source": "detection",
+            "last_seen": __import__("time").time() - 100.0,
+        }
+        component._scene_refresh_tick()
+
+        assert component._refresh_scene_from_detections.call_count == 2
+
+    def test_tick_without_any_message_does_nothing(self, component):
+        component._refresh_scene_from_detections = MagicMock()
+        self._wire_message(component, None)
+
+        component._scene_refresh_tick()
+
+        component._refresh_scene_from_detections.assert_not_called()

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -446,3 +446,381 @@ class TestRequestBuilders:
             == "PLANNING_FAILED"
         )
         assert moveit_error_string(-987654) == "UNKNOWN_ERROR(-987654)"
+
+
+class TestGoalExecution:
+    """Goal handling in main_action_callback, with mocked move_group clients."""
+
+    @pytest.fixture
+    def component(self, rclpy_init):
+        pytest.importorskip("moveit_msgs.msg")
+        from agents.components.moveit import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(
+                arm_group_name="panda_arm",
+                gripper_group_name="hand",
+                end_effector_link="panda_link8",
+            ),
+            component_name="test_moveit_goals",
+        )
+        comp.get_logger = MagicMock()
+        comp.health_status = MagicMock()
+        comp._named_targets = {
+            "panda_arm": {"ready": {"panda_joint1": 0.0}},
+            "hand": {"open": {"panda_finger_joint1": 0.035}},
+        }
+        return comp
+
+    @staticmethod
+    def _client(error_code=None, returned=True, accepted=True):
+        """Action client handler that has already returned a result."""
+        from moveit_msgs.msg import MoveItErrorCodes
+
+        client = MagicMock()
+        client.send_request.return_value = accepted
+        client.action_returned = returned
+        client.cancel_request.return_value = (True, "canceled")
+        client.action_result = MagicMock(
+            error_code=MagicMock(
+                val=MoveItErrorCodes.SUCCESS if error_code is None else error_code
+            )
+        )
+        return client
+
+    @staticmethod
+    def _goal_handle(goal, active=True, cancel_requested=False):
+        handle = MagicMock()
+        handle.request = goal
+        handle.is_active = active
+        handle.is_cancel_requested = cancel_requested
+        return handle
+
+    @staticmethod
+    def _joint_goal():
+        from automatika_embodied_agents.action import MoveManipulator
+
+        goal = MoveManipulator.Goal()
+        goal.mode = "joints"
+        goal.joint_names = ["panda_joint1"]
+        goal.joint_positions = [0.5]
+        return goal
+
+    def test_successful_motion_succeeds_goal(self, component):
+        component._move_client = self._client()
+        handle = self._goal_handle(self._joint_goal())
+
+        result = component.main_action_callback(handle)
+
+        assert result.success is True
+        assert result.message == "SUCCESS"
+        handle.succeed.assert_called_once()
+        handle.abort.assert_not_called()
+        component.health_status.set_healthy.assert_called_once()
+
+    def test_planning_failure_aborts_with_reason(self, component):
+        from moveit_msgs.msg import MoveItErrorCodes
+
+        component._move_client = self._client(
+            error_code=MoveItErrorCodes.PLANNING_FAILED
+        )
+        handle = self._goal_handle(self._joint_goal())
+
+        result = component.main_action_callback(handle)
+
+        assert result.success is False
+        assert result.message == "PLANNING_FAILED"
+        assert result.error_code == MoveItErrorCodes.PLANNING_FAILED
+        handle.abort.assert_called_once()
+        component.health_status.set_fail_component.assert_called_once()
+
+    def test_cancel_is_propagated_to_move_group(self, component):
+        # goal never returns, so the wait loop sees the cancel request
+        component._move_client = self._client(returned=False)
+        handle = self._goal_handle(self._joint_goal(), cancel_requested=True)
+
+        component.main_action_callback(handle)
+
+        component._move_client.cancel_request.assert_called_once()
+        handle.canceled.assert_called_once()
+        handle.abort.assert_not_called()
+
+    def test_preempted_goal_is_not_transitioned(self, component):
+        """A goal aborted by preemption is terminal — transitioning it again
+        would be an invalid state transition."""
+        component._move_client = self._client(returned=False)
+        handle = self._goal_handle(self._joint_goal(), active=False)
+
+        component.main_action_callback(handle)
+
+        component._move_client.cancel_request.assert_called_once()
+        handle.canceled.assert_not_called()
+        handle.abort.assert_not_called()
+        handle.succeed.assert_not_called()
+
+    def test_rejected_goal_aborts(self, component):
+        component._move_client = self._client(accepted=False)
+        handle = self._goal_handle(self._joint_goal())
+
+        result = component.main_action_callback(handle)
+
+        assert result.success is False
+        assert "did not accept" in result.message
+        handle.abort.assert_called_once()
+
+    def test_invalid_goal_aborts_without_sending(self, component):
+        from automatika_embodied_agents.action import MoveManipulator
+
+        component._move_client = self._client()
+        handle = self._goal_handle(MoveManipulator.Goal())  # no target set
+
+        result = component.main_action_callback(handle)
+
+        assert "No motion target" in result.message
+        component._move_client.send_request.assert_not_called()
+        handle.abort.assert_called_once()
+
+    def test_named_target_resolved_to_group_and_joints(self, component):
+        from automatika_embodied_agents.action import MoveManipulator
+
+        component._move_client = self._client()
+        goal = MoveManipulator.Goal()
+        goal.named_target = "ready"
+
+        component.main_action_callback(self._goal_handle(goal))
+
+        sent = component._move_client.send_request.call_args[0][0]
+        assert sent.request.group_name == "panda_arm"
+        constraint = sent.request.goal_constraints[0].joint_constraints[0]
+        assert constraint.joint_name == "panda_joint1"
+
+    def test_unknown_named_target_aborts(self, component):
+        from automatika_embodied_agents.action import MoveManipulator
+
+        component._move_client = self._client()
+        goal = MoveManipulator.Goal()
+        goal.named_target = "nowhere"
+
+        result = component.main_action_callback(self._goal_handle(goal))
+
+        assert "not defined in the robot SRDF" in result.message
+        component._move_client.send_request.assert_not_called()
+
+    def test_pose_goal_uses_configured_link_and_scalings(self, component):
+        from automatika_embodied_agents.action import MoveManipulator
+
+        component._move_client = self._client()
+        goal = MoveManipulator.Goal()
+        goal.mode = "pose"
+        goal.target_pose.header.frame_id = "panda_link0"
+        goal.target_pose.pose.orientation.w = 1.0
+        goal.velocity_scaling = 0.5
+
+        component.main_action_callback(self._goal_handle(goal))
+
+        sent = component._move_client.send_request.call_args[0][0]
+        position = sent.request.goal_constraints[0].position_constraints[0]
+        assert position.link_name == "panda_link8"
+        # per-goal override wins, unset scaling falls back to the config value
+        assert sent.request.max_velocity_scaling_factor == pytest.approx(0.5)
+        assert sent.request.max_acceleration_scaling_factor == pytest.approx(0.1)
+
+    def test_mismatched_joint_arrays_abort(self, component):
+        component._move_client = self._client()
+        goal = self._joint_goal()
+        goal.joint_positions = [0.5, 0.7]
+
+        result = component.main_action_callback(self._goal_handle(goal))
+
+        assert "same length" in result.message
+        component._move_client.send_request.assert_not_called()
+
+
+class TestCartesianGoals:
+    @pytest.fixture
+    def component(self, rclpy_init):
+        pytest.importorskip("moveit_msgs.msg")
+        from agents.components.moveit import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(arm_group_name="panda_arm"),
+            component_name="test_moveit_cartesian",
+        )
+        comp.get_logger = MagicMock()
+        comp.health_status = MagicMock()
+        return comp
+
+    @staticmethod
+    def _cartesian_goal(plan_only=False):
+        from automatika_embodied_agents.action import MoveManipulator
+        from geometry_msgs.msg import Pose
+
+        goal = MoveManipulator.Goal()
+        goal.mode = "cartesian"
+        waypoint = Pose()
+        waypoint.position.z = 0.5
+        waypoint.orientation.w = 1.0
+        goal.cartesian_waypoints = [waypoint]
+        goal.frame_id = "panda_link0"
+        goal.plan_only = plan_only
+        return goal
+
+    @staticmethod
+    def _path_response(fraction):
+        from moveit_msgs.msg import MoveItErrorCodes, RobotTrajectory
+
+        return SimpleNamespace(
+            fraction=fraction,
+            solution=RobotTrajectory(),
+            error_code=MoveItErrorCodes(val=MoveItErrorCodes.SUCCESS),
+        )
+
+    def test_full_path_is_executed(self, component):
+        from moveit_msgs.msg import MoveItErrorCodes
+
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = self._path_response(1.0)
+        component._exec_client = TestGoalExecution._client()
+        handle = TestGoalExecution._goal_handle(self._cartesian_goal())
+
+        result = component.main_action_callback(handle)
+
+        assert result.success is True
+        assert result.cartesian_fraction == pytest.approx(1.0)
+        assert result.error_code == MoveItErrorCodes.SUCCESS
+        component._exec_client.send_request.assert_called_once()
+        handle.succeed.assert_called_once()
+
+    def test_partial_path_aborts_without_executing(self, component):
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = self._path_response(0.4)
+        component._exec_client = TestGoalExecution._client()
+        handle = TestGoalExecution._goal_handle(self._cartesian_goal())
+
+        result = component.main_action_callback(handle)
+
+        assert result.success is False
+        assert result.cartesian_fraction == pytest.approx(0.4)
+        assert "below the configured threshold" in result.message
+        # nothing is executed when too little of the path is achievable
+        component._exec_client.send_request.assert_not_called()
+        handle.abort.assert_called_once()
+
+    def test_plan_only_does_not_execute(self, component):
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = self._path_response(1.0)
+        component._exec_client = TestGoalExecution._client()
+        handle = TestGoalExecution._goal_handle(self._cartesian_goal(plan_only=True))
+
+        result = component.main_action_callback(handle)
+
+        assert result.success is True
+        component._exec_client.send_request.assert_not_called()
+        handle.succeed.assert_called_once()
+
+    def test_no_service_response_aborts(self, component):
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = None
+        handle = TestGoalExecution._goal_handle(self._cartesian_goal())
+
+        result = component.main_action_callback(handle)
+
+        assert result.success is False
+        assert "No response" in result.message
+        handle.abort.assert_called_once()
+
+
+class TestGripperActions:
+    @staticmethod
+    def _component(rclpy_init, **config_fields):
+        from agents.components.moveit import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(
+                arm_group_name="panda_arm", gripper_group_name="hand", **config_fields
+            ),
+            component_name=f"test_moveit_gripper_{len(config_fields)}",
+        )
+        comp.get_logger = MagicMock()
+        comp._named_targets = {"hand": {"open": {"f1": 0.035}, "close": {"f1": 0.0}}}
+        return comp
+
+    @pytest.fixture
+    def move_group_component(self, rclpy_init):
+        pytest.importorskip("moveit_msgs.msg")
+        return self._component(rclpy_init)
+
+    @pytest.fixture
+    def controller_component(self, rclpy_init):
+        pytest.importorskip("moveit_msgs.msg")
+        return self._component(
+            rclpy_init,
+            gripper_mode="gripper_command",
+            gripper_command_action="/gripper_controller/gripper_cmd",
+        )
+
+    def test_open_gripper_sends_named_target(self, move_group_component):
+        comp = move_group_component
+        comp._gripper_client = TestGoalExecution._client()
+
+        message = comp.open_gripper.__wrapped__(comp)
+
+        sent = comp._gripper_client.send_request.call_args[0][0]
+        assert sent.request.group_name == "hand"
+        assert sent.request.goal_constraints[0].joint_constraints[0].position == 0.035
+        assert "open" in message
+
+    def test_close_gripper_uses_controller_position(self, controller_component):
+        comp = controller_component
+        comp._gripper_client = TestGoalExecution._client()
+        comp._gripper_client.action_result = MagicMock(spec=[])  # no error_code field
+
+        comp.close_gripper.__wrapped__(comp)
+
+        sent = comp._gripper_client.send_request.call_args[0][0]
+        assert sent.command.position == pytest.approx(0.0)
+
+    def test_set_gripper_needs_controller_mode(self, move_group_component):
+        comp = move_group_component
+        comp._gripper_client = TestGoalExecution._client()
+
+        message = comp.set_gripper.__wrapped__(comp, 0.02)
+
+        assert "gripper_command" in message
+        comp._gripper_client.send_request.assert_not_called()
+
+    def test_set_gripper_sends_position(self, controller_component):
+        comp = controller_component
+        comp._gripper_client = TestGoalExecution._client()
+        comp._gripper_client.action_result = MagicMock(spec=[])
+
+        comp.set_gripper.__wrapped__(comp, 0.02)
+
+        sent = comp._gripper_client.send_request.call_args[0][0]
+        assert sent.command.position == pytest.approx(0.02)
+
+    def test_stop_motion_cancels_active_goals(self, move_group_component):
+        comp = move_group_component
+        comp._move_client = TestGoalExecution._client()
+        comp._move_client.goal_accepted = True
+        comp._exec_client = TestGoalExecution._client()
+        comp._exec_client.goal_accepted = False
+        comp._gripper_client = None
+
+        message = comp.stop_motion.__wrapped__(comp)
+
+        comp._move_client.cancel_request.assert_called_once()
+        comp._exec_client.cancel_request.assert_not_called()
+        assert "arm" in message
+
+    def test_stop_motion_without_active_goals(self, move_group_component):
+        comp = move_group_component
+        comp._move_client = TestGoalExecution._client()
+        comp._move_client.goal_accepted = False
+        comp._exec_client = None
+        comp._gripper_client = None
+
+        assert "No motion" in comp.stop_motion.__wrapped__(comp)

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -12,6 +12,14 @@ from agents.utils.moveit import (
     parse_srdf_group_states,
 )
 
+
+def _trajectory():
+    """A real RobotTrajectory for mocked cartesian responses: the component
+    assigns it to a message field, whose setter checks the type."""
+    from moveit_msgs.msg import RobotTrajectory
+
+    return RobotTrajectory()
+
 SAMPLE_SRDF = """
 <robot name="panda">
   <group name="panda_arm">
@@ -964,12 +972,15 @@ class TestDetectionObjects:
         msg.header.frame_id = frame
         for label, score, center, size in entries:
             box = Bbox3D()
-            box.center.position.x, box.center.position.y, box.center.position.z = center
+            # coerced: humble's generated messages reject ints on float fields
+            box.center.position.x, box.center.position.y, box.center.position.z = (
+                float(v) for v in center
+            )
             box.center.orientation.w = 1.0
-            box.size.x, box.size.y, box.size.z = size
+            box.size.x, box.size.y, box.size.z = (float(v) for v in size)
             msg.boxes.append(box)
             msg.labels.append(label)
-            msg.scores.append(score)
+            msg.scores.append(float(score))
         return msg
 
     def test_ids_rank_per_label_by_score(self):
@@ -2025,7 +2036,7 @@ class TestPickSequence:
         comp._gripper_client = TestGoalExecution._client()
         comp._cartesian_client = MagicMock()
         comp._cartesian_client.send_request.return_value = SimpleNamespace(
-            fraction=1.0, solution=MagicMock(), error_code=SimpleNamespace(val=1)
+            fraction=1.0, solution=_trajectory(), error_code=SimpleNamespace(val=1)
         )
         comp._apply_scene_client = MagicMock()
         comp._apply_scene_client.send_request.return_value = SimpleNamespace(
@@ -2150,7 +2161,7 @@ class TestPickSequence:
 
     def test_a_partial_descent_aborts(self, component):
         component._cartesian_client.send_request.return_value = SimpleNamespace(
-            fraction=0.4, solution=MagicMock(), error_code=SimpleNamespace(val=1)
+            fraction=0.4, solution=_trajectory(), error_code=SimpleNamespace(val=1)
         )
         handle = TestGoalExecution._goal_handle(self._pick_goal(target_object="mug"))
 
@@ -2202,7 +2213,7 @@ class TestPlaceSequence:
         comp._gripper_client = TestGoalExecution._client()
         comp._cartesian_client = MagicMock()
         comp._cartesian_client.send_request.return_value = SimpleNamespace(
-            fraction=1.0, solution=MagicMock(), error_code=SimpleNamespace(val=1)
+            fraction=1.0, solution=_trajectory(), error_code=SimpleNamespace(val=1)
         )
         comp._apply_scene_client = MagicMock()
         comp._apply_scene_client.send_request.return_value = SimpleNamespace(
@@ -2281,7 +2292,7 @@ class TestPlaceSequence:
 
     def test_a_partial_descent_aborts_before_release(self, component):
         component._cartesian_client.send_request.return_value = SimpleNamespace(
-            fraction=0.3, solution=MagicMock(), error_code=SimpleNamespace(val=1)
+            fraction=0.3, solution=_trajectory(), error_code=SimpleNamespace(val=1)
         )
         handle = TestGoalExecution._goal_handle(self._place_goal())
 

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -235,6 +235,7 @@ class TestMoveMode:
         goal = SimpleNamespace(
             mode="",
             named_target="",
+            target_object="",
             cartesian_waypoints=[],
             joint_names=[],
             joint_positions=[],
@@ -248,7 +249,27 @@ class TestMoveMode:
         return goal
 
     def test_values(self):
-        assert MoveMode.values() == ["pose", "joints", "named", "cartesian"]
+        assert MoveMode.values() == [
+            "pose", "joints", "named", "cartesian", "pick", "place",
+        ]
+
+    def test_inferred_pick_from_target_object(self):
+        assert MoveMode.from_goal(self._goal(target_object="mug")) is MoveMode.PICK
+
+    def test_pick_wins_over_a_pose_that_locates_it(self):
+        """A pick may carry a pose as the object's location; naming an object
+        makes the intent unambiguous."""
+        goal = self._goal(target_object="mug")
+        goal.target_pose.pose.position.x = 0.4
+        assert MoveMode.from_goal(goal) is MoveMode.PICK
+
+    def test_place_is_never_inferred(self):
+        """A place goal's bare pose is indistinguishable from a POSE goal, so
+        'place' must be explicit."""
+        goal = self._goal()
+        goal.target_pose.pose.position.x = 0.4
+        assert MoveMode.from_goal(goal) is MoveMode.POSE
+        assert MoveMode.from_goal(self._goal(mode="place")) is MoveMode.PLACE
 
     def test_is_a_string_enum(self):
         assert MoveMode.POSE == "pose"

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -2117,3 +2117,125 @@ class TestPickSequence:
         component.main_action_callback(handle)
 
         handle.canceled.assert_called_once()
+
+
+class TestPlaceSequence:
+    """The place mode: approach, descend, release, detach, retreat."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_moveit_msgs(self):
+        pytest.importorskip("moveit_msgs.msg")
+
+    @pytest.fixture
+    def component(self, rclpy_init):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+
+        comp = MoveIt(
+            config=MoveItConfig(
+                arm_group_name="arm",
+                gripper_group_name="gripper",
+                end_effector_link="hand",
+                pose_reference_frame="base",
+                approach_clearance=0.1,
+                touch_links=["hand", "jaw"],
+            ),
+            component_name="m_place",
+        )
+        comp.get_logger = MagicMock()
+        comp.health_status = MagicMock()
+        comp._named_targets = {
+            "gripper": {"open": {"jaw": 1.0}, "close": {"jaw": 0.0}}
+        }
+        comp._move_client = TestGoalExecution._client()
+        comp._exec_client = TestGoalExecution._client()
+        comp._gripper_client = TestGoalExecution._client()
+        comp._cartesian_client = MagicMock()
+        comp._cartesian_client.send_request.return_value = SimpleNamespace(
+            fraction=1.0, solution=MagicMock(), error_code=SimpleNamespace(val=1)
+        )
+        comp._apply_scene_client = MagicMock()
+        comp._apply_scene_client.send_request.return_value = SimpleNamespace(
+            success=True
+        )
+        comp._scene_objects["det__mug_0"] = {
+            "source": "detection",
+            "last_seen": 0.0,
+            "center": (0.4, 0.0, 0.05),
+            "size": (0.06, 0.06, 0.1),
+            "attached": "hand",
+        }
+        return comp
+
+    @staticmethod
+    def _place_goal(x=0.6, y=0.1, z=0.08):
+        from automatika_embodied_agents.action import MoveManipulator
+
+        goal = MoveManipulator.Goal()
+        goal.mode = "place"
+        position = goal.target_pose.pose.position
+        position.x, position.y, position.z = x, y, z
+        return goal
+
+    def test_place_runs_the_whole_sequence(self, component):
+        handle = TestGoalExecution._goal_handle(self._place_goal())
+
+        result = component.main_action_callback(handle)
+
+        assert result.success and "det__mug_0" in result.message
+        handle.succeed.assert_called_once()
+        assert TestPickSequence._states(handle) == [
+            "PRE_PLACE", "DESCEND", "RELEASE", "DETACH", "RETREAT",
+        ]
+        # approach and retreat above the release point: z 0.08 + half
+        # height 0.05 + clearance 0.1
+        heights = [
+            call[0][0].request.goal_constraints[0]
+            .position_constraints[0].constraint_region.primitive_poses[0].position.z
+            for call in component._move_client.send_request.call_args_list
+        ]
+        assert heights == [pytest.approx(0.23), pytest.approx(0.23)]
+        # the descent is contact permitted, down to the release center
+        request = component._cartesian_client.send_request.call_args[0][0]
+        assert request.avoid_collisions is False
+        assert request.waypoints[0].position.z == pytest.approx(0.08)
+        # released: no longer attached, and the scene records the new spot
+        entry = component._scene_objects["det__mug_0"]
+        assert "attached" not in entry
+        assert entry["center"] == (0.6, 0.1, 0.08)
+
+    def test_place_with_nothing_attached_aborts(self, component):
+        del component._scene_objects["det__mug_0"]["attached"]
+        handle = TestGoalExecution._goal_handle(self._place_goal())
+
+        result = component.main_action_callback(handle)
+
+        assert not result.success and "Nothing is attached" in result.message
+        handle.abort.assert_called_once()
+        component._move_client.send_request.assert_not_called()
+
+    def test_a_failed_approach_keeps_the_object_attached(self, component):
+        from moveit_msgs.msg import MoveItErrorCodes
+
+        component._move_client = TestGoalExecution._client(
+            error_code=MoveItErrorCodes.PLANNING_FAILED
+        )
+        handle = TestGoalExecution._goal_handle(self._place_goal())
+
+        result = component.main_action_callback(handle)
+
+        assert not result.success
+        assert result.message.startswith("Pre-place:")
+        entry = component._scene_objects["det__mug_0"]
+        assert entry["attached"] == "hand" and entry["center"] == (0.4, 0.0, 0.05)
+
+    def test_a_partial_descent_aborts_before_release(self, component):
+        component._cartesian_client.send_request.return_value = SimpleNamespace(
+            fraction=0.3, solution=MagicMock(), error_code=SimpleNamespace(val=1)
+        )
+        handle = TestGoalExecution._goal_handle(self._place_goal())
+
+        result = component.main_action_callback(handle)
+
+        assert not result.success and result.message.startswith("Descent:")
+        assert component._scene_objects["det__mug_0"]["attached"] == "hand"

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1074,3 +1074,67 @@ class TestTouchLinks:
         from agents.utils.moveit import derive_touch_links
 
         assert derive_touch_links(None, "tool0") == ["tool0"]
+
+
+class TestSceneInputs:
+    """The component takes detected objects as an input topic, to feed the
+    planning scene with."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_moveit_msgs(self):
+        pytest.importorskip("moveit_msgs.msg")
+
+    @staticmethod
+    def _config():
+        from agents.config import MoveItConfig
+
+        return MoveItConfig(arm_group_name="arm")
+
+    def test_a_detections_input_is_accepted_and_recorded(self, rclpy_init):
+        from agents.components import MoveIt
+        from agents.ros import Topic
+
+        component = MoveIt(
+            config=self._config(),
+            component_name="m_scene_in",
+            inputs=[Topic(name="detections_3d", msg_type="Detections3D")],
+        )
+        assert component._detections_topic.name == "detections_3d"
+
+    def test_other_input_types_are_rejected(self, rclpy_init):
+        """Regression: this used to raise AttributeError instead of a clear
+        TypeError, since `allowed_inputs` was never assigned."""
+        from agents.components import MoveIt
+        from agents.ros import Topic
+
+        with pytest.raises(TypeError, match="allowed"):
+            MoveIt(
+                config=self._config(),
+                component_name="m_scene_bad",
+                inputs=[Topic(name="image", msg_type="Image")],
+            )
+
+    def test_no_inputs_remains_valid(self, rclpy_init):
+        from agents.components import MoveIt
+
+        component = MoveIt(config=self._config(), component_name="m_scene_none")
+        assert component._detections_topic is None
+
+    def test_the_executable_reconstruction_shape_is_tolerated(self, rclpy_init):
+        """The launch executable's generic branch passes model_client,
+        db_client and trigger to every component it rebuilds in a child
+        process; MoveIt takes none of them and must swallow them."""
+        from agents.components import MoveIt
+        from agents.ros import Topic
+
+        component = MoveIt(
+            inputs=[Topic(name="detections_3d", msg_type="Detections3D")],
+            outputs=None,
+            model_client=None,
+            db_client=None,
+            trigger=1.0,
+            config=self._config(),
+            component_name="m_scene_relaunch",
+            config_file=None,
+        )
+        assert component._detections_topic.name == "detections_3d"

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1204,6 +1204,32 @@ class TestDetectionObjects:
             msg.scores.append(float(score))
         return msg
 
+    def test_include_labels_admits_only_listed_labels(self):
+        """Filtered before ranking, so admitted ids stay contiguous even
+        when a filtered label sits between two admitted ones."""
+        from agents.utils.moveit import collision_objects_from_detections
+
+        objects = collision_objects_from_detections(
+            self._detections([
+                ("orange", 0.9, (0.4, 0.0, 0.05), (0.06, 0.06, 0.06)),
+                ("dining table", 0.8, (0.5, 0.0, 0.2), (0.6, 0.8, 0.3)),
+                ("orange", 0.7, (0.6, 0.1, 0.05), (0.06, 0.06, 0.06)),
+            ]),
+            include_labels=["orange"],
+        )
+        assert sorted(o.id for o in objects) == ["det__orange_0", "det__orange_1"]
+
+    def test_no_filter_admits_everything(self):
+        from agents.utils.moveit import collision_objects_from_detections
+
+        objects = collision_objects_from_detections(
+            self._detections([
+                ("orange", 0.9, (0.4, 0.0, 0.05), (0.06, 0.06, 0.06)),
+                ("dining table", 0.8, (0.5, 0.0, 0.2), (0.6, 0.8, 0.3)),
+            ])
+        )
+        assert len(objects) == 2
+
     def test_ids_rank_per_label_by_score(self):
         """The strongest orange stays det__orange_0 between refreshes of a
         static scene, without needing a tracker."""
@@ -1832,6 +1858,36 @@ class TestSceneRefresh:
         )
         assert component._scene_objects["det__orange_0"]["source"] == "detection"
         assert "2 detected object(s)" in message
+
+    def test_configured_label_filter_reaches_the_scene(self, rclpy_init):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+        from agents.ros import Topic
+
+        comp = MoveIt(
+            config=MoveItConfig(
+                arm_group_name="arm", scene_detection_labels=["orange"]
+            ),
+            component_name="m_refresh_filtered",
+            inputs=[Topic(name="d3", msg_type="Detections3D")],
+        )
+        comp.get_logger = MagicMock()
+        comp._apply_scene_client = MagicMock()
+        comp._apply_scene_client.send_request.return_value = SimpleNamespace(
+            success=True
+        )
+        self._wire(
+            comp,
+            self._detections([
+                ("orange", 0.9, (0.3, 0.0, 0.05), (0.06, 0.06, 0.06)),
+                ("dining table", 0.8, (0.5, 0.0, 0.2), (0.6, 0.8, 0.3)),
+            ]),
+        )
+
+        comp.update_planning_scene.__wrapped__(comp)
+
+        scene = self._applied_scene(comp)
+        assert {o.id for o in scene.world.collision_objects} == {"det__orange_0"}
 
     def test_without_a_detections_input_it_says_so(self, rclpy_init):
         from agents.components import MoveIt

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -831,6 +831,156 @@ class TestCartesianGroupAndOrientation:
         sent = component_with_group._cartesian_client.send_request.call_args[0][0]
         assert sent.group_name == "panda_arm_cartesian"
 
+    @staticmethod
+    def _fk_client(x=0.1, y=0.2, z=0.3, w=0.927):
+        """FK service handler reporting a current end-effector orientation"""
+        from geometry_msgs.msg import PoseStamped
+
+        pose = PoseStamped()
+        orientation = pose.pose.orientation
+        orientation.x, orientation.y, orientation.z, orientation.w = x, y, z, w
+        client = MagicMock()
+        client.send_request.return_value = SimpleNamespace(
+            error_code=SimpleNamespace(val=1), pose_stamped=[pose]
+        )
+        return client
+
+    @staticmethod
+    def _unoriented_goal():
+        from automatika_embodied_agents.action import MoveManipulator
+        from geometry_msgs.msg import Pose
+
+        goal = MoveManipulator.Goal()
+        goal.mode = "cartesian"
+        waypoint = Pose()
+        waypoint.position.z = 0.5
+        goal.cartesian_waypoints = [waypoint]
+        return goal
+
+    def test_unset_waypoint_orientation_defaults_to_the_current_one(self, component):
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = None
+        component._fk_client = self._fk_client()
+        goal = self._unoriented_goal()
+
+        component.main_action_callback(TestGoalExecution._goal_handle(goal))
+
+        sent = component._cartesian_client.send_request.call_args[0][0]
+        orientation = sent.waypoints[0].orientation
+        assert (orientation.x, orientation.y, orientation.z, orientation.w) == (
+            0.1,
+            0.2,
+            0.3,
+            0.927,
+        )
+        # the goal itself is not mutated
+        goal_orientation = goal.cartesian_waypoints[0].orientation
+        assert goal_orientation.x == 0.0 and goal_orientation.w == 1.0
+
+    def test_explicit_waypoint_orientation_is_preserved(self, component):
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = None
+        component._fk_client = self._fk_client()
+        goal = self._unoriented_goal()
+        orientation = goal.cartesian_waypoints[0].orientation
+        orientation.z, orientation.w = 0.707, 0.707
+
+        component.main_action_callback(TestGoalExecution._goal_handle(goal))
+
+        sent = component._cartesian_client.send_request.call_args[0][0]
+        assert sent.waypoints[0].orientation.z == pytest.approx(0.707)
+        component._fk_client.send_request.assert_not_called()
+
+    def test_identity_orientation_counts_as_unset(self, component):
+        """ROS2 defaults an untouched Quaternion to identity, so identity on
+        the wire is read as "no preference", not as a target."""
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = None
+        component._fk_client = self._fk_client()
+
+        # _cartesian_goal sets orientation.w = 1.0 explicitly
+        component.main_action_callback(
+            TestGoalExecution._goal_handle(TestCartesianGoals._cartesian_goal())
+        )
+
+        sent = component._cartesian_client.send_request.call_args[0][0]
+        assert sent.waypoints[0].orientation.x == pytest.approx(0.1)
+        component._fk_client.send_request.assert_called_once()
+
+    def test_unset_orientation_falls_back_to_identity_without_fk(self, component):
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = None
+        component._fk_client = None
+
+        component.main_action_callback(
+            TestGoalExecution._goal_handle(self._unoriented_goal())
+        )
+
+        sent = component._cartesian_client.send_request.call_args[0][0]
+        assert sent.waypoints[0].orientation.w == 1.0
+
+    def test_fk_failure_falls_back_to_identity_with_a_warning(self, component):
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = None
+        component._fk_client = MagicMock()
+        component._fk_client.send_request.return_value = SimpleNamespace(
+            error_code=SimpleNamespace(val=99999), pose_stamped=[]
+        )
+
+        component.main_action_callback(
+            TestGoalExecution._goal_handle(self._unoriented_goal())
+        )
+
+        sent = component._cartesian_client.send_request.call_args[0][0]
+        assert sent.waypoints[0].orientation.w == 1.0
+        warning = component.get_logger().warning.call_args[0][0]
+        assert "end-effector pose" in warning
+
+    def test_descend_holds_the_current_orientation(self, component):
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = (
+            TestCartesianGoals._path_response(1.0)
+        )
+        component._exec_client = TestGoalExecution._client()
+        component._fk_client = self._fk_client()
+        handle = TestGoalExecution._goal_handle(MagicMock(), active=True)
+
+        outcome, _ = component._sequence_descent(
+            0.2, 0.0, 0.05, None, handle, deadline=time.time() + 10
+        )
+
+        assert outcome == "ok"
+        sent = component._cartesian_client.send_request.call_args[0][0]
+        orientation = sent.waypoints[0].orientation
+        assert (orientation.x, orientation.y, orientation.z, orientation.w) == (
+            0.1,
+            0.2,
+            0.3,
+            0.927,
+        )
+        assert sent.group_name == "panda_arm"
+
+    def test_descend_respects_an_explicit_orientation(self, component):
+        from geometry_msgs.msg import Quaternion
+
+        component._cartesian_client = MagicMock()
+        component._cartesian_client.send_request.return_value = (
+            TestCartesianGoals._path_response(1.0)
+        )
+        component._exec_client = TestGoalExecution._client()
+        component._fk_client = self._fk_client()
+        handle = TestGoalExecution._goal_handle(MagicMock(), active=True)
+
+        explicit = Quaternion(x=0.0, y=0.0, z=0.707, w=0.707)
+        outcome, _ = component._sequence_descent(
+            0.2, 0.0, 0.05, explicit, handle, deadline=time.time() + 10
+        )
+
+        assert outcome == "ok"
+        sent = component._cartesian_client.send_request.call_args[0][0]
+        assert sent.waypoints[0].orientation.z == pytest.approx(0.707)
+        component._fk_client.send_request.assert_not_called()
+
 
 class TestGripperActions:
     @staticmethod

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -824,3 +824,253 @@ class TestGripperActions:
         comp._gripper_client = None
 
         assert "No motion" in comp.stop_motion.__wrapped__(comp)
+
+
+class TestSceneBuilders:
+    """Collision objects and scene diffs the planning scene is fed with."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_moveit_msgs(self):
+        pytest.importorskip("moveit_msgs.msg")
+
+    def test_box_object_from_a_position(self):
+        from moveit_msgs.msg import CollisionObject
+
+        from agents.utils.moveit import build_collision_object
+
+        obj = build_collision_object("crate", "base_link", (0.4, 0.0, 0.1), (0.2, 0.3, 0.2))
+
+        assert obj.id == "crate" and obj.header.frame_id == "base_link"
+        # zero stamp, so move_group does no TF lookup on an object already
+        # given in the planning frame
+        assert obj.header.stamp.sec == 0 and obj.header.stamp.nanosec == 0
+        assert obj.operation == CollisionObject.ADD
+        assert list(obj.primitives[0].dimensions) == [0.2, 0.3, 0.2]
+        pose = obj.primitive_poses[0]
+        assert pose.position.x == 0.4
+        # a bare Pose carries an all-zero quaternion, which is not a rotation
+        assert pose.orientation.w == 1.0
+
+    def test_box_object_from_a_pose_keeps_its_orientation(self):
+        from geometry_msgs.msg import Pose
+
+        from agents.utils.moveit import build_collision_object
+
+        center = Pose()
+        center.position.z = 0.5
+        center.orientation.z = center.orientation.w = 0.7071
+
+        pose = build_collision_object("o", "map", center, (0.1, 0.1, 0.1)).primitive_poses[0]
+        assert pose.orientation.z == pytest.approx(0.7071)
+        # the input pose is copied, not aliased
+        center.position.z = 9.9
+        assert pose.position.z == 0.5
+
+    def test_an_all_zero_quaternion_becomes_identity(self):
+        from geometry_msgs.msg import Pose
+
+        from agents.utils.moveit import build_collision_object
+
+        obj = build_collision_object("o", "map", Pose(), (0.1, 0.1, 0.1))
+        assert obj.primitive_poses[0].orientation.w == 1.0
+
+    def test_flat_boxes_get_a_minimum_thickness(self):
+        """A fronto-parallel surface lifts with no extent along the view
+        axis, and a zero-thickness box is invisible to collision checking."""
+        from agents.utils.moveit import build_collision_object
+
+        obj = build_collision_object("o", "map", (0, 0, 0), (0.04, 0.02, 0.0))
+        assert list(obj.primitives[0].dimensions) == [0.04, 0.02, 0.01]
+
+    def test_remove_object(self):
+        from moveit_msgs.msg import CollisionObject
+
+        from agents.utils.moveit import build_remove_object
+
+        obj = build_remove_object("crate")
+        assert obj.id == "crate" and obj.operation == CollisionObject.REMOVE
+
+    def test_scene_diff_never_replaces_the_scene(self):
+        from agents.utils.moveit import (
+            build_collision_object,
+            build_remove_object,
+            build_scene_diff,
+        )
+
+        scene = build_scene_diff(
+            [
+                build_collision_object("a", "map", (0, 0, 0), (0.1, 0.1, 0.1)),
+                build_remove_object("b"),
+            ]
+        )
+        assert scene.is_diff
+        # without this, applying the diff would overwrite the robot state
+        # move_group is monitoring
+        assert scene.robot_state.is_diff
+        assert [o.id for o in scene.world.collision_objects] == ["a", "b"]
+
+    def test_attach_and_detach(self):
+        from moveit_msgs.msg import CollisionObject
+
+        from agents.utils.moveit import build_attached_object, build_detach_object
+
+        attached = build_attached_object(
+            "det__orange_0", "gripper_link", ["gripper_link", "jaw_link"]
+        )
+        assert attached.link_name == "gripper_link"
+        assert attached.object.id == "det__orange_0"
+        assert attached.object.operation == CollisionObject.ADD
+        assert list(attached.touch_links) == ["gripper_link", "jaw_link"]
+
+        detached = build_detach_object("det__orange_0")
+        assert detached.object.operation == CollisionObject.REMOVE
+        assert detached.link_name == ""
+
+
+class TestDetectionObjects:
+    """Detections3D messages turned into collision objects."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_messages(self):
+        pytest.importorskip("moveit_msgs.msg")
+        pytest.importorskip("automatika_embodied_agents.msg")
+
+    @staticmethod
+    def _detections(entries, frame="base_link"):
+        from automatika_embodied_agents.msg import Bbox3D, Detections3D
+
+        msg = Detections3D()
+        msg.header.frame_id = frame
+        for label, score, center, size in entries:
+            box = Bbox3D()
+            box.center.position.x, box.center.position.y, box.center.position.z = center
+            box.center.orientation.w = 1.0
+            box.size.x, box.size.y, box.size.z = size
+            msg.boxes.append(box)
+            msg.labels.append(label)
+            msg.scores.append(score)
+        return msg
+
+    def test_ids_rank_per_label_by_score(self):
+        """The strongest orange stays det__orange_0 between refreshes of a
+        static scene, without needing a tracker."""
+        from agents.utils.moveit import collision_objects_from_detections
+
+        objects = collision_objects_from_detections(
+            self._detections([
+                ("orange", 0.5, (0.1, 0.0, 0.0), (0.05, 0.05, 0.05)),
+                ("bowl", 0.7, (0.2, 0.0, 0.0), (0.2, 0.2, 0.1)),
+                ("orange", 0.9, (0.3, 0.0, 0.0), (0.06, 0.06, 0.06)),
+            ])
+        )
+        by_id = {o.id: o for o in objects}
+        assert set(by_id) == {"det__orange_0", "det__orange_1", "det__bowl_0"}
+        # the higher scoring orange takes rank 0
+        assert by_id["det__orange_0"].primitive_poses[0].position.x == pytest.approx(0.3)
+        assert by_id["det__orange_1"].primitive_poses[0].position.x == pytest.approx(0.1)
+
+    def test_objects_carry_the_message_frame_and_geometry(self):
+        from agents.utils.moveit import collision_objects_from_detections
+
+        (obj,) = collision_objects_from_detections(
+            self._detections(
+                [("cup", 0.8, (0.4, -0.1, 0.05), (0.06, 0.06, 0.12))], frame="world"
+            )
+        )
+        assert obj.header.frame_id == "world"
+        assert list(obj.primitives[0].dimensions) == pytest.approx([0.06, 0.06, 0.12])
+
+    def test_padding_inflates_every_side(self):
+        from agents.utils.moveit import collision_objects_from_detections
+
+        (obj,) = collision_objects_from_detections(
+            self._detections([("cup", 0.8, (0, 0, 0), (0.06, 0.06, 0.12))]),
+            padding=0.01,
+        )
+        assert list(obj.primitives[0].dimensions) == pytest.approx([0.08, 0.08, 0.14])
+
+    def test_labels_are_sanitized_and_defaulted(self):
+        from agents.utils.moveit import collision_objects_from_detections
+
+        objects = collision_objects_from_detections(
+            self._detections([
+                ("sports ball", 0.9, (0, 0, 0), (0.1, 0.1, 0.1)),
+                ("", 0.8, (1, 0, 0), (0.1, 0.1, 0.1)),
+            ])
+        )
+        assert {o.id for o in objects} == {"det__sports_ball_0", "det__object_0"}
+
+    def test_no_detections_no_objects(self):
+        from agents.utils.moveit import collision_objects_from_detections
+
+        assert collision_objects_from_detections(self._detections([])) == []
+
+
+class TestTouchLinks:
+    """Which links may stay in contact with a grasped object."""
+
+    SO101_JOINT_ONLY = """
+    <robot name="so101">
+      <group name="arm"><chain base_link="base_link" tip_link="gripper_frame_link"/></group>
+      <group name="gripper"><joint name="gripper"/></group>
+      <end_effector name="eef" parent_link="gripper_frame_link" group="gripper"/>
+      <disable_collisions link1="wrist_link" link2="gripper_link" reason="Adjacent"/>
+      <disable_collisions link1="gripper_link" link2="moving_jaw_so101_v1_link" reason="Adjacent"/>
+    </robot>
+    """
+
+    SO101_WITH_LINKS = SO101_JOINT_ONLY.replace(
+        '<group name="gripper"><joint name="gripper"/></group>',
+        '<group name="gripper"><joint name="gripper"/>'
+        '<link name="gripper_frame_link"/><link name="gripper_link"/>'
+        '<link name="moving_jaw_so101_v1_link"/></group>',
+    )
+
+    def test_explicit_config_wins(self):
+        from agents.utils.moveit import derive_touch_links
+
+        assert derive_touch_links(
+            self.SO101_WITH_LINKS, "eef", explicit=["a", "b", "a"]
+        ) == ["a", "b"]
+
+    def test_links_declared_in_the_gripper_group(self):
+        from agents.utils.moveit import derive_touch_links
+
+        assert derive_touch_links(
+            self.SO101_WITH_LINKS, "eef", gripper_group="gripper"
+        ) == ["gripper_frame_link", "gripper_link", "moving_jaw_so101_v1_link"]
+
+    def test_adjacent_partners_of_the_end_effector_parent(self):
+        """The heuristic path, for SRDFs that declare neither links nor an
+        explicit list. Only physically connected pairs describe the gripper;
+        'Never' pairs span the whole robot."""
+        from agents.utils.moveit import derive_touch_links
+
+        srdf = """
+        <robot>
+          <end_effector name="eef" parent_link="hand" group="g"/>
+          <disable_collisions link1="hand" link2="left_finger" reason="Adjacent"/>
+          <disable_collisions link1="right_finger" link2="hand" reason="Adjacent"/>
+          <disable_collisions link1="hand" link2="base" reason="Never"/>
+        </robot>
+        """
+        assert derive_touch_links(srdf, "hand", gripper_group="g") == [
+            "hand",
+            "left_finger",
+            "right_finger",
+        ]
+
+    def test_joint_only_group_without_adjacency_falls_back(self):
+        """The SO-101's own shape: the end effector parent appears in no
+        disable_collisions pair, so nothing can be derived and the configured
+        link is returned alone."""
+        from agents.utils.moveit import derive_touch_links
+
+        assert derive_touch_links(
+            self.SO101_JOINT_ONLY, "gripper_frame_link", gripper_group="gripper"
+        ) == ["gripper_frame_link"]
+
+    def test_no_srdf_falls_back(self):
+        from agents.utils.moveit import derive_touch_links
+
+        assert derive_touch_links(None, "tool0") == ["tool0"]

--- a/tests/test_moveit.py
+++ b/tests/test_moveit.py
@@ -1138,3 +1138,71 @@ class TestSceneInputs:
             config_file=None,
         )
         assert component._detections_topic.name == "detections_3d"
+
+
+class TestSceneServiceClients:
+    """The move_group planning scene services the component connects to."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_moveit_msgs(self):
+        pytest.importorskip("moveit_msgs.msg")
+
+    def test_scene_clients_wire_to_the_move_group_services(
+        self, rclpy_init, monkeypatch
+    ):
+        from moveit_msgs.srv import ApplyPlanningScene, GetPlanningScene
+        from std_srvs.srv import Empty
+
+        import agents.components.moveit as moveit_module
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+
+        component = MoveIt(
+            config=MoveItConfig(arm_group_name="arm", move_group_namespace="/bot"),
+            component_name="m_scene_clients",
+        )
+
+        created = []
+
+        def _fake_handler(_component, config):
+            created.append(config)
+            return MagicMock(config=config)
+
+        monkeypatch.setattr(moveit_module, "ServiceClientHandler", _fake_handler)
+        monkeypatch.setattr(
+            "agents.components.component_base.Component.create_all_service_clients",
+            lambda _: None,
+        )
+
+        component.create_all_service_clients()
+
+        by_name = {config.name: config.srv_type for config in created}
+        assert by_name["/bot/apply_planning_scene"] is ApplyPlanningScene
+        assert by_name["/bot/get_planning_scene"] is GetPlanningScene
+        assert by_name["/bot/clear_octomap"] is Empty
+        assert component._apply_scene_client is not None
+        assert component._get_scene_client is not None
+        assert component._clear_octomap_client is not None
+
+    def test_destroy_resets_the_scene_clients(self, rclpy_init, monkeypatch):
+        from agents.components import MoveIt
+        from agents.config import MoveItConfig
+
+        component = MoveIt(
+            config=MoveItConfig(arm_group_name="arm"),
+            component_name="m_scene_destroy",
+        )
+        for name in ("_apply_scene_client", "_get_scene_client", "_clear_octomap_client"):
+            setattr(component, name, MagicMock())
+        component.destroy_client = MagicMock()
+        monkeypatch.setattr(
+            "agents.components.component_base.Component.destroy_all_service_clients",
+            lambda _: None,
+        )
+
+        component.destroy_all_service_clients()
+
+        assert component.destroy_client.call_count == 3
+        assert component._apply_scene_client is None
+        assert component._get_scene_client is None
+        assert component._clear_octomap_client is None

--- a/tests/test_perception3d.py
+++ b/tests/test_perception3d.py
@@ -162,29 +162,47 @@ class TestLifting:
         boxes = self._lift([PATCH])
         assert len(boxes) == 1
         box = boxes[0]
-        # the detector reports in a forward-left-up frame, so x is the distance
-        assert box.center[0] == pytest.approx(PATCH_DEPTH_M, abs=0.02)
+        # with no pose given, boxes come back in the camera's own optical
+        # frame: x right, y down, z forward
+        assert box.center[2] == pytest.approx(PATCH_DEPTH_M, abs=0.02)
         # 40 px wide at 0.5 m with a 500 px focal length is 4 cm
-        assert box.size[1] == pytest.approx(40 * PATCH_DEPTH_M / FX, abs=0.01)
-        assert box.size[2] == pytest.approx(20 * PATCH_DEPTH_M / FY, abs=0.01)
+        assert box.size[0] == pytest.approx(40 * PATCH_DEPTH_M / FX, abs=0.01)
+        assert box.size[1] == pytest.approx(20 * PATCH_DEPTH_M / FY, abs=0.01)
         assert box.validity == 1.0
+
+    def test_boxes_are_placed_along_the_optical_axes(self):
+        """An object right of and below the principal point has to come back
+        with a positive x and a positive y, or every box handed to a planner
+        is mirrored."""
+        right_and_low = (130, 80, 150, 95)
+        box = self._lift([right_and_low])[0]
+        assert box.center[0] > 0 and box.center[1] > 0
+
+    def test_a_pose_places_boxes_in_the_frame_it_is_given_in(self):
+        """The detector works in forward-left-up axes internally. Handing it
+        the camera's own optical-to-body rotation must therefore land the box
+        in those axes, with the distance on x."""
+        optical_to_body = (-0.5, 0.5, -0.5, 0.5)
+        box = self._lift([PATCH], rotation=optical_to_body)[0]
+        assert box.center[0] == pytest.approx(PATCH_DEPTH_M, abs=0.02)
 
     def test_depth_is_that_of_whatever_fills_the_box(self):
         """The distance is a median, so a box padded well beyond its object
         reports the wall behind it. Detections must be tight."""
         tight = (PATCH[0] - 2, PATCH[1] - 2, PATCH[2] + 2, PATCH[3] + 2)
-        assert self._lift([tight])[0].center[0] == pytest.approx(
+        assert self._lift([tight])[0].center[2] == pytest.approx(
             PATCH_DEPTH_M, abs=0.05
         )
 
         loose = (PATCH[0] - 10, PATCH[1] - 10, PATCH[2] + 10, PATCH[3] + 10)
-        assert self._lift([loose])[0].center[0] == pytest.approx(
+        assert self._lift([loose])[0].center[2] == pytest.approx(
             BACKGROUND_DEPTH_M, abs=0.05
         )
 
     def test_translation_moves_the_box(self):
-        boxes = self._lift([PATCH], translation=(1.0, 0.0, 0.0))
-        assert boxes[0].center[0] == pytest.approx(1.0 + PATCH_DEPTH_M, abs=0.02)
+        here = self._lift([PATCH])[0]
+        moved = self._lift([PATCH], translation=(1.0, 0.0, 0.0))[0]
+        assert moved.center[0] - here.center[0] == pytest.approx(1.0, abs=0.01)
 
     def test_boxes_without_depth_are_dropped_and_indices_survive(self):
         """kompass drops boxes it cannot place, so the surviving boxes must
@@ -209,6 +227,8 @@ class TestLifting:
         message = Detections3D.convert(**fields)
         assert message.labels == ["orange"]
         assert list(message.depth_validity) == [1.0]
-        assert message.boxes[0].center.position.x == pytest.approx(
+        assert message.boxes[0].center.position.z == pytest.approx(
             PATCH_DEPTH_M, abs=0.02
         )
+        # the 2D boxes have to become messages, not stay as pixel tuples
+        assert message.boxes_2d[0].top_left_x == float(PATCH[0])

--- a/tests/test_perception3d.py
+++ b/tests/test_perception3d.py
@@ -1,0 +1,214 @@
+"""Tests for lifting 2D detections into metric 3D boxes — no ROS node needed."""
+
+import numpy as np
+import pytest
+
+from agents.utils.perception3d import (
+    Box3D,
+    depth_validity,
+    detections_to_message_fields,
+    ensure_kompass_core,
+    prepare_depth,
+)
+
+# A synthetic camera and a scene: a background wall with a nearer patch on it
+FX = FY = 500.0
+WIDTH, HEIGHT = 200, 120
+CX, CY = WIDTH / 2, HEIGHT / 2
+PATCH = (100, 40, 140, 60)  # x1, y1, x2, y2 — 40x20 px
+PATCH_DEPTH_M = 0.5
+BACKGROUND_DEPTH_M = 2.0
+
+
+def scene(patch_depth=PATCH_DEPTH_M, background=BACKGROUND_DEPTH_M):
+    """Depth image in meters with a nearer patch on a far background."""
+    depth = np.full((HEIGHT, WIDTH), background, dtype=np.float32)
+    x1, y1, x2, y2 = PATCH
+    depth[y1:y2, x1:x2] = patch_depth
+    return depth
+
+
+class TestPrepareDepth:
+    def test_float_meters_become_millimeters(self):
+        depth = prepare_depth(np.full((4, 4), 1.5, dtype=np.float32))
+        assert depth.dtype == np.uint16
+        assert depth[0, 0] == 1500
+
+    def test_integer_millimeters_are_kept(self):
+        depth = prepare_depth(np.full((4, 4), 1500, dtype=np.uint16), encoding="16UC1")
+        assert depth[0, 0] == 1500
+
+    def test_encoding_wins_over_dtype(self):
+        """A float image already in millimeters must not be scaled again."""
+        depth = prepare_depth(np.full((4, 4), 1500.0, dtype=np.float32), encoding="mono16")
+        assert depth[0, 0] == 1500
+
+    def test_explicit_scale_overrides_everything(self):
+        depth = prepare_depth(np.full((4, 4), 15, dtype=np.uint16), scale=100.0)
+        assert depth[0, 0] == 1500
+
+    def test_invalid_pixels_become_no_reading(self):
+        raw = np.array([[np.nan, np.inf], [-np.inf, 1.0]], dtype=np.float32)
+        depth = prepare_depth(raw)
+        assert depth[0, 0] == 0 and depth[0, 1] == 0 and depth[1, 0] == 0
+        assert depth[1, 1] == 1000
+
+    def test_layout_is_column_major(self):
+        """Row major gives the same answer but is copied element by element."""
+        depth = prepare_depth(np.ascontiguousarray(scene()))
+        assert depth.flags["F_CONTIGUOUS"]
+
+    def test_single_channel_image_is_accepted(self):
+        depth = prepare_depth(np.full((4, 4, 1), 1.0, dtype=np.float32))
+        assert depth.shape == (4, 4)
+
+    def test_non_2d_image_raises(self):
+        with pytest.raises(ValueError, match="2D"):
+            prepare_depth(np.zeros((4, 4, 3), dtype=np.float32))
+
+    def test_values_beyond_the_range_are_capped(self):
+        depth = prepare_depth(np.full((2, 2), 100.0, dtype=np.float32))
+        assert depth[0, 0] == np.iinfo(np.uint16).max
+
+
+class TestDepthValidity:
+    def test_fully_covered_box(self):
+        assert depth_validity(prepare_depth(scene()), PATCH) == 1.0
+
+    def test_box_with_no_usable_depth(self):
+        depth = prepare_depth(np.zeros((HEIGHT, WIDTH), dtype=np.float32))
+        assert depth_validity(depth, PATCH) == 0.0
+
+    def test_out_of_range_depth_does_not_count(self):
+        depth = prepare_depth(scene(patch_depth=9.0, background=9.0))
+        assert depth_validity(depth, PATCH, depth_range=(0.1, 5.0)) == 0.0
+
+    def test_partially_valid_box(self):
+        depth = prepare_depth(scene())
+        # half the box sits on background at 2 m, still in range
+        assert depth_validity(depth, (100, 40, 140, 60), (0.1, 1.0)) == 1.0
+        assert depth_validity(depth, (100, 40, 140, 80), (0.1, 1.0)) == pytest.approx(0.5)
+
+    def test_box_off_the_image(self):
+        depth = prepare_depth(scene())
+        assert depth_validity(depth, (500, 500, 600, 600)) == 0.0
+
+    def test_empty_box(self):
+        assert depth_validity(prepare_depth(scene()), (10, 10, 10, 10)) == 0.0
+
+
+class TestMessageFields:
+    def test_labels_and_scores_follow_the_boxes(self):
+        """Boxes without usable depth are dropped, so metadata must be taken
+        by the detection index rather than by position."""
+        boxes = [
+            Box3D(index=0, center=(0.5, 0.0, 0.0), size=(0.1, 0.1, 0.1), validity=0.9),
+            Box3D(index=2, center=(1.0, 0.0, 0.0), size=(0.2, 0.2, 0.2), validity=0.4),
+        ]
+        fields = detections_to_message_fields(
+            boxes,
+            labels=["orange", "cup", "bowl"],
+            scores=[0.9, 0.8, 0.7],
+            boxes_2d=[(0, 0, 1, 1), (1, 1, 2, 2), (2, 2, 3, 3)],
+        )
+        assert fields["labels"] == ["orange", "bowl"]
+        assert fields["scores"] == [0.9, 0.7]
+        assert fields["depth_validity"] == [0.9, 0.4]
+        assert fields["boxes_2d"] == [(0, 0, 1, 1), (2, 2, 3, 3)]
+        assert fields["output"][0] == ((0.5, 0.0, 0.0), (0.1, 0.1, 0.1))
+
+    def test_without_metadata(self):
+        fields = detections_to_message_fields(
+            [Box3D(index=0, center=(0.5, 0.0, 0.0), size=(0.1, 0.1, 0.1))]
+        )
+        assert fields["labels"] == [] and fields["scores"] == []
+        assert len(fields["output"]) == 1
+
+    def test_no_boxes(self):
+        assert detections_to_message_fields([])["output"] == []
+
+
+class TestKompassCoreGuard:
+    def test_missing_dependency_is_actionable(self, monkeypatch):
+        monkeypatch.setattr("agents.utils.perception3d.find_spec", lambda name: None)
+        with pytest.raises(ModuleNotFoundError, match="kompass-core"):
+            ensure_kompass_core()
+
+
+class TestLifting:
+    """The geometry itself, against a synthetic camera and scene."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_kompass_core(self):
+        pytest.importorskip("kompass_core.vision")
+
+    @staticmethod
+    def _intrinsics():
+        from ros_sugar.io import CameraIntrinsics
+
+        return CameraIntrinsics(
+            fx=FX, fy=FY, cx=CX, cy=CY, width=WIDTH, height=HEIGHT,
+            frame_id="camera_optical",
+        )
+
+    def _lift(self, boxes_2d, depth=None, **kwargs):
+        from agents.utils.perception3d import boxes_from_detections, make_detector
+
+        detector = make_detector(self._intrinsics(), **kwargs)
+        depth_mm = prepare_depth(scene() if depth is None else depth)
+        return boxes_from_detections(detector, depth_mm, boxes_2d)
+
+    def test_patch_is_placed_at_its_distance_and_size(self):
+        boxes = self._lift([PATCH])
+        assert len(boxes) == 1
+        box = boxes[0]
+        # the detector reports in a forward-left-up frame, so x is the distance
+        assert box.center[0] == pytest.approx(PATCH_DEPTH_M, abs=0.02)
+        # 40 px wide at 0.5 m with a 500 px focal length is 4 cm
+        assert box.size[1] == pytest.approx(40 * PATCH_DEPTH_M / FX, abs=0.01)
+        assert box.size[2] == pytest.approx(20 * PATCH_DEPTH_M / FY, abs=0.01)
+        assert box.validity == 1.0
+
+    def test_depth_is_that_of_whatever_fills_the_box(self):
+        """The distance is a median, so a box padded well beyond its object
+        reports the wall behind it. Detections must be tight."""
+        tight = (PATCH[0] - 2, PATCH[1] - 2, PATCH[2] + 2, PATCH[3] + 2)
+        assert self._lift([tight])[0].center[0] == pytest.approx(
+            PATCH_DEPTH_M, abs=0.05
+        )
+
+        loose = (PATCH[0] - 10, PATCH[1] - 10, PATCH[2] + 10, PATCH[3] + 10)
+        assert self._lift([loose])[0].center[0] == pytest.approx(
+            BACKGROUND_DEPTH_M, abs=0.05
+        )
+
+    def test_translation_moves_the_box(self):
+        boxes = self._lift([PATCH], translation=(1.0, 0.0, 0.0))
+        assert boxes[0].center[0] == pytest.approx(1.0 + PATCH_DEPTH_M, abs=0.02)
+
+    def test_boxes_without_depth_are_dropped_and_indices_survive(self):
+        """kompass drops boxes it cannot place, so the surviving boxes must
+        still say which detection they came from."""
+        depth = scene()
+        # a region with no readings, larger than the box below because the
+        # detector reads its pixel limits inclusively
+        depth[0:40, 0:40] = 0.0
+        boxes = self._lift([(0, 0, 20, 20), PATCH], depth=depth)
+        assert [box.index for box in boxes] == [1]
+
+    def test_no_detections(self):
+        assert self._lift([]) == []
+
+    def test_lifted_boxes_build_a_message(self):
+        from agents.ros import Detections3D
+
+        boxes = self._lift([PATCH])
+        fields = detections_to_message_fields(
+            boxes, labels=["orange"], scores=[0.9], boxes_2d=[PATCH]
+        )
+        message = Detections3D.convert(**fields)
+        assert message.labels == ["orange"]
+        assert list(message.depth_validity) == [1.0]
+        assert message.boxes[0].center.position.x == pytest.approx(
+            PATCH_DEPTH_M, abs=0.02
+        )

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -109,3 +109,78 @@ class TestConvertHeaders:
         )
         assert message.header.frame_id == ""
         assert message.labels == ["cup"]
+
+
+class TestDetections3DMessage:
+    """The 3D detection message and its conversion."""
+
+    @staticmethod
+    def _boxes():
+        return [((0.3, 0.0, 0.15), (0.06, 0.06, 0.08))]
+
+    def test_convert_round_trip(self):
+        from agents.ros import Detections3D
+
+        message = Detections3D.convert(
+            self._boxes(),
+            labels=["orange"],
+            scores=[0.87],
+            depth_validity=[0.64],
+            source_frame="front_optical",
+        )
+        assert message.labels == ["orange"]
+        assert list(message.scores) == [0.87]
+        assert list(message.depth_validity) == [0.64]
+        assert message.source_frame == "front_optical"
+        box = message.boxes[0]
+        assert (box.center.position.x, box.center.position.z) == (0.3, 0.15)
+        assert (box.size.x, box.size.y, box.size.z) == (0.06, 0.06, 0.08)
+        # a bare Pose has w=0, which is not a valid rotation
+        assert box.center.orientation.w == 1.0
+
+    def test_convert_without_metadata(self):
+        from agents.ros import Detections3D
+
+        message = Detections3D.convert(self._boxes())
+        assert len(message.boxes) == 1
+        assert message.labels == [] and list(message.scores) == []
+
+    def test_box_maps_onto_ros_and_moveit_types(self):
+        """The message is shaped so neither perception nor planning needs a
+        conversion layer."""
+        vision_msgs = pytest.importorskip("vision_msgs.msg")
+        shape_msgs = pytest.importorskip("shape_msgs.msg")
+        from agents.ros import Detections3D
+
+        box = Detections3D.convert(self._boxes()).boxes[0]
+
+        bounding_box = vision_msgs.BoundingBox3D()
+        bounding_box.center = box.center
+        bounding_box.size = box.size
+        assert bounding_box.size.x == 0.06
+
+        primitive = shape_msgs.SolidPrimitive(
+            type=shape_msgs.SolidPrimitive.BOX,
+            dimensions=[box.size.x, box.size.y, box.size.z],
+        )
+        assert list(primitive.dimensions) == [0.06, 0.06, 0.08]
+
+    def test_callback_gives_context_by_default_and_the_message_on_request(self):
+        """Prompts and memory want the classes; a planner wants the boxes."""
+        from agents.callbacks import Detections3DCallback
+        from agents.ros import Detections3D, Topic
+
+        callback = Detections3DCallback(Topic(name="d3", msg_type="Detections3D"))
+        assert callback.get_output() is None
+        assert callback.get_output(get_msg=True) is None
+        assert "No objects" in callback._get_ui_content()
+
+        message = Detections3D.convert(self._boxes(), labels=["orange"])
+        message.header.frame_id = "base_link"
+        callback.msg = message
+
+        assert callback.get_output() == "1 orange"
+        assert callback.get_output(get_msg=True) is message
+
+        content = callback._get_ui_content()
+        assert "orange" in content and "base_link" in content

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -731,6 +731,56 @@ class TestLiftingFromRGBD(_SyntheticCamera):
         assert center[2] == pytest.approx(self.PATCH_DEPTH_M, abs=0.02)
 
 
+class TestSerializedRelaunch:
+    """The launch executable reconstructs a component in a child process from
+    its serialized config, inputs and outputs — it knows nothing of Vision's
+    `depth` and `camera_info` parameters. They ride the config instead."""
+
+    def test_3d_vision_survives_the_executable_reconstruction(
+        self, rclpy_init, mock_model_client
+    ):
+        import json
+
+        from agents.ros import QoSConfig
+
+        type(mock_model_client).model_type = PropertyMock(return_value="VisionModel")
+        original = Vision(
+            inputs=[Topic(name="image", msg_type="Image")],
+            outputs=[Topic(name="d3", msg_type="Detections3D")],
+            depth=Topic(name="depth", msg_type="Image"),
+            camera_info=Topic(name="cam_info", msg_type="CameraInfo"),
+            model_client=mock_model_client,
+            config=VisionConfig(detections_frame="base_link"),
+            component_name="v",
+        )
+
+        # what scripts/executable does in the child process: config from its
+        # JSON, topics from theirs, and no depth/camera_info parameters
+        def _topics(serialized):
+            topics = []
+            for entry in json.loads(serialized):
+                data = json.loads(entry)
+                data["qos_profile"] = QoSConfig(**data.get("qos_profile", {}))
+                data["additional_types"] = []
+                topics.append(Topic(**data))
+            return topics
+
+        rebuilt = Vision(
+            inputs=_topics(original._inputs_json),
+            outputs=_topics(original._outputs_json),
+            model_client=mock_model_client,
+            trigger=1.0,
+            config=VisionConfig(**json.loads(original.config.to_json())),
+            component_name="v",
+        )
+
+        assert rebuilt._aux_inputs == original._aux_inputs
+        assert rebuilt._lift_camera == original._lift_camera == "image"
+        assert rebuilt._inference_set == original._inference_set
+        assert rebuilt.depth_topic.name == "depth"
+        assert rebuilt.camera_info_topic.name == "cam_info"
+
+
 class TestPublishRouting:
     """Inference returns one set of detections per image; each output topic
     gets the shape it can carry."""

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,111 @@
+"""Tests for the Vision component — requires rclpy."""
+
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+from agents.components.vision import Vision
+from agents.config import VisionConfig
+from agents.ros import Detections, DetectionsMultiSource, Topic
+from tests.conftest import mock_component_internals
+
+
+def _image(frame_id="camera_optical_frame"):
+    """A minimal ROS image carrying a frame."""
+    from sensor_msgs.msg import Image as ROSImage
+
+    image = ROSImage()
+    image.header.frame_id = frame_id
+    image.height, image.width = 2, 2
+    image.encoding = "rgb8"
+    image.step = 6
+    image.data = bytes(12)
+    return image
+
+
+@pytest.fixture
+def vision(rclpy_init, mock_model_client):
+    # Vision rejects clients that do not serve a VisionModel
+    type(mock_model_client).model_type = PropertyMock(return_value="VisionModel")
+    comp = Vision(
+        inputs=[Topic(name="image", msg_type="Image")],
+        outputs=[Topic(name="detections", msg_type="Detections")],
+        model_client=mock_model_client,
+        config=VisionConfig(),
+        component_name="test_vision",
+    )
+    mock_component_internals(comp)
+    return comp
+
+
+class TestDetectionFrames:
+    """Detections must carry the frame of the camera that made them —
+    without it they cannot be placed in the world."""
+
+    def test_publish_passes_source_frame(self, vision, mock_model_client):
+        mock_model_client.inference.return_value = {
+            "output": [{"bboxes": [[0, 0, 1, 1]], "labels": ["cup"], "scores": [0.9]}]
+        }
+        callback = MagicMock()
+        callback.msg = _image("front_camera_optical")
+        callback.get_output.return_value = [[0, 0, 0]]
+        vision.callbacks = {"image": callback}
+        vision.trig_callbacks = {}
+        vision.run_type = vision.run_type  # keep whatever mock_component_internals set
+
+        vision._execution_step()
+
+        publish_kwargs = vision.publishers_dict["out"].publish.call_args[1]
+        assert publish_kwargs["frame_id"] == "front_camera_optical"
+
+    def test_source_frame_from_rgbd(self, vision):
+        rgbd = MagicMock()
+        rgbd.rgb = _image("rgbd_optical")
+        vision._images = [rgbd]
+        assert vision._source_frame() == "rgbd_optical"
+
+    def test_source_frame_none_without_header(self, vision):
+        vision._images = [MagicMock(spec=[])]
+        assert vision._source_frame() is None
+
+    def test_multi_camera_leaves_outer_frame_unset(self, vision):
+        """A single frame would name only one of the cameras — the nested
+        per-source detections carry the frames instead."""
+        vision._images = [_image("left_camera"), _image("right_camera")]
+        assert vision._source_frame() is None
+
+    def test_no_images_has_no_frame(self, vision):
+        vision._images = []
+        assert vision._source_frame() is None
+
+
+class TestConvertHeaders:
+    """The per-source detections nested in a multi-source message need their
+    own frames — the outer header can only name one camera."""
+
+    def test_detections_convert_copies_header(self):
+        message = Detections.convert(
+            [{"bboxes": [[0, 0, 2, 2]], "labels": ["cup"], "scores": [0.8]}],
+            [_image("left_camera")],
+        )
+        assert message.header.frame_id == "left_camera"
+
+    def test_multi_source_nests_per_camera_frames(self):
+        output = [
+            {"bboxes": [[0, 0, 1, 1]], "labels": ["cup"], "scores": [0.8]},
+            {"bboxes": [[1, 1, 2, 2]], "labels": ["bowl"], "scores": [0.7]},
+        ]
+        message = DetectionsMultiSource.convert(
+            output, [_image("left_camera"), _image("right_camera")]
+        )
+        assert [d.header.frame_id for d in message.detections] == [
+            "left_camera",
+            "right_camera",
+        ]
+
+    def test_convert_without_image_is_unchanged(self):
+        message = Detections.convert(
+            [{"bboxes": [[0, 0, 1, 1]], "labels": ["cup"], "scores": [0.8]}], []
+        )
+        assert message.header.frame_id == ""
+        assert message.labels == ["cup"]

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -215,6 +215,212 @@ class TestDetectionSet:
         assert mock_model_client._model._num_trackers == 1
 
 
+class Test3DContract:
+    """Asking for a Detections3D output is what turns lifting on, so the
+    component says up front when it was not given what that takes: one camera,
+    depth registered to its pictures, that depth's calibration, and a frame to
+    report boxes in."""
+
+    @staticmethod
+    def _build(mock_model_client, inputs, config=None, outputs=None, **kwargs):
+        type(mock_model_client).model_type = PropertyMock(return_value="VisionModel")
+        return Vision(
+            inputs=inputs,
+            outputs=outputs or [Topic(name="d3", msg_type="Detections3D")],
+            model_client=mock_model_client,
+            config=config or VisionConfig(detections_frame="base_link"),
+            component_name="test_3d",
+            **kwargs,
+        )
+
+    def test_an_rgbd_input_carries_everything(self, rclpy_init, mock_model_client):
+        """Depth registered to the picture, plus both calibrations, in one
+        message — so it needs no other topic."""
+        component = self._build(
+            mock_model_client, [Topic(name="rgbd", msg_type="RGBD")]
+        )
+        assert component._lift_to_3d and component._inference_set == ["rgbd"]
+
+    def test_a_named_depth_topic_is_accepted(self, rclpy_init, mock_model_client):
+        """Every stereo camera other than RealSense publishes its registered
+        depth on its own topic."""
+        component = self._build(
+            mock_model_client,
+            [Topic(name="image", msg_type="Image")],
+            depth=Topic(name="depth", msg_type="Image"),
+            camera_info=Topic(name="camera_info", msg_type="CameraInfo"),
+        )
+        # both become inputs, but neither is a picture to detect on
+        assert component._aux_inputs == {"depth", "camera_info"}
+        assert component._inference_set == ["image"]
+        assert component._spectators == []
+        assert {"depth", "camera_info"} <= {t.name for t in component.in_topics}
+
+    def test_depth_is_required(self, rclpy_init, mock_model_client):
+        """An image topic cannot be guessed to be depth."""
+        with pytest.raises(TypeError, match="requires depth"):
+            self._build(mock_model_client, [Topic(name="image", msg_type="Image")])
+
+    def test_depth_needs_its_calibration(self, rclpy_init, mock_model_client):
+        with pytest.raises(TypeError, match="camera_info"):
+            self._build(
+                mock_model_client,
+                [Topic(name="image", msg_type="Image")],
+                depth=Topic(name="depth", msg_type="Image"),
+            )
+
+    def test_depth_cannot_be_compressed(self, rclpy_init, mock_model_client):
+        with pytest.raises(TypeError, match="uncompressed"):
+            self._build(
+                mock_model_client,
+                [Topic(name="image", msg_type="Image")],
+                depth=Topic(name="depth", msg_type="CompressedImage"),
+                camera_info=Topic(name="camera_info", msg_type="CameraInfo"),
+            )
+
+    def test_a_frame_to_report_in_is_required(self, rclpy_init, mock_model_client):
+        """Boxes are axis aligned in the frame they are measured in, so it is
+        chosen before they exist."""
+        with pytest.raises(TypeError, match="detections_frame"):
+            self._build(
+                mock_model_client,
+                [Topic(name="rgbd", msg_type="RGBD")],
+                config=VisionConfig(),
+            )
+
+    def test_the_first_of_several_cameras_is_lifted(
+        self, rclpy_init, mock_model_client
+    ):
+        """Only one camera's depth and calibration are given, so the rest are
+        left for the component actions, as with 2D outputs."""
+        component = self._build(
+            mock_model_client,
+            [
+                Topic(name="left", msg_type="RGBD"),
+                Topic(name="right", msg_type="RGBD"),
+            ],
+        )
+        assert component._lift_camera == "left"
+        assert component._inference_set == ["left"]
+        assert component._spectators == ["right"]
+
+    def test_an_rgbd_wins_over_a_plain_camera_whatever_the_order(
+        self, rclpy_init, mock_model_client
+    ):
+        """An RGBD frame identifies its own camera, so it needs no ordering
+        convention to be chosen."""
+        component = self._build(
+            mock_model_client,
+            [
+                Topic(name="spare", msg_type="Image"),
+                Topic(name="rgbd", msg_type="RGBD"),
+            ],
+        )
+        assert component._lift_camera == "rgbd"
+        assert component._inference_set == ["rgbd"]
+        assert component._spectators == ["spare"]
+
+    def test_the_lifted_camera_is_named_when_others_are_inferenced_on(
+        self, rclpy_init, mock_model_client, monkeypatch
+    ):
+        """A multi source output pulls every camera into the pass, but only one
+        of them can be placed in space."""
+        component = self._build(
+            mock_model_client,
+            [
+                Topic(name="rgbd", msg_type="RGBD"),
+                Topic(name="spare", msg_type="Image"),
+            ],
+            outputs=[
+                Topic(name="d3", msg_type="Detections3D"),
+                Topic(name="all", msg_type="DetectionsMultiSource"),
+            ],
+        )
+        mock_component_internals(component)
+        monkeypatch.setattr(
+            "agents.components.model_component.ModelComponent.custom_on_configure",
+            lambda _: None,
+        )
+        assert component._inference_set == ["rgbd", "spare"]
+
+        component.custom_on_configure()
+
+        warning = " ".join(
+            str(call[0][0]) for call in component.get_logger().warning.call_args_list
+        )
+        assert "rgbd" in warning and "spare" in warning and "2D only" in warning
+
+    def test_camera_info_may_override_what_an_rgbd_carries(
+        self, rclpy_init, mock_model_client
+    ):
+        component = self._build(
+            mock_model_client,
+            [Topic(name="rgbd", msg_type="RGBD")],
+            camera_info=Topic(name="camera_info", msg_type="CameraInfo"),
+        )
+        assert component.camera_info.name == "camera_info"
+        assert component._inference_set == ["rgbd"]
+
+    def test_camera_info_in_inputs_is_refused(self, rclpy_init, mock_model_client):
+        """Depth cannot be told from a camera in `inputs`, so neither is looked
+        for there: both have exactly one way in."""
+        with pytest.raises(TypeError, match="camera_info=Topic"):
+            self._build(
+                mock_model_client,
+                [
+                    Topic(name="rgbd", msg_type="RGBD"),
+                    Topic(name="camera_info", msg_type="CameraInfo"),
+                ],
+            )
+
+    def test_depth_cannot_be_the_trigger(self, rclpy_init, mock_model_client):
+        depth = Topic(name="depth", msg_type="Image")
+        with pytest.raises(TypeError, match="trigger"):
+            self._build(
+                mock_model_client,
+                [Topic(name="image", msg_type="Image")],
+                depth=depth,
+                camera_info=Topic(name="camera_info", msg_type="CameraInfo"),
+                trigger=depth,
+            )
+
+    def test_depth_without_a_3d_output_is_ignored_and_said_so(
+        self, rclpy_init, mock_model_client, monkeypatch
+    ):
+        """Unused config rather than an impossibility, so the component builds
+        and says what it is leaving out."""
+        component = self._build(
+            mock_model_client,
+            [Topic(name="image", msg_type="Image")],
+            outputs=[Topic(name="detections", msg_type="Detections")],
+            depth=Topic(name="depth", msg_type="Image"),
+            camera_info=Topic(name="camera_info", msg_type="CameraInfo"),
+        )
+        # nothing reads them, so nothing subscribes to them either
+        assert {t.name for t in component.in_topics} == {"image"}
+
+        mock_component_internals(component)
+        monkeypatch.setattr(
+            "agents.components.model_component.ModelComponent.custom_on_configure",
+            lambda _: None,
+        )
+        component.custom_on_configure()
+
+        warning = " ".join(
+            str(call[0][0]) for call in component.get_logger().warning.call_args_list
+        )
+        assert "depth" in warning and "camera_info" in warning
+
+    def test_2d_only_components_are_untouched(self, rclpy_init, mock_model_client):
+        component = self._build(
+            mock_model_client,
+            [Topic(name="image", msg_type="Image")],
+            config=VisionConfig(),
+            outputs=[Topic(name="detections", msg_type="Detections")],
+        )
+        assert not component._lift_to_3d and component._aux_inputs == set()
+
+
 class TestPublishRouting:
     """Inference returns one set of detections per image; each output topic
     gets the shape it can carry."""

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -10,16 +10,18 @@ from agents.ros import Detections, DetectionsMultiSource, Topic
 from tests.conftest import mock_component_internals
 
 
-def _image(frame_id="camera_optical_frame"):
+def _image(frame_id="camera_optical_frame", width=2, height=2, stamp=0.0):
     """A minimal ROS image carrying a frame."""
     from sensor_msgs.msg import Image as ROSImage
 
     image = ROSImage()
     image.header.frame_id = frame_id
-    image.height, image.width = 2, 2
+    image.header.stamp.sec = int(stamp)
+    image.header.stamp.nanosec = int((stamp % 1) * 1e9)
+    image.height, image.width = height, width
     image.encoding = "rgb8"
-    image.step = 6
-    image.data = bytes(12)
+    image.step = width * 3
+    image.data = bytes(width * height * 3)
     return image
 
 
@@ -30,6 +32,12 @@ def _callback(msg=None, output=None, msg_type="Image", name="topic"):
     callback.msg = msg
     callback.get_output.return_value = output
     return callback
+
+
+def _warnings(component) -> str:
+    return " ".join(
+        str(call[0][0]) for call in component.get_logger().warning.call_args_list
+    )
 
 
 @pytest.fixture
@@ -348,7 +356,7 @@ class Test3DContract:
         warning = " ".join(
             str(call[0][0]) for call in component.get_logger().warning.call_args_list
         )
-        assert "rgbd" in warning and "spare" in warning and "2D only" in warning
+        assert "rgbd" in warning and "spare" in warning and "3D" in warning
 
     def test_camera_info_may_override_what_an_rgbd_carries(
         self, rclpy_init, mock_model_client
@@ -358,7 +366,7 @@ class Test3DContract:
             [Topic(name="rgbd", msg_type="RGBD")],
             camera_info=Topic(name="camera_info", msg_type="CameraInfo"),
         )
-        assert component.camera_info.name == "camera_info"
+        assert component.camera_info_topic.name == "camera_info"
         assert component._inference_set == ["rgbd"]
 
     def test_camera_info_in_inputs_is_refused(self, rclpy_init, mock_model_client):
@@ -419,6 +427,308 @@ class Test3DContract:
             outputs=[Topic(name="detections", msg_type="Detections")],
         )
         assert not component._lift_to_3d and component._aux_inputs == set()
+
+
+class _SyntheticCamera:
+    """A camera looking at a patch half a meter away on a far wall. Shared by
+    the two ways depth reaches the component."""
+
+    FX = FY = 500.0
+    WIDTH, HEIGHT = 200, 120
+    PATCH = (100, 40, 140, 60)
+    PATCH_DEPTH_M = 0.5
+
+    @pytest.fixture(autouse=True)
+    def _needs_kompass_core(self):
+        pytest.importorskip("kompass_core.vision")
+
+    @classmethod
+    def _depth_scene(cls, frame_id="cam", stamp=0.0, background_m=3.0):
+        import numpy as np
+        from sensor_msgs.msg import Image as ROSImage
+
+        pixels = np.full((cls.HEIGHT, cls.WIDTH), int(background_m * 1000), np.uint16)
+        x1, y1, x2, y2 = cls.PATCH
+        pixels[y1:y2, x1:x2] = int(cls.PATCH_DEPTH_M * 1000)
+
+        msg = ROSImage()
+        msg.header.frame_id = frame_id
+        msg.header.stamp.sec = int(stamp)
+        msg.header.stamp.nanosec = int((stamp % 1) * 1e9)
+        msg.height, msg.width = cls.HEIGHT, cls.WIDTH
+        msg.encoding = "16UC1"
+        msg.step = cls.WIDTH * 2
+        msg.data = pixels.tobytes()
+        return msg
+
+    @classmethod
+    def _intrinsics(cls, frame_id="cam", width=None, height=None):
+        from ros_sugar.io import CameraIntrinsics
+
+        return CameraIntrinsics(
+            fx=cls.FX,
+            fy=cls.FY,
+            cx=cls.WIDTH / 2,
+            cy=cls.HEIGHT / 2,
+            width=width or cls.WIDTH,
+            height=height or cls.HEIGHT,
+            frame_id=frame_id,
+        )
+
+    @classmethod
+    def _detections(cls, boxes=None):
+        return {
+            "output": [
+                {
+                    "bboxes": boxes if boxes is not None else [list(cls.PATCH)],
+                    "labels": ["orange"],
+                    "scores": [0.9],
+                }
+            ]
+        }
+
+    @staticmethod
+    def _published(component):
+        """The boxes and the fields they were published with."""
+        args, kwargs = component.publishers_dict["out"].publish.call_args
+        return args[0], kwargs
+
+
+class TestLiftingWithADepthTopic(_SyntheticCamera):
+    """Depth on its own topic, as ZED, Orbbec and OAK publish it."""
+
+    @pytest.fixture
+    def vision_3d(self, rclpy_init, mock_model_client):
+        type(mock_model_client).model_type = PropertyMock(return_value="VisionModel")
+        component = Vision(
+            inputs=[Topic(name="image", msg_type="Image")],
+            outputs=[Topic(name="d3", msg_type="Detections3D")],
+            depth=Topic(name="depth", msg_type="Image"),
+            camera_info=Topic(name="camera_info", msg_type="CameraInfo"),
+            model_client=mock_model_client,
+            config=VisionConfig(detections_frame="cam"),
+            component_name="test_lift",
+        )
+        return mock_component_internals(component)
+
+    def _wire(self, component, stamp=0.0, depth_stamp=0.0, intrinsics=None):
+        component.callbacks = {
+            "image": _callback(
+                _image("cam", width=self.WIDTH, height=self.HEIGHT, stamp=stamp),
+                [[0]],
+                name="image",
+            ),
+            "depth": _callback(self._depth_scene("cam", depth_stamp), name="depth"),
+            "camera_info": _callback(
+                msg_type="CameraInfo",
+                output=intrinsics or self._intrinsics(),
+                name="camera_info",
+            ),
+        }
+        component.trig_callbacks = {}
+
+    def test_detections_are_published_in_metric_space(
+        self, vision_3d, mock_model_client
+    ):
+        mock_model_client.inference.return_value = self._detections()
+        self._wire(vision_3d)
+
+        vision_3d._execution_step()
+
+        boxes, published = self._published(vision_3d)
+        assert published["labels"] == ["orange"] and published["scores"] == [0.9]
+        assert published["frame_id"] == "cam"
+        # published in the camera's own frame, where distance runs along z
+        (center, size), = boxes
+        assert center[2] == pytest.approx(self.PATCH_DEPTH_M, abs=0.02)
+        assert size[0] == pytest.approx(40 * self.PATCH_DEPTH_M / self.FX, abs=0.01)
+        assert published["boxes_2d"] == [list(self.PATCH)]
+
+    def test_an_empty_scene_is_still_reported(self, vision_3d, mock_model_client):
+        """Seeing nothing is an observation, and consumers need it to let go of
+        objects that are no longer there."""
+        mock_model_client.inference.return_value = self._detections(boxes=[])
+        self._wire(vision_3d)
+
+        vision_3d._execution_step()
+
+        boxes, _ = self._published(vision_3d)
+        assert boxes == []
+
+    def test_depth_is_paired_when_the_picture_is_taken(
+        self, vision_3d, mock_model_client
+    ):
+        """Which depth frame pairs with the picture must not depend on how
+        long inference takes."""
+        self._wire(vision_3d)
+
+        def _slow_inference(*_, **__):
+            # a much later depth frame lands while the model is busy
+            vision_3d.callbacks["depth"].msg = self._depth_scene("cam", stamp=99.0)
+            return self._detections()
+
+        mock_model_client.inference.side_effect = _slow_inference
+
+        vision_3d._execution_step()
+
+        # had the late frame been read, max_depth_age would have refused it
+        boxes, _ = self._published(vision_3d)
+        assert boxes[0][0][2] == pytest.approx(self.PATCH_DEPTH_M, abs=0.02)
+
+    def test_stale_depth_publishes_nothing(self, vision_3d, mock_model_client):
+        """Silence differs from an empty message: one says the camera cannot be
+        used, the other that the scene is clear."""
+        mock_model_client.inference.return_value = self._detections()
+        self._wire(vision_3d, stamp=10.0, depth_stamp=9.0)
+
+        vision_3d._execution_step()
+
+        assert vision_3d.publishers_dict["out"].publish.call_count == 0
+        assert "max_depth_age" in _warnings(vision_3d)
+
+    def test_intrinsics_for_another_resolution_are_refused(
+        self, vision_3d, mock_model_client
+    ):
+        mock_model_client.inference.return_value = self._detections()
+        self._wire(vision_3d, intrinsics=self._intrinsics(width=1280, height=720))
+
+        vision_3d._execution_step()
+
+        assert vision_3d.publishers_dict["out"].publish.call_count == 0
+        assert "1280x720" in vision_3d.get_logger().error.call_args[0][0]
+
+    def test_boxes_built_from_too_little_depth_are_dropped(
+        self, vision_3d, mock_model_client
+    ):
+        vision_3d.config.min_depth_validity = 0.9
+        vision_3d.config.max_depth = 5.0
+        mock_model_client.inference.return_value = self._detections(
+            boxes=[[80, 20, 160, 80]]
+        )
+        self._wire(vision_3d)
+        # the wall is beyond max_depth, so only the patch itself reads back
+        vision_3d.callbacks["depth"].msg = self._depth_scene("cam", background_m=9.0)
+
+        vision_3d._execution_step()
+
+        boxes, _ = self._published(vision_3d)
+        assert boxes == []
+
+    def test_boxes_are_transformed_into_the_configured_frame(
+        self, vision_3d, mock_model_client
+    ):
+        """A planner works in the robot's frame, not the camera's."""
+        vision_3d.config.detections_frame = "base_link"
+        mock_model_client.inference.return_value = self._detections()
+        self._wire(vision_3d)
+        # a camera looking straight ahead, a meter up on the robot
+        vision_3d.get_transform_listener = MagicMock(
+            return_value=MagicMock(
+                got_transform=True,
+                translation=[0.0, 0.0, 1.0],
+                rotation=[-0.5, 0.5, -0.5, 0.5],
+            )
+        )
+
+        vision_3d._execution_step()
+
+        boxes, published = self._published(vision_3d)
+        assert published["frame_id"] == "base_link"
+        (center, _), = boxes
+        assert center[0] == pytest.approx(self.PATCH_DEPTH_M, abs=0.02)
+        assert center[2] == pytest.approx(1.0, abs=0.02)
+
+    def test_nothing_is_published_before_the_transform_resolves(
+        self, vision_3d, mock_model_client
+    ):
+        vision_3d.config.detections_frame = "base_link"
+        mock_model_client.inference.return_value = self._detections()
+        self._wire(vision_3d)
+        vision_3d.get_transform_listener = MagicMock(
+            return_value=MagicMock(got_transform=False)
+        )
+
+        vision_3d._execution_step()
+
+        assert vision_3d.publishers_dict["out"].publish.call_count == 0
+        assert "has not been resolved" in _warnings(vision_3d)
+
+
+class TestLiftingFromRGBD(_SyntheticCamera):
+    """A RealSense publishes everything lifting needs in one message."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_realsense_msgs(self):
+        pytest.importorskip("realsense2_camera_msgs.msg")
+
+    @classmethod
+    def _camera_info_msg(cls, frame_id="cam"):
+        from sensor_msgs.msg import CameraInfo as ROSCameraInfo
+
+        info = ROSCameraInfo()
+        info.header.frame_id = frame_id
+        info.width, info.height = cls.WIDTH, cls.HEIGHT
+        info.k = [cls.FX, 0.0, cls.WIDTH / 2, 0.0, cls.FY, cls.HEIGHT / 2, 0.0, 0.0, 1.0]
+        return info
+
+    @classmethod
+    def _rgbd_frame(cls, frame_id="cam", stamp=0.0):
+        from realsense2_camera_msgs.msg import RGBD as ROSRGBD
+
+        frame = ROSRGBD()
+        frame.header.frame_id = frame_id
+        frame.rgb = _image(frame_id, width=cls.WIDTH, height=cls.HEIGHT, stamp=stamp)
+        frame.depth = cls._depth_scene(frame_id, stamp)
+        frame.rgb_camera_info = cls._camera_info_msg(frame_id)
+        frame.depth_camera_info = cls._camera_info_msg(frame_id)
+        return frame
+
+    @pytest.fixture
+    def vision_rgbd(self, rclpy_init, mock_model_client):
+        type(mock_model_client).model_type = PropertyMock(return_value="VisionModel")
+        component = Vision(
+            inputs=[Topic(name="rgbd", msg_type="RGBD")],
+            outputs=[Topic(name="d3", msg_type="Detections3D")],
+            model_client=mock_model_client,
+            config=VisionConfig(detections_frame="cam"),
+            component_name="test_rgbd",
+        )
+        return mock_component_internals(component)
+
+    def test_intrinsics_are_parsed_once_and_reused(self, vision_rgbd):
+        """Intrinsics do not change in ordinary operation, so they are read
+        from the captured frame whenever needed and parsed only once."""
+        vision_rgbd._lift_msg = self._rgbd_frame()
+        parsed = vision_rgbd._camera_intrinsics()
+        assert parsed.fx == self.FX and parsed.frame_id == "cam"
+
+        vision_rgbd._lift_msg = self._rgbd_frame(stamp=1.0)
+        assert vision_rgbd._camera_intrinsics() is parsed
+
+    def test_a_new_calibration_is_picked_up(self, vision_rgbd):
+        vision_rgbd._lift_msg = self._rgbd_frame()
+        vision_rgbd._camera_intrinsics()
+
+        changed = self._rgbd_frame()
+        changed.depth_camera_info.k[0] = 999.0
+        vision_rgbd._lift_msg = changed
+        assert vision_rgbd._camera_intrinsics().fx == 999.0
+
+    def test_an_rgbd_frame_lifts_with_no_other_topic(
+        self, vision_rgbd, mock_model_client
+    ):
+        mock_model_client.inference.return_value = self._detections()
+        vision_rgbd.callbacks = {
+            "rgbd": _callback(self._rgbd_frame(), [[0]], msg_type="RGBD", name="rgbd")
+        }
+        vision_rgbd.trig_callbacks = {}
+
+        vision_rgbd._execution_step()
+
+        boxes, published = self._published(vision_rgbd)
+        assert published["frame_id"] == "cam"
+        (center, _), = boxes
+        assert center[2] == pytest.approx(self.PATCH_DEPTH_M, abs=0.02)
 
 
 class TestPublishRouting:

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -23,6 +23,15 @@ def _image(frame_id="camera_optical_frame"):
     return image
 
 
+def _callback(msg=None, output=None, msg_type="Image", name="topic"):
+    """A stand-in for an input callback, carrying the topic it subscribes to."""
+    callback = MagicMock()
+    callback.input_topic = Topic(name=name, msg_type=msg_type)
+    callback.msg = msg
+    callback.get_output.return_value = output
+    return callback
+
+
 @pytest.fixture
 def vision(rclpy_init, mock_model_client):
     # Vision rejects clients that do not serve a VisionModel
@@ -79,16 +88,202 @@ class TestDetectionFrames:
         assert vision._source_frame() is None
 
 
+class TestDetectionSet:
+    """Which image inputs reach the model. The rest stay subscribed for
+    take_picture and record_video rather than being inferred on and thrown
+    away, which is what used to happen."""
+
+    @staticmethod
+    def _build(mock_model_client, inputs, outputs, trigger=1.0):
+        type(mock_model_client).model_type = PropertyMock(return_value="VisionModel")
+        component = Vision(
+            inputs=inputs,
+            outputs=outputs,
+            model_client=mock_model_client,
+            config=VisionConfig(),
+            component_name="test_set",
+            trigger=trigger,
+        )
+        return mock_component_internals(component)
+
+    @staticmethod
+    def _cameras(*names):
+        return [Topic(name=name, msg_type="Image") for name in names]
+
+    def test_timed_single_source_detects_on_one_camera(
+        self, rclpy_init, mock_model_client
+    ):
+        component = self._build(
+            mock_model_client,
+            self._cameras("front", "rear"),
+            [Topic(name="detections", msg_type="Detections")],
+        )
+        assert component._inference_set == ["front"]
+        assert component._spectators == ["rear"]
+
+    def test_a_spectator_camera_never_reaches_the_model(
+        self, rclpy_init, mock_model_client
+    ):
+        """Inferring on it and discarding the result costs a full model pass
+        per tick."""
+        component = self._build(
+            mock_model_client,
+            self._cameras("front", "rear"),
+            [Topic(name="detections", msg_type="Detections")],
+        )
+        component.callbacks = {
+            "front": _callback(_image("front_optical"), [[1]], name="front"),
+            "rear": _callback(_image("rear_optical"), [[2]], name="rear"),
+        }
+        component.trig_callbacks = {}
+
+        assert component._create_input()["images"] == [[[1]]]
+
+    def test_it_is_named_rather_than_quietly_ignored(
+        self, rclpy_init, mock_model_client, monkeypatch
+    ):
+        component = self._build(
+            mock_model_client,
+            self._cameras("front", "rear"),
+            [Topic(name="detections", msg_type="Detections")],
+        )
+        monkeypatch.setattr(
+            "agents.components.model_component.ModelComponent.custom_on_configure",
+            lambda _: None,
+        )
+
+        component.custom_on_configure()
+
+        warning = " ".join(
+            str(call[0][0]) for call in component.get_logger().warning.call_args_list
+        )
+        assert "rear" in warning and "take_picture" in warning
+
+    def test_timed_multi_source_detects_on_all_cameras(
+        self, rclpy_init, mock_model_client
+    ):
+        component = self._build(
+            mock_model_client,
+            self._cameras("front", "rear"),
+            [Topic(name="detections", msg_type="DetectionsMultiSource")],
+        )
+        assert component._inference_set == ["front", "rear"]
+        assert component._spectators == []
+
+    def test_single_source_alongside_multi_source_is_refused(
+        self, rclpy_init, mock_model_client
+    ):
+        """The multi source output pulls both cameras into the same pass, and
+        a Detections topic cannot describe both."""
+        with pytest.raises(TypeError, match="MultiSource"):
+            self._build(
+                mock_model_client,
+                self._cameras("front", "rear"),
+                [
+                    Topic(name="all", msg_type="DetectionsMultiSource"),
+                    Topic(name="one", msg_type="Detections"),
+                ],
+            )
+
+    def test_triggered_cameras_are_the_detection_set(
+        self, rclpy_init, mock_model_client
+    ):
+        """A tick reads only the topic that fired, so several triggers still
+        mean one picture per tick and a single source output stays valid."""
+        cameras = self._cameras("front", "rear", "spare")
+        component = self._build(
+            mock_model_client,
+            cameras,
+            [Topic(name="detections", msg_type="Detections")],
+            trigger=cameras[:2],
+        )
+        assert component._inference_set == ["front", "rear"]
+        assert component._spectators == ["spare"]
+
+    def test_trackers_are_allocated_per_camera_detected_on(
+        self, rclpy_init, mock_model_client
+    ):
+        type(mock_model_client).model_type = PropertyMock(return_value="VisionModel")
+        mock_model_client._model = MagicMock(setup_trackers=True)
+        Vision(
+            inputs=self._cameras("front", "rear"),
+            outputs=[Topic(name="detections", msg_type="Detections")],
+            model_client=mock_model_client,
+            config=VisionConfig(),
+            component_name="test_trackers",
+        )
+        assert mock_model_client._model._num_trackers == 1
+
+
+class TestPublishRouting:
+    """Inference returns one set of detections per image; each output topic
+    gets the shape it can carry."""
+
+    def test_single_source_gets_one_cameras_detections(
+        self, vision, mock_model_client
+    ):
+        mock_model_client.inference.return_value = {
+            "output": [{"bboxes": [[0, 0, 1, 1]], "labels": ["cup"], "scores": [0.9]}]
+        }
+        vision.callbacks = {"image": _callback(_image("front"), [[0]], name="image")}
+        vision.trig_callbacks = {}
+
+        vision._execution_step()
+
+        published = vision.publishers_dict["out"].publish.call_args[0][0]
+        assert published["labels"] == ["cup"]
+
+    def test_multi_source_gets_the_whole_list(self, rclpy_init, mock_model_client):
+        type(mock_model_client).model_type = PropertyMock(return_value="VisionModel")
+        component = mock_component_internals(
+            Vision(
+                inputs=[
+                    Topic(name="front", msg_type="Image"),
+                    Topic(name="rear", msg_type="Image"),
+                ],
+                outputs=[Topic(name="all", msg_type="DetectionsMultiSource")],
+                model_client=mock_model_client,
+                config=VisionConfig(),
+                component_name="test_multi",
+            )
+        )
+        mock_model_client.inference.return_value = {
+            "output": [
+                {"bboxes": [[0, 0, 1, 1]], "labels": ["cup"], "scores": [0.9]},
+                {"bboxes": [[1, 1, 2, 2]], "labels": ["bowl"], "scores": [0.8]},
+            ]
+        }
+        component.callbacks = {
+            "front": _callback(_image("front_optical"), [[1]], name="front"),
+            "rear": _callback(_image("rear_optical"), [[2]], name="rear"),
+        }
+        component.trig_callbacks = {}
+
+        component._execution_step()
+
+        published = component.publishers_dict["out"].publish.call_args[0][0]
+        assert [d["labels"] for d in published] == [["cup"], ["bowl"]]
+
+
 class TestConvertHeaders:
     """The per-source detections nested in a multi-source message need their
     own frames — the outer header can only name one camera."""
 
     def test_detections_convert_copies_header(self):
         message = Detections.convert(
-            [{"bboxes": [[0, 0, 2, 2]], "labels": ["cup"], "scores": [0.8]}],
-            [_image("left_camera")],
+            {"bboxes": [[0, 0, 2, 2]], "labels": ["cup"], "scores": [0.8]},
+            _image("left_camera"),
         )
         assert message.header.frame_id == "left_camera"
+
+    def test_detections_refuses_several_cameras(self):
+        """Silently keeping the first camera's detections and dropping the
+        rest is what this message type used to do."""
+        with pytest.raises(TypeError, match="MultiSource"):
+            Detections.convert(
+                [{"bboxes": [[0, 0, 2, 2]], "labels": ["cup"], "scores": [0.8]}],
+                [_image("left_camera")],
+            )
 
     def test_multi_source_nests_per_camera_frames(self):
         output = [
@@ -105,7 +300,7 @@ class TestConvertHeaders:
 
     def test_convert_without_image_is_unchanged(self):
         message = Detections.convert(
-            [{"bboxes": [[0, 0, 1, 1]], "labels": ["cup"], "scores": [0.8]}], []
+            {"bboxes": [[0, 0, 1, 1]], "labels": ["cup"], "scores": [0.8]}
         )
         assert message.header.frame_id == ""
         assert message.labels == ["cup"]


### PR DESCRIPTION
Adds classical, collision-aware manipulation to EmbodiedAgents: a MoveIt component that plans and executes through a running `move_group`, and the perception pipeline that lets it plan around what the robot's cameras actually see. Requires the sugarcoat external-launch PR (automatika-robotics/sugarcoat#61).

## The MoveIt component (`MoveManipulator` action server)

- Six goal modes: `pose`, `joints`, `named` (SRDF targets read from the live `move_group`), `cartesian` (fraction-checked), and the sequence modes `pick` and `place`.
- `pick`: resolve the target (scene id → detection label by best rank → nearest to a pose within `target_match_radius`) → approach above it → open → straight-line descent with contact permitted on that one segment → grasp → attach with SRDF-derived `touch_links` → lift. `place` is the inverse; the released object stays in the scene where it was set down.
- Gripper control via planning group or `GripperCommand`; all capabilities exposed as component actions, discoverable as tools by Cortex.

## The planning scene

- Optional `Detections3D` input mirrored into move_group as named collision objects (`det__<label>_<rank>`), refreshed `manual`ly, `on_goal`, or `continuous`ly — always as a single diff, with TTL eviction bridging detection dropouts. Scene failures degrade, never abort a motion.
- The scene freezes while an object is held: detection ids are score ranks, not identities, so refreshing mid-grasp could hide a real obstacle behind the held object's id or re-add the held object at the gripper (the snapshot-then-freeze pattern perception pipelines generally follow).
- Manual scene management, attach/detach, `clear_octomap` as component actions.

## Perception: 2D → metric 3D

- New `Bbox3D`/`Detections3D` messages (map 1:1 onto `vision_msgs/BoundingBox3D` and MoveIt BOX primitives), with callback, type wrapper and frame ids on all vision messages.
- Vision lifts detections to 3D boxes per detector frame via kompass-core (optional dependency): registered depth + `CameraInfo` aux inputs, robust depth statistics, per-box `depth_validity`, boxes published directly in the consumer's planning frame.
- MLLM does the same per grounding snapshot: depth is latched with the picture the VLM saw (inference takes seconds), and lifted boxes are labeled with the query that grounded them — so "ground the red mug" → `det__the red mug_0` → `pick, target_object: "the red mug"` with no glue.
- Shared machinery: `DepthLiftMixin`, node-free `perception3d` utils, a common 3D config contract, and serialized-relaunch support for the aux topics.